### PR TITLE
fix(viaTempTable): unnest is unsafe and not all array types exist

### DIFF
--- a/packages/graphile-build-pg/src/plugins/viaTemporaryTable.js
+++ b/packages/graphile-build-pg/src/plugins/viaTemporaryTable.js
@@ -79,7 +79,7 @@ export default async function viaTemporaryTable(
         select ${isPgClassLike
           ? sql.query`(str::${sqlTypeIdentifier}).*`
           : sql.query`str::${sqlTypeIdentifier} as ${sqlResultSourceAlias}`}
-        from unnest((${sql.value(values)})::${sqlTypeIdentifier}[]) str
+        from unnest((${sql.value(values)})::text[]) str
       )
       ${sqlResultQuery}`
     );


### PR DESCRIPTION
Ref: https://github.com/postgraphql/postgraphql/issues/555

Previously we would assume that for every type `T` an array type `T[]` would exist; this was a false assumption. This also doesn't work well with arrays as `unnest` is recursive and flattens everything out.

This PR switches to interpreting the input as a text array and then uses the casting inside the `select` to handle converting to a known type.