### PR TITLE
fix(relations): make forward relations nullable

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -19,7 +19,6 @@ export default (function PgForwardRelationPlugin(
         getAliasFromResolveInfo,
         pgIntrospectionResultsByKind: introspectionResultsByKind,
         pgSql: sql,
-        graphql: { GraphQLNonNull },
       },
       {
         scope: {
@@ -31,8 +30,6 @@ export default (function PgForwardRelationPlugin(
         fieldWithHooks,
       }
     ) => {
-      const nullableIf = (condition, Type) =>
-        condition ? Type : new GraphQLNonNull(Type);
       const table = pgIntrospectionTable || pgIntrospection;
       if (
         !(isPgRowType || isMutationPayload) ||
@@ -148,10 +145,7 @@ export default (function PgForwardRelationPlugin(
               });
               return {
                 description: `Reads a single \`${foreignTableTypeName}\` that is related to this \`${tableTypeName}\`.`,
-                type: nullableIf(
-                  isMutationPayload || !keys.every(key => key.isNotNull),
-                  gqlForeignTableType
-                ),
+                type: gqlForeignTableType, // Nullable since RLS may forbid fetching
                 resolve: (rawData, _args, _context, resolveInfo) => {
                   const data = isMutationPayload ? rawData.data : rawData;
                   const alias = getAliasFromResolveInfo(resolveInfo);

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -13,10 +13,10 @@ type CompoundKey implements Node {
   id: ID!
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
-  personByPersonId1: Person!
+  personByPersonId1: Person
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
-  personByPersonId2: Person!
+  personByPersonId2: Person
   personId1: Int!
   personId2: Int!
 }
@@ -2369,10 +2369,10 @@ type CompoundKey implements Node {
   nodeId: ID!
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
-  personByPersonId1: Person!
+  personByPersonId1: Person
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
-  personByPersonId2: Person!
+  personByPersonId2: Person
   personId1: Int!
   personId2: Int!
 }
@@ -5442,10 +5442,10 @@ type CompoundKey implements Node {
   nodeId: ID!
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
-  personByPersonId1: Person!
+  personByPersonId1: Person
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
-  personByPersonId2: Person!
+  personByPersonId2: Person
   personId1: Int!
   personId2: Int!
 }


### PR DESCRIPTION
Fixes #51 - RLS policy may prevent fetching the relation (even if references are non-null) so we must account for this.