### PR TITLE
chore: remove JSON/UUID types from core

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -12,9 +12,13 @@ import {
   GraphQLInputObjectType,
   GraphQLScalarType,
   isInputType,
+  getNamedType,
 } from "graphql";
 import { Kind } from "graphql/language";
 import { types as pgTypes } from "pg";
+
+import GraphQLJSON from "graphql-type-json";
+
 const stringType = (name, description) =>
   new GraphQLScalarType({
     name,
@@ -100,7 +104,6 @@ export default (function PgTypesPlugin(
       pgSql: sql,
     } = build;
 
-    const GraphQLJSON = getTypeByName("JSON");
     const GraphQLUUID = getTypeByName("UUID");
     const gqlTypeByTypeId = Object.assign({}, build.pgGqlTypeByTypeId);
     const gqlInputTypeByTypeId = Object.assign(
@@ -538,6 +541,7 @@ export default (function PgTypesPlugin(
           gqlInputTypeByTypeId[type.id] = gqlTypeByTypeId[type.id];
         }
       }
+      addType(getNamedType(gqlTypeByTypeId[type.id]));
       return gqlTypeByTypeId[type.id];
     };
 

--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "babel-runtime": ">=6 <7",
     "debug": ">=2 <3",
-    "graphql-parse-resolve-info": "^0.1.0-alpha.18",
-    "graphql-type-json": "^0.1.4"
+    "graphql-parse-resolve-info": "^0.1.0-alpha.18"
   },
   "engines": {
     "node": ">=4"

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -160,6 +160,14 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
       return data[alias];
     },
     addType(type: GraphQLNamedType): void {
+      if (!type.name) {
+        throw new Error(
+          `addType must only be called with named types, try using require('graphql').getNamedType`
+        );
+      }
+      if (allTypes[type.name] && allTypes[type.name] !== type) {
+        throw new Error(`There's already a type with the name: ${type.name}`);
+      }
       allTypes[type.name] = type;
     },
     getTypeByName(typeName) {

--- a/packages/graphile-build/src/plugins/StandardTypesPlugin.js
+++ b/packages/graphile-build/src/plugins/StandardTypesPlugin.js
@@ -1,7 +1,6 @@
 // @flow
 import type { Plugin, Build } from "../SchemaBuilder";
 import { Kind } from "graphql/language";
-import GraphQLJSON from "graphql-type-json";
 
 export default (function StandardTypesPlugin(builder) {
   // XXX: this should be in an "init" plugin, but PgTypesPlugin requires it in build - fix that, then fix this
@@ -25,12 +24,6 @@ export default (function StandardTypesPlugin(builder) {
       "A location in a connection that can be used for resuming pagination."
     );
     build.addType(Cursor);
-    const UUID = stringType(
-      "UUID",
-      "A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122)."
-    );
-    build.addType(UUID);
-    build.addType(GraphQLJSON);
     return build;
   });
   builder.hook(


### PR DESCRIPTION
We don't want two conflicting implementations of JSON (one string, one object).