### PR TITLE
fix(mutations): nullable payloads, rollback individual mutations on error

### DIFF
--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -425,18 +425,30 @@ export default function makeProcField(
                 const isVoid = returnType.id === "2278";
                 const isPgClass =
                   !returnFirstValueAsValue || returnTypeTable || false;
-                queryResult = await viaTemporaryTable(
-                  pgClient,
-                  isVoid
-                    ? null
-                    : sql.identifier(returnType.namespaceName, returnType.name),
-                  sql.query`select ${isPgClass
-                    ? sql.query`${intermediateIdentifier}.*`
-                    : sql.query`${intermediateIdentifier}.${intermediateIdentifier} as ${functionAlias}`} from ${sqlMutationQuery} ${intermediateIdentifier}`,
-                  functionAlias,
-                  query,
-                  isPgClass
-                );
+                try {
+                  await pgClient.query("SAVEPOINT graphql_mutation");
+                  queryResult = await viaTemporaryTable(
+                    pgClient,
+                    isVoid
+                      ? null
+                      : sql.identifier(
+                          returnType.namespaceName,
+                          returnType.name
+                        ),
+                    sql.query`select ${isPgClass
+                      ? sql.query`${intermediateIdentifier}.*`
+                      : sql.query`${intermediateIdentifier}.${intermediateIdentifier} as ${functionAlias}`} from ${sqlMutationQuery} ${intermediateIdentifier}`,
+                    functionAlias,
+                    query,
+                    isPgClass
+                  );
+                  await pgClient.query("RELEASE SAVEPOINT graphql_mutation");
+                } catch (e) {
+                  await pgClient.query(
+                    "ROLLBACK TO SAVEPOINT graphql_mutation"
+                  );
+                  throw e;
+                }
               } else {
                 const query = makeQuery(
                   parsedResolveInfoFragment,

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -346,7 +346,7 @@ export default function makeProcField(
             scope
           )
         );
-        ReturnType = new GraphQLNonNull(PayloadType);
+        ReturnType = PayloadType;
         const InputType = newWithHooks(
           GraphQLInputObjectType,
           {

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-delete-error.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-delete-error.graphql
@@ -1,0 +1,13 @@
+mutation {
+  deleteTypeById(input: { id: 12 }) {
+    clientMutationId
+    deletedTypeId
+    type {
+      nodeId
+      id
+    }
+    query {
+      nodeId
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-delete.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-delete.graphql
@@ -3,6 +3,7 @@ mutation {
   b: deletePost(input: { nodeId: "WyJwb3N0cyIsMl0=", clientMutationId: "hello" }) { ...deletePostPayload }
   c: deletePost(input: { nodeId: "WyJwb3N0cyIsMjAwMF0=" }) { ...deletePostPayload }
   d: deletePost(input: { nodeId: "WyJwb3N0cyIsM10=", clientMutationId: "world" }) { ...deletePostPayload }
+  d2: deleteTypeById(input: { id: 12, clientMutationId: "throw error" }) { clientMutationId deletedTypeId }
   e: deletePostById(input: { id: 6 }) { ...deletePostPayload }
   f: deletePostById(input: { id: 9, clientMutationId: "hello" }) { ...deletePostPayload }
   g: deletePostById(input: { id: 2000 }) { ...deletePostPayload }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -4,6 +4,7 @@ mutation {
   add2Mutation(input: { clientMutationId: "hello", a: 2, b: 2 }) { clientMutationId integer }
   add3Mutation(input: { clientMutationId: "world", arg1: 5 }) { clientMutationId integer }
   add4Mutation(input: { arg0: 1, b: 3 }) { integer }
+  add4MutationError(input: { arg0: 1, b: 3 }) { integer }
   mult1(input: { arg0: 0, arg1: 1 }) { integer }
   mult2(input: { arg0: 1, arg1: 1 }) { integer }
   mult3(input: { arg0: 1, arg1: 2 }) { integer }
@@ -17,5 +18,4 @@ mutation {
   returnVoidMutation(input: {}) { __typename }
   guidFn(input: {g: null}) { guid }
   guidFn2: guidFn(input: {g: "0123456789abcde"}) { guid }
-  add4MutationError(input: { arg0: 1, b: 3 }) { integer }
 }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -4,6 +4,7 @@ mutation {
   add2Mutation(input: { clientMutationId: "hello", a: 2, b: 2 }) { clientMutationId integer }
   add3Mutation(input: { clientMutationId: "world", arg1: 5 }) { clientMutationId integer }
   add4Mutation(input: { arg0: 1, b: 3 }) { integer }
+  add4MutationError(input: { arg0: 1, b: 3 }) { integer }
   mult1(input: { arg0: 0, arg1: 1 }) { integer }
   mult2(input: { arg0: 1, arg1: 1 }) { integer }
   mult3(input: { arg0: 1, arg1: 2 }) { integer }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -4,7 +4,6 @@ mutation {
   add2Mutation(input: { clientMutationId: "hello", a: 2, b: 2 }) { clientMutationId integer }
   add3Mutation(input: { clientMutationId: "world", arg1: 5 }) { clientMutationId integer }
   add4Mutation(input: { arg0: 1, b: 3 }) { integer }
-  add4MutationError(input: { arg0: 1, b: 3 }) { integer }
   mult1(input: { arg0: 0, arg1: 1 }) { integer }
   mult2(input: { arg0: 1, arg1: 1 }) { integer }
   mult3(input: { arg0: 1, arg1: 2 }) { integer }
@@ -18,4 +17,5 @@ mutation {
   returnVoidMutation(input: {}) { __typename }
   guidFn(input: {g: null}) { guid }
   guidFn2: guidFn(input: {g: "0123456789abcde"}) { guid }
+  add4MutationError(input: { arg0: 1, b: 3 }) { integer }
 }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -714,6 +714,7 @@ Object {
     "add4Mutation": Object {
       "integer": 4,
     },
+    "add4MutationError": null,
     "compoundTypeMutation": Object {
       "compoundType": Object {
         "a": 420,
@@ -808,5 +809,8 @@ Object {
       "boolean": false,
     },
   },
+  "errors": Array [
+    [GraphQLError: Deliberate error],
+  ],
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -398,6 +398,7 @@ Object {
         "nodeId": "query",
       },
     },
+    "d2": null,
     "e": Object {
       "clientMutationId": null,
       "deletedPostId": "WyJwb3N0cyIsNl0=",
@@ -509,6 +510,7 @@ Object {
   },
   "errors": Array [
     [GraphQLError: No values were deleted in collection 'posts' because no values were found.],
+    [GraphQLError: Nope.],
     [GraphQLError: No values were deleted in collection 'posts' because no values were found.],
   ],
 }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -514,6 +514,17 @@ Object {
 }
 `;
 
+exports[`mutation-delete-error.graphql 1`] = `
+Object {
+  "data": Object {
+    "deleteTypeById": null,
+  },
+  "errors": Array [
+    [GraphQLError: Nope.],
+  ],
+}
+`;
+
 exports[`mutation-update.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -2288,6 +2288,27 @@ type Add3MutationPayload {
   query: Query
 }
 
+# All input for the \`add4MutationError\` mutation.
+input Add4MutationErrorInput {
+  arg0: Int
+  b: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`add4MutationError\` mutation.
+type Add4MutationErrorPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
 # All input for the \`add4Mutation\` mutation.
 input Add4MutationInput {
   arg0: Int
@@ -3717,6 +3738,10 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add4MutationInput!
   ): Add4MutationPayload!
+  add4MutationError(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add4MutationErrorInput!
+  ): Add4MutationErrorPayload!
 
   # Reads and enables pagination through a set of \`JwtToken\`.
   authenticate(

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -526,31 +526,31 @@ type Mutation {
   intSetMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: IntSetMutationInput!
-  ): IntSetMutationPayload!
+  ): IntSetMutationPayload
   jsonIdentityMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: JsonIdentityMutationInput!
-  ): JsonIdentityMutationPayload!
+  ): JsonIdentityMutationPayload
   noArgsMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: NoArgsMutationInput!
-  ): NoArgsMutationPayload!
+  ): NoArgsMutationPayload
 
   # Reads and enables pagination through a set of \`Post\`.
   tableMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TableMutationInput!
-  ): TableMutationPayload!
+  ): TableMutationPayload
 
   # Reads and enables pagination through a set of \`Person\`.
   tableSetMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TableSetMutationInput!
-  ): TableSetMutationPayload!
+  ): TableSetMutationPayload
   typesMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TypesMutationInput!
-  ): TypesMutationPayload!
+  ): TypesMutationPayload
 
   # Updates a single \`CompoundKey\` using its globally unique id and a patch.
   updateCompoundKey(
@@ -1655,21 +1655,21 @@ type Mutation {
   authenticate(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateInput!
-  ): AuthenticatePayload!
+  ): AuthenticatePayload
   authenticateFail(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateFailInput!
-  ): AuthenticateFailPayload!
+  ): AuthenticateFailPayload
   authenticateMany(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateManyInput!
-  ): AuthenticateManyPayload!
+  ): AuthenticateManyPayload
 
   # Reads and enables pagination through a set of \`CompoundType\`.
   compoundTypeMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: CompoundTypeMutationInput!
-  ): CompoundTypeMutationPayload!
+  ): CompoundTypeMutationPayload
 
   # Creates a single \`Type\`.
   createType(
@@ -1697,23 +1697,23 @@ type Mutation {
   guidFn(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: GuidFnInput!
-  ): GuidFnPayload!
+  ): GuidFnPayload
   mult1(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult1Input!
-  ): Mult1Payload!
+  ): Mult1Payload
   mult2(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult2Input!
-  ): Mult2Payload!
+  ): Mult2Payload
   mult3(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult3Input!
-  ): Mult3Payload!
+  ): Mult3Payload
   mult4(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult4Input!
-  ): Mult4Payload!
+  ): Mult4Payload
 
   # Updates a single \`Type\` using its globally unique id and a patch.
   updateType(
@@ -3719,53 +3719,53 @@ type Mutation {
   add1Mutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add1MutationInput!
-  ): Add1MutationPayload!
+  ): Add1MutationPayload
 
   # lol, add some stuff 2 mutation
   add2Mutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add2MutationInput!
-  ): Add2MutationPayload!
+  ): Add2MutationPayload
 
   # lol, add some stuff 3 mutation
   add3Mutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add3MutationInput!
-  ): Add3MutationPayload!
+  ): Add3MutationPayload
 
   # lol, add some stuff 4 mutation
   add4Mutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add4MutationInput!
-  ): Add4MutationPayload!
+  ): Add4MutationPayload
   add4MutationError(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add4MutationErrorInput!
-  ): Add4MutationErrorPayload!
+  ): Add4MutationErrorPayload
 
   # Reads and enables pagination through a set of \`JwtToken\`.
   authenticate(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateInput!
-  ): AuthenticatePayload!
+  ): AuthenticatePayload
 
   # Reads and enables pagination through a set of \`JwtToken\`.
   authenticateFail(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateFailInput!
-  ): AuthenticateFailPayload!
+  ): AuthenticateFailPayload
 
   # Reads and enables pagination through a set of \`JwtToken\`.
   authenticateMany(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateManyInput!
-  ): AuthenticateManyPayload!
+  ): AuthenticateManyPayload
 
   # Reads and enables pagination through a set of \`CompoundType\`.
   compoundTypeMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: CompoundTypeMutationInput!
-  ): CompoundTypeMutationPayload!
+  ): CompoundTypeMutationPayload
 
   # Creates a single \`CompoundKey\`.
   createCompoundKey(
@@ -3919,59 +3919,59 @@ type Mutation {
   guidFn(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: GuidFnInput!
-  ): GuidFnPayload!
+  ): GuidFnPayload
   intSetMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: IntSetMutationInput!
-  ): IntSetMutationPayload!
+  ): IntSetMutationPayload
   jsonIdentityMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: JsonIdentityMutationInput!
-  ): JsonIdentityMutationPayload!
+  ): JsonIdentityMutationPayload
   mult1(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult1Input!
-  ): Mult1Payload!
+  ): Mult1Payload
   mult2(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult2Input!
-  ): Mult2Payload!
+  ): Mult2Payload
   mult3(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult3Input!
-  ): Mult3Payload!
+  ): Mult3Payload
   mult4(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Mult4Input!
-  ): Mult4Payload!
+  ): Mult4Payload
   noArgsMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: NoArgsMutationInput!
-  ): NoArgsMutationPayload!
+  ): NoArgsMutationPayload
   normalRand(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: NormalRandInput!
-  ): NormalRandPayload!
+  ): NormalRandPayload
   returnVoidMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: ReturnVoidMutationInput!
-  ): ReturnVoidMutationPayload!
+  ): ReturnVoidMutationPayload
 
   # Reads and enables pagination through a set of \`Post\`.
   tableMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TableMutationInput!
-  ): TableMutationPayload!
+  ): TableMutationPayload
 
   # Reads and enables pagination through a set of \`Person\`.
   tableSetMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TableSetMutationInput!
-  ): TableSetMutationPayload!
+  ): TableSetMutationPayload
   typesMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TypesMutationInput!
-  ): TypesMutationPayload!
+  ): TypesMutationPayload
 
   # Updates a single \`CompoundKey\` using its globally unique id and a patch.
   updateCompoundKey(
@@ -6254,31 +6254,31 @@ type Mutation {
   intSetMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: IntSetMutationInput!
-  ): IntSetMutationPayload!
+  ): IntSetMutationPayload
   jsonIdentityMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: JsonIdentityMutationInput!
-  ): JsonIdentityMutationPayload!
+  ): JsonIdentityMutationPayload
   noArgsMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: NoArgsMutationInput!
-  ): NoArgsMutationPayload!
+  ): NoArgsMutationPayload
 
   # Reads and enables pagination through a set of \`Post\`.
   tableMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TableMutationInput!
-  ): TableMutationPayload!
+  ): TableMutationPayload
 
   # Reads and enables pagination through a set of \`Person\`.
   tableSetMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TableSetMutationInput!
-  ): TableSetMutationPayload!
+  ): TableSetMutationPayload
   typesMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: TypesMutationInput!
-  ): TypesMutationPayload!
+  ): TypesMutationPayload
 }
 
 # All input for the \`noArgsMutation\` mutation.

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -148,6 +148,15 @@ create table b.types (
   "nested_compound_type" b.nested_compound_type not null
 );
 
+create function b.throw_error() returns trigger as $$
+begin
+  raise exception 'Nope.';
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger dont_delete before delete on b.types for each row execute procedure b.throw_error();
+
 create function a.add_1_mutation(int, int) returns int as $$ select $1 + $2 $$ language sql volatile strict;
 create function a.add_2_mutation(a int, b int default 2) returns int as $$ select $1 + $2 $$ language sql strict;
 create function a.add_3_mutation(a int, int) returns int as $$ select $1 + $2 $$ language sql volatile;

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -161,6 +161,7 @@ create function a.add_1_mutation(int, int) returns int as $$ select $1 + $2 $$ l
 create function a.add_2_mutation(a int, b int default 2) returns int as $$ select $1 + $2 $$ language sql strict;
 create function a.add_3_mutation(a int, int) returns int as $$ select $1 + $2 $$ language sql volatile;
 create function a.add_4_mutation(int, b int default 2) returns int as $$ select $1 + $2 $$ language sql;
+create function a.add_4_mutation_error(int, b int default 2) returns int as $$ begin raise exception 'Deliberate error'; end $$ language plpgsql;
 create function a.add_1_query(int, int) returns int as $$ select $1 + $2 $$ language sql immutable strict;
 create function a.add_2_query(a int, b int default 2) returns int as $$ select $1 + $2 $$ language sql stable strict;
 create function a.add_3_query(a int, int) returns int as $$ select $1 + $2 $$ language sql immutable;


### PR DESCRIPTION
Wraps each mutation in a transaction, automatically rolling back so that a) results of previous mutations are not invalidated (see #75) and b) future mutations are not prevented.

Fixes postgraphql/postgraphql#563
Fixes #75