### PR TITLE
Add breaking tests for creating objects with explicit "null" values

### DIFF
--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
@@ -201,6 +201,17 @@ mutation {
       issue27UserExists: exists(email: "graphile-build.issue.27@example.com")
     }
   }
+  i: createDefaultValue(input: {
+    defaultValue: {
+      id: 2000
+      nullValue: null
+    }
+  }) {
+    defaultValue {
+      id
+      nullValue
+    }
+  }
 }
 
 fragment createPersonPayload on CreatePersonPayload {

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
@@ -70,6 +70,17 @@ mutation {
       email: "somethingelse@example.com"
     }
   }) { ...updatePersonPayload }
+  k: updateDefaultValueById(input: {
+    id: 1
+    defaultValuePatch: {
+      nullValue: null
+    }
+  }) {
+    defaultValue {
+      id
+      nullValue
+    }
+  }
 }
 
 fragment updatePersonPayload on UpdatePersonPayload {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -672,6 +672,12 @@ Object {
         "nodeId": "query",
       },
     },
+    "k": Object {
+      "defaultValue": Object {
+        "id": 1,
+        "nullValue": null,
+      },
+    },
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -342,6 +342,12 @@ Object {
         "issue27UserExists": true,
       },
     },
+    "i": Object {
+      "defaultValue": Object {
+        "id": 2000,
+        "nullValue": null,
+      },
+    },
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -2610,6 +2610,35 @@ type CreateCompoundKeyPayload {
   query: Query
 }
 
+# All input for the create \`DefaultValue\` mutation.
+input CreateDefaultValueInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`DefaultValue\` to be created by this mutation.
+  defaultValue: DefaultValueInput!
+}
+
+# The output of our create \`DefaultValue\` mutation.
+type CreateDefaultValuePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`DefaultValue\` that was created by this mutation.
+  defaultValue: DefaultValue
+
+  # An edge for the type. May be used by Relay 1.
+  defaultValueEdge(
+    # The method to use when ordering \`DefaultValue\`.
+    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+  ): DefaultValuesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
 # All input for the create \`EdgeCase\` mutation.
 input CreateEdgeCaseInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -2897,6 +2926,71 @@ input DateRangeInput {
 # 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 scalar Datetime
 
+type DefaultValue implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  nullValue: String
+}
+
+# A condition to be used against \`DefaultValue\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input DefaultValueCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`nullValue\` field.
+  nullValue: String
+}
+
+# An input for mutations affecting \`DefaultValue\`
+input DefaultValueInput {
+  id: Int
+  nullValue: String
+}
+
+# Represents an update to a \`DefaultValue\`. Fields that are set will be updated.
+input DefaultValuePatch {
+  id: Int
+  nullValue: String
+}
+
+# A connection to a list of \`DefaultValue\` values.
+type DefaultValuesConnection {
+  # A list of edges which contains the \`DefaultValue\` and cursor to aid in pagination.
+  edges: [DefaultValuesEdge!]!
+
+  # A list of \`DefaultValue\` objects.
+  nodes: [DefaultValue]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`DefaultValue\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`DefaultValue\` edge in the connection.
+type DefaultValuesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`DefaultValue\` at the end of the edge.
+  node: DefaultValue!
+}
+
+# Methods to use when ordering \`DefaultValue\`.
+enum DefaultValuesOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NULL_VALUE_ASC
+  NULL_VALUE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 # All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
 input DeleteCompoundKeyByPersonId1AndPersonId2Input {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -2937,6 +3031,44 @@ type DeleteCompoundKeyPayload {
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
   personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deleteDefaultValueById\` mutation.
+input DeleteDefaultValueByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteDefaultValue\` mutation.
+input DeleteDefaultValueInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`DefaultValue\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`DefaultValue\` mutation.
+type DeleteDefaultValuePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`DefaultValue\` that was deleted by this mutation.
+  defaultValue: DefaultValue
+
+  # An edge for the type. May be used by Relay 1.
+  defaultValueEdge(
+    # The method to use when ordering \`DefaultValue\`.
+    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+  ): DefaultValuesEdge
+  deletedDefaultValueId: ID
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
@@ -3593,6 +3725,12 @@ type Mutation {
     input: CreateCompoundKeyInput!
   ): CreateCompoundKeyPayload
 
+  # Creates a single \`DefaultValue\`.
+  createDefaultValue(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateDefaultValueInput!
+  ): CreateDefaultValuePayload
+
   # Creates a single \`EdgeCase\`.
   createEdgeCase(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -3652,6 +3790,18 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
   ): DeleteCompoundKeyPayload
+
+  # Deletes a single \`DefaultValue\` using its globally unique id.
+  deleteDefaultValue(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteDefaultValueInput!
+  ): DeleteDefaultValuePayload
+
+  # Deletes a single \`DefaultValue\` using a unique key.
+  deleteDefaultValueById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteDefaultValueByIdInput!
+  ): DeleteDefaultValuePayload
 
   # Deletes a single \`Person\` using its globally unique id.
   deletePerson(
@@ -3786,6 +3936,18 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
   ): UpdateCompoundKeyPayload
+
+  # Updates a single \`DefaultValue\` using its globally unique id and a patch.
+  updateDefaultValue(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateDefaultValueInput!
+  ): UpdateDefaultValuePayload
+
+  # Updates a single \`DefaultValue\` using a unique key and a patch.
+  updateDefaultValueById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateDefaultValueByIdInput!
+  ): UpdateDefaultValuePayload
 
   # Updates a single \`Person\` using its globally unique id and a patch.
   updatePerson(
@@ -4314,6 +4476,31 @@ type Query implements Node {
     orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
   ): CompoundKeysConnection
 
+  # Reads and enables pagination through a set of \`DefaultValue\`.
+  allDefaultValues(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: DefaultValueCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`DefaultValue\`.
+    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+  ): DefaultValuesConnection
+
   # Reads and enables pagination through a set of \`EdgeCase\`.
   allEdgeCases(
     # Read all values in the set after (below) this cursor.
@@ -4627,6 +4814,13 @@ type Query implements Node {
     # based pagination. May not be used with \`last\`.
     offset: Int
   ): TablefuncCrosstab4SConnection!
+
+  # Reads a single \`DefaultValue\` using its globally unique \`ID\`.
+  defaultValue(
+    # The globally unique \`ID\` to be used in selecting a single \`DefaultValue\`.
+    nodeId: ID!
+  ): DefaultValue
+  defaultValueById(id: Int!): DefaultValue
   intSetQuery(
     # Read all values in the set after (below) this cursor.
     after: Cursor
@@ -5456,6 +5650,49 @@ type UpdateCompoundKeyPayload {
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
   personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updateDefaultValueById\` mutation.
+input UpdateDefaultValueByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`DefaultValue\` being updated.
+  defaultValuePatch: DefaultValuePatch!
+  id: Int!
+}
+
+# All input for the \`updateDefaultValue\` mutation.
+input UpdateDefaultValueInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`DefaultValue\` being updated.
+  defaultValuePatch: DefaultValuePatch!
+
+  # The globally unique \`ID\` which will identify a single \`DefaultValue\` to be updated.
+  nodeId: ID!
+}
+
+# The output of our update \`DefaultValue\` mutation.
+type UpdateDefaultValuePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`DefaultValue\` that was updated by this mutation.
+  defaultValue: DefaultValue
+
+  # An edge for the type. May be used by Relay 1.
+  defaultValueEdge(
+    # The method to use when ordering \`DefaultValue\`.
+    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+  ): DefaultValuesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -84,3 +84,6 @@ insert into a.similar_table_2 (id, col4, col5, col3) values
   (3, -78, 4, 20),
   (4, 86, null, 362),
   (5, null, 1, 14);
+
+insert into a.default_value (id, null_value) values
+  (1, 'someValue!');

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -219,3 +219,8 @@ create table a.similar_table_2 (
   col4 int,
   col5 int
 );
+
+CREATE TABLE a.default_value (
+    id serial primary key,
+    null_value text DEFAULT 'defaultValue!'
+);


### PR DESCRIPTION
It is currently impossible to create objects and pass a value as `null`, so I added a breaking test, see https://github.com/postgraphql/postgraphql/issues/584

``` graphql
createDefaultValue(input: {
    defaultValue: {
      id: 2000
      nullValue: null
    }
  }) {
    defaultValue {
      id
      nullValue // => is "defaultValue!" instead of "null"
    }
  }
```