### PR TITLE
feat(inflector): split rowByUniqueKeys from singleRelationByKeys

### DIFF
--- a/packages/graphile-build-pg/src/inflections.js
+++ b/packages/graphile-build-pg/src/inflections.js
@@ -115,7 +115,7 @@ export const newInflector = (
             .join("-and-")}`
         );
       },
-      rowByUniqueKey(detailedKeys: Keys, table: string, schema: ?string) {
+      rowByUniqueKeys(detailedKeys: Keys, table: string, schema: ?string) {
         return camelCase(
           `${this.tableName(table, schema)}-by-${detailedKeys
             .map(key => this.column(key.column, key.table, key.schema))

--- a/packages/graphile-build-pg/src/inflections.js
+++ b/packages/graphile-build-pg/src/inflections.js
@@ -115,6 +115,13 @@ export const newInflector = (
             .join("-and-")}`
         );
       },
+      rowByUniqueKey(detailedKeys: Keys, table: string, schema: ?string) {
+        return camelCase(
+          `${this.tableName(table, schema)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}`
+        );
+      },
       updateByKeys(detailedKeys: Keys, table: string, schema: ?string) {
         return camelCase(
           `update-${this.tableName(table, schema)}-by-${detailedKeys

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -60,7 +60,7 @@ export default (async function PgRowByUniqueConstraint(
                   table: k.class.name,
                   schema: k.class.namespace.name,
                 }));
-                const fieldName = inflection.rowByUniqueKey(
+                const fieldName = inflection.rowByUniqueKeys(
                   simpleKeys,
                   table.name,
                   table.namespace.name

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -60,7 +60,7 @@ export default (async function PgRowByUniqueConstraint(
                   table: k.class.name,
                   schema: k.class.namespace.name,
                 }));
-                const fieldName = inflection.singleRelationByKeys(
+                const fieldName = inflection.rowByUniqueKey(
                   simpleKeys,
                   table.name,
                   table.namespace.name


### PR DESCRIPTION
The inflector function `singleRelationByKeys` does not only change the names for related elements on an object, e.g.

```graphql
user {
  postsByUserId { // <--
    ....
  }
}
```

but also for queries that are based on unique columns, e.g. `userByEmail()`.
This PR splits it up into two functions.



Please note that I was not able to build this locally, the changes seemed to be ignored. 
I followed the instructions from the README.md, but had to run `yarn` in the directory of all packages.