### PR TITLE
[WIP] feat(mutations): add option to enable default mutations only for the specified tables

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgJWTPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgJWTPlugin.js
@@ -117,7 +117,7 @@ export default (function PgJWTPlugin(
   );
 }: Plugin);
 
-function parseTypeIdentifier(typeIdentifier) {
+export function parseTypeIdentifier(typeIdentifier: string) {
   const match = typeIdentifier.match(
     /^(?:([a-zA-Z0-9_]+)|"([^"]*)")\.(?:([a-zA-Z0-9_]+)|"([^"]*)")$/
   );

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -8,7 +8,7 @@ const debug = debugFactory("graphile-build-pg");
 
 export default (function PgMutationCreatePlugin(
   builder,
-  { pgInflection: inflection, pgDisableDefaultMutations }
+  { pgInflection: inflection, pgDisableDefaultMutations, pgEnableDefaultMutationTables }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -44,6 +44,11 @@ export default (function PgMutationCreatePlugin(
           .filter(table => !!table.namespace)
           .filter(table => table.isSelectable)
           .filter(table => table.isInsertable)
+          .filter(
+            table =>
+              (pgEnableDefaultMutationTables.length == 0) ||
+              (pgEnableDefaultMutationTables.indexOf(table.name) >= 0)
+          )
           .reduce((memo, table) => {
             const Table = getTypeByName(
               inflection.tableType(table.name, table.namespace.name)

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -17,6 +17,9 @@ export default (function PgMutationCreatePlugin(
   if (pgDisableDefaultMutations) {
     return;
   }
+  if (!Array.isArray(pgEnableDefaultMutationTables)) {
+    pgEnableDefaultMutationTables = [];
+  }
   builder.hook(
     "GraphQLObjectType:fields",
     (
@@ -51,7 +54,9 @@ export default (function PgMutationCreatePlugin(
           .filter(
             table =>
               pgEnableDefaultMutationTables.length == 0 ||
-              pgEnableDefaultMutationTables.indexOf(table.name) >= 0
+              pgEnableDefaultMutationTables.indexOf(
+                `${table.namespace.name}.${table.name}`
+              ) >= 0
           )
           .reduce((memo, table) => {
             const Table = getTypeByName(

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -8,7 +8,11 @@ const debug = debugFactory("graphile-build-pg");
 
 export default (function PgMutationCreatePlugin(
   builder,
-  { pgInflection: inflection, pgDisableDefaultMutations, pgEnableDefaultMutationTables }
+  {
+    pgInflection: inflection,
+    pgDisableDefaultMutations,
+    pgEnableDefaultMutationTables,
+  }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -46,8 +50,8 @@ export default (function PgMutationCreatePlugin(
           .filter(table => table.isInsertable)
           .filter(
             table =>
-              (pgEnableDefaultMutationTables.length == 0) ||
-              (pgEnableDefaultMutationTables.indexOf(table.name) >= 0)
+              pgEnableDefaultMutationTables.length == 0 ||
+              pgEnableDefaultMutationTables.indexOf(table.name) >= 0
           )
           .reduce((memo, table) => {
             const Table = getTypeByName(

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -20,6 +20,9 @@ export default (async function PgMutationUpdateDeletePlugin(
   if (pgDisableDefaultMutations) {
     return;
   }
+  if (!Array.isArray(pgEnableDefaultMutationTables)) {
+    pgEnableDefaultMutationTables = [];
+  }
   builder.hook(
     "GraphQLObjectType:fields",
     (
@@ -63,7 +66,9 @@ export default (async function PgMutationUpdateDeletePlugin(
               .filter(
                 table =>
                   pgEnableDefaultMutationTables.length == 0 ||
-                  pgEnableDefaultMutationTables.indexOf(table.name) >= 0
+                  pgEnableDefaultMutationTables.indexOf(
+                    `${table.namespace.name}.${table.name}`
+                  ) >= 0
               )
               .reduce((memo, table) => {
                 const TableType = getTypeByName(

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -11,7 +11,11 @@ const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 
 export default (async function PgMutationUpdateDeletePlugin(
   builder,
-  { pgInflection: inflection, pgDisableDefaultMutations, pgEnableDefaultMutationTables }
+  {
+    pgInflection: inflection,
+    pgDisableDefaultMutations,
+    pgEnableDefaultMutationTables,
+  }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -58,8 +62,8 @@ export default (async function PgMutationUpdateDeletePlugin(
               )
               .filter(
                 table =>
-                  (pgEnableDefaultMutationTables.length == 0) ||
-                  (pgEnableDefaultMutationTables.indexOf(table.name) >= 0)
+                  pgEnableDefaultMutationTables.length == 0 ||
+                  pgEnableDefaultMutationTables.indexOf(table.name) >= 0
               )
               .reduce((memo, table) => {
                 const TableType = getTypeByName(

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -11,7 +11,7 @@ const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 
 export default (async function PgMutationUpdateDeletePlugin(
   builder,
-  { pgInflection: inflection, pgDisableDefaultMutations }
+  { pgInflection: inflection, pgDisableDefaultMutations, pgEnableDefaultMutationTables }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -55,6 +55,11 @@ export default (async function PgMutationUpdateDeletePlugin(
                 table =>
                   (mode === "update" && table.isUpdatable) ||
                   (mode === "delete" && table.isDeletable)
+              )
+              .filter(
+                table =>
+                  (pgEnableDefaultMutationTables.length == 0) ||
+                  (pgEnableDefaultMutationTables.indexOf(table.name) >= 0)
               )
               .reduce((memo, table) => {
                 const TableType = getTypeByName(

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -26,6 +26,7 @@ type PostGraphQLOptions = {
   dynamicJson?: boolean,
   classicIds?: boolean,
   disableDefaultMutations?: string,
+  enableDefaultMutationTables?: Array<string>,
   nodeIdFieldName?: string,
   graphqlBuildOptions?: Options,
   replaceAllPlugins?: Array<Plugin>,
@@ -74,6 +75,7 @@ const getPostGraphQLBuilder = async (
     jwtPgTypeIdentifier,
     jwtSecret,
     disableDefaultMutations,
+    enableDefaultMutationTables,
     graphqlBuildOptions,
     inflector,
   } = options;
@@ -113,6 +115,7 @@ const getPostGraphQLBuilder = async (
         pgJwtTypeIdentifier: jwtPgTypeIdentifier,
         pgJwtSecret: jwtSecret,
         pgDisableDefaultMutations: disableDefaultMutations,
+        pgEnableDefaultMutationTables: enableDefaultMutationTables,
       },
       graphqlBuildOptions
     )


### PR DESCRIPTION
Close https://github.com/postgraphql/postgraphql/issues/576

I added the filter, but test failed.
How should I fix the test?
```
$ scripts/test --updateSnapshot
...
  ● mutation-delete-error.graphql

    GraphQLError: Schema is not configured for mutations

      at getOperationRootType (../../node_modules/graphql/execution/execute.js:261:15)
      at executeOperation (../../node_modules/graphql/execution/execute.js:225:14)
      at executeImpl (../../node_modules/graphql/execution/execute.js:133:26)
      at execute (../../node_modules/graphql/execution/execute.js:110:229)
      at ../../node_modules/graphql/graphql.js:75:34
          at Promise (<anonymous>)
      at graphqlImpl (../../node_modules/graphql/graphql.js:59:10)
      at graphql (../../node_modules/graphql/graphql.js:48:227)
      at withPgClient (__tests__/integration/mutations.test.js:57:28)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```
