### PR TITLE
give the QueryBuilder to callback function in callIfNecessary

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -10,10 +10,7 @@ type GenContext = {
 };
 type Gen<T> = (context: GenContext) => T;
 
-function callIfNecessary<T>(
-  o: Gen<T> | T,
-  context: GenContext
-): T {
+function callIfNecessary<T>(o: Gen<T> | T, context: GenContext): T {
   if (typeof o === "function") {
     return o(context);
   } else {

--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -5,7 +5,10 @@ import isSafeInteger from "lodash/isSafeInteger";
 
 const isDev = ["test", "development"].indexOf(process.env.NODE_ENV) >= 0;
 
-type Gen<T> = () => T;
+type GenContext = {
+  queryBuilder: QueryBuilder,
+};
+type Gen<T> = (context: GenContext) => T;
 
 function callIfNecessary<T>(
   o: Gen<T> | T,
@@ -23,7 +26,7 @@ function callIfNecessaryArray<T>(
   context: { queryBuilder: QueryBuilder }
 ): Array<T> {
   if (Array.isArray(o)) {
-    return o.map(callIfNecessary, context);
+    return o.map(v => callIfNecessary(v, context));
   } else {
     return o;
   }
@@ -489,6 +492,9 @@ class QueryBuilder {
   }
   lock(type: string) {
     if (this.locks[type]) return;
+    const getContext = () => ({
+      queryBuilder: this,
+    });
     const beforeLocks = this.data.beforeLock[type];
     this.data.beforeLock[type] = [];
     for (const fn of beforeLocks || []) {
@@ -502,50 +508,42 @@ class QueryBuilder {
       // Handle properties separately
       this.compiledData[type].lower = callIfNecessaryArray(
         this.data[type].lower,
-        { queryBuilder: this }
+        getContext()
       );
       this.compiledData[type].upper = callIfNecessaryArray(
         this.data[type].upper,
-        { queryBuilder: this }
+        getContext()
       );
     } else if (type === "select") {
       this.compiledData[type] = this.data[type].map(([a, b]) => [
-        callIfNecessary(a, { queryBuilder: this }),
+        callIfNecessary(a, getContext()),
         b,
       ]);
     } else if (type === "orderBy") {
       this.compiledData[type] = this.data[type].map(([a, b]) => [
-        callIfNecessary(a, { queryBuilder: this }),
+        callIfNecessary(a, getContext()),
         b,
       ]);
     } else if (type === "from") {
       if (this.data.from) {
         const f = this.data.from;
-        this.compiledData.from = [
-          callIfNecessary(f[0], { queryBuilder: this }),
-          f[1],
-        ];
+        this.compiledData.from = [callIfNecessary(f[0], getContext()), f[1]];
       }
     } else if (type === "join" || type === "where") {
-      this.compiledData[type] = callIfNecessaryArray(this.data[type], {
-        queryBuilder: this,
-      });
+      this.compiledData[type] = callIfNecessaryArray(
+        this.data[type],
+        getContext()
+      );
     } else if (type === "selectCursor") {
-      this.compiledData[type] = callIfNecessary(this.data[type], {
-        queryBuilder: this,
-      });
+      this.compiledData[type] = callIfNecessary(this.data[type], getContext());
     } else if (type === "cursorPrefix") {
       this.compiledData[type] = this.data[type];
     } else if (type === "orderIsUnique") {
       this.compiledData[type] = this.data[type];
     } else if (type === "limit") {
-      this.compiledData[type] = callIfNecessary(this.data[type], {
-        queryBuilder: this,
-      });
+      this.compiledData[type] = callIfNecessary(this.data[type], getContext());
     } else if (type === "offset") {
-      this.compiledData[type] = callIfNecessary(this.data[type], {
-        queryBuilder: this,
-      });
+      this.compiledData[type] = callIfNecessary(this.data[type], getContext());
     } else if (type === "first") {
       this.compiledData[type] = this.data[type];
     } else if (type === "last") {

--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -12,7 +12,7 @@ type Gen<T> = (context: GenContext) => T;
 
 function callIfNecessary<T>(
   o: Gen<T> | T,
-  context: { queryBuilder: QueryBuilder }
+  context: GenContext
 ): T {
   if (typeof o === "function") {
     return o(context);
@@ -23,7 +23,7 @@ function callIfNecessary<T>(
 
 function callIfNecessaryArray<T>(
   o: Array<Gen<T> | T>,
-  context: { queryBuilder: QueryBuilder }
+  context: GenContext
 ): Array<T> {
   if (Array.isArray(o)) {
     return o.map(v => callIfNecessary(v, context));


### PR DESCRIPTION
see #88 

I have not found a way to get access to the QueryBuilder yet from a orderby callback spec. maybe some sleep will help, meanwhile. I could complete my task with this patch to the QueryBuilder