### PR TITLE
Improve pg view cursor support

### DIFF
--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -79,6 +79,7 @@ with
       'class' as "kind",
       rel.oid as "id",
       rel.relname as "name",
+      rel.relkind as "classKind",
       dsc.description as "description",
       rel.relnamespace as "namespaceId",
       nsp.nspname as "namespaceName",

--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -258,9 +258,15 @@ class QueryBuilder {
 
   // ----------------------------------------
 
-  isOrderUnique() {
-    this.lock("orderIsUnique");
-    return this.compiledData.orderIsUnique;
+  isOrderUnique(lock?: boolean = true) {
+    if (lock) {
+      this.lock("orderBy");
+      this.lock("orderIsUnique");
+      return this.compiledData.orderIsUnique;
+    } else {
+      // This is useful inside `beforeLock("orderBy", ...)` calls
+      return this.data.orderIsUnique;
+    }
   }
   getTableExpression(): SQL {
     this.lock("from");

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -122,6 +122,11 @@ export default (async function PgAllRows(
                               );
                               builder.setOrderIsUnique();
                             });
+                          } else {
+                            builder.orderBy(
+                              sql.fragment`(row_number() over (partition by 1))`,
+                              true
+                            );
                           }
                         }
                       );

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -58,7 +58,9 @@ export default (async function PgAllRows(
                 num => attributes.filter(attr => attr.num === num)[0]
               );
             const isView = t => t.classKind === "v";
-            const hasUniqueId = a => !!a.find(elem => elem.name === "uniqueId");
+            const uniqueIdAttribute = attributes.filter(
+              attr => attr.name === "uniqueId" || attr.name === "unique_id"
+            )[0];
             if (!ConnectionType) {
               throw new Error(
                 `Could not find GraphQL connection type for table '${table.name}'`
@@ -107,12 +109,12 @@ export default (async function PgAllRows(
                                 builder.setOrderIsUnique();
                               }
                             });
-                          } else if (isView(table) && hasUniqueId(attributes)) {
+                          } else if (isView(table) && !!uniqueIdAttribute) {
                             builder.beforeLock("orderBy", () => {
                               builder.data.cursorPrefix = ["unique_id_asc"];
                               builder.orderBy(
                                 sql.fragment`${builder.getTableAlias()}.${sql.identifier(
-                                  "uniqueId"
+                                  uniqueIdAttribute.name
                                 )}`,
                                 true
                               );

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -93,7 +93,7 @@ export default (async function PgAllRows(
                         builder => {
                           if (primaryKeys) {
                             builder.beforeLock("orderBy", () => {
-                              if (!builder.isOrderUnique()) {
+                              if (!builder.isOrderUnique(false)) {
                                 // Order by PK if no order specified
                                 builder.data.cursorPrefix = ["primary_key_asc"];
                                 primaryKeys.forEach(key => {
@@ -120,11 +120,6 @@ export default (async function PgAllRows(
                               );
                               builder.setOrderIsUnique();
                             });
-                          } else {
-                            builder.orderBy(
-                              sql.fragment`(row_number() over (partition by 1))`,
-                              true
-                            );
                           }
                         }
                       );

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -58,9 +58,9 @@ export default (async function PgAllRows(
                 num => attributes.filter(attr => attr.num === num)[0]
               );
             const isView = t => t.classKind === "v";
-            const uniqueIdAttribute = attributes.filter(
+            const uniqueIdAttribute = attributes.find(
               attr => attr.name === "uniqueId" || attr.name === "unique_id"
-            )[0];
+            );
             if (!ConnectionType) {
               throw new Error(
                 `Could not find GraphQL connection type for table '${table.name}'`

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -109,16 +109,18 @@ export default (async function PgAllRows(
                             });
                           } else if (isView(table) && !!uniqueIdAttribute) {
                             builder.beforeLock("orderBy", () => {
-                              builder.data.cursorPrefix = [
-                                "view_unique_key_asc",
-                              ];
-                              builder.orderBy(
-                                sql.fragment`${builder.getTableAlias()}.${sql.identifier(
-                                  uniqueIdAttribute.name
-                                )}`,
-                                true
-                              );
-                              builder.setOrderIsUnique();
+                              if (!builder.isOrderUnique(false)) {
+                                builder.data.cursorPrefix = [
+                                  "view_unique_key_asc",
+                                ];
+                                builder.orderBy(
+                                  sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                                    uniqueIdAttribute.name
+                                  )}`,
+                                  true
+                                );
+                                builder.setOrderIsUnique();
+                              }
                             });
                           }
                         }

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -57,8 +57,8 @@ export default (async function PgAllRows(
               primaryKeyConstraint.keyAttributeNums.map(
                 num => attributes.filter(attr => attr.num === num)[0]
               );
-            const isView = t => t.classKind === 'v';
-            const hasUniqueId = a => !!a.find(elem => elem.name === 'uniqueId');
+            const isView = t => t.classKind === "v";
+            const hasUniqueId = a => !!a.find(elem => elem.name === "uniqueId");
             if (!ConnectionType) {
               throw new Error(
                 `Could not find GraphQL connection type for table '${table.name}'`
@@ -111,7 +111,9 @@ export default (async function PgAllRows(
                             builder.beforeLock("orderBy", () => {
                               builder.data.cursorPrefix = ["unique_id_asc"];
                               builder.orderBy(
-                                sql.fragment`${builder.getTableAlias()}.${sql.identifier('uniqueId')}`,
+                                sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                                  "uniqueId"
+                                )}`,
                                 true
                               );
                               builder.setOrderIsUnique();

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -131,7 +131,7 @@ export default (function PgBackwardRelationPlugin(
                           if (primaryKeys) {
                             innerQueryBuilder.beforeLock("orderBy", () => {
                               // append order by primary key to the list of orders
-                              if (!innerQueryBuilder.isOrderUnique()) {
+                              if (!innerQueryBuilder.isOrderUnique(false)) {
                                 innerQueryBuilder.data.cursorPrefix = [
                                   "primary_key_asc",
                                 ];

--- a/packages/graphile-build-pg/src/queryFromResolveData.js
+++ b/packages/graphile-build-pg/src/queryFromResolveData.js
@@ -188,15 +188,14 @@ export default (
     const haveFields = queryBuilder.getSelectFieldsCount() > 0;
     const sqlQueryAlias = sql.identifier(Symbol());
     const sqlSummaryAlias = sql.identifier(Symbol());
-    // Tables should ALWAYS push their PK onto the order stack, if this
-    // isn't present then we're either dealing with a view or a table
-    // without a PK. Either way, we're going to need something else to
-    // guarantee cursor uniqueness.
     //
-    // If this is used, we DO NOT GUARANTEE in any way that the cursors
-    // will not change value/order!
+    // Tables should ALWAYS push their PK onto the order stack, if this isn't
+    // present then we're either dealing with a view or a table without a PK.
+    // Either way, we don't have anything to guarantee uniqueness so we need to
+    // fall back to limit/offset.
     //
-    // TODO: add a warning if this fires and it's not a view.
+    // TODO: support unique keys in PgAllRows etc
+    // TODO: add a warning for cursor-based pagination when using the fallback
     // TODO: if it is a view maybe add a warning encouraging pgViewUniqueKey
     const canHaveCursorInWhere =
       queryBuilder.getOrderByExpressionsAndDirections().length > 0 &&

--- a/packages/graphile-build-pg/src/queryFromResolveData.js
+++ b/packages/graphile-build-pg/src/queryFromResolveData.js
@@ -111,7 +111,7 @@ export default (
         const orderBy = queryBuilder
           .getOrderByExpressionsAndDirections()
           .map(([expr]) => expr);
-        if (orderBy.length > 0) {
+        if (queryBuilder.isOrderUnique() && orderBy.length > 0) {
           return sql.fragment`json_build_array(${sql.join(
             [
               ...getPgCursorPrefix(),
@@ -188,8 +188,19 @@ export default (
     const haveFields = queryBuilder.getSelectFieldsCount() > 0;
     const sqlQueryAlias = sql.identifier(Symbol());
     const sqlSummaryAlias = sql.identifier(Symbol());
+    // Tables should ALWAYS push their PK onto the order stack, if this
+    // isn't present then we're either dealing with a view or a table
+    // without a PK. Either way, we're going to need something else to
+    // guarantee cursor uniqueness.
+    //
+    // If this is used, we DO NOT GUARANTEE in any way that the cursors
+    // will not change value/order!
+    //
+    // TODO: add a warning if this fires and it's not a view.
+    // TODO: if it is a view maybe add a warning encouraging pgViewUniqueKey
     const canHaveCursorInWhere =
-      queryBuilder.getOrderByExpressionsAndDirections().length > 0;
+      queryBuilder.getOrderByExpressionsAndDirections().length > 0 &&
+      queryBuilder.isOrderUnique();
     const queryHasBefore =
       queryBuilder.compiledData.whereBound.upper.length > 0;
     const queryHasAfter = queryBuilder.compiledData.whereBound.lower.length > 0;

--- a/packages/postgraphile-core/__tests__/fixtures/queries/view.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/view.graphql
@@ -1,0 +1,4 @@
+{
+  a: allTestviews { edges { cursor node { testviewid col1 col2 } } }
+  b: allTestviews(orderBy: COL1_DESC) { edges { cursor node { testviewid col1 col2 } } }
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -322,7 +322,7 @@ Object {
     "h": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJuYXR1cmFsIiwxXQ==",
+          "cursor": "WyJuYXR1cmFsIixbMV1d",
           "node": Object {
             "constant": 2,
             "name": "John Smith",
@@ -330,7 +330,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiwyXQ==",
+          "cursor": "WyJuYXR1cmFsIixbMl1d",
           "node": Object {
             "constant": 2,
             "name": "Sara Smith",
@@ -338,7 +338,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiwzXQ==",
+          "cursor": "WyJuYXR1cmFsIixbM11d",
           "node": Object {
             "constant": 2,
             "name": "Budd Deey",
@@ -346,7 +346,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiw0XQ==",
+          "cursor": "WyJuYXR1cmFsIixbNF1d",
           "node": Object {
             "constant": 2,
             "name": "Kathryn Ramirez",
@@ -354,7 +354,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiw1XQ==",
+          "cursor": "WyJuYXR1cmFsIixbNV1d",
           "node": Object {
             "constant": 2,
             "name": "Joe Tucker",
@@ -362,7 +362,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiw2XQ==",
+          "cursor": "WyJuYXR1cmFsIixbNl1d",
           "node": Object {
             "constant": 2,
             "name": "Twenty Seventwo",
@@ -374,7 +374,7 @@ Object {
     "i": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDFdXQ==",
           "node": Object {
             "constant": 2,
             "name": "John Smith",
@@ -382,7 +382,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDJdXQ==",
           "node": Object {
             "constant": 2,
             "name": "Sara Smith",
@@ -390,7 +390,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDNdXQ==",
           "node": Object {
             "constant": 2,
             "name": "Budd Deey",
@@ -398,7 +398,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDRdXQ==",
           "node": Object {
             "constant": 2,
             "name": "Kathryn Ramirez",
@@ -406,7 +406,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDVdXQ==",
           "node": Object {
             "constant": 2,
             "name": "Joe Tucker",
@@ -414,7 +414,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDZdXQ==",
           "node": Object {
             "constant": 2,
             "name": "Twenty Seventwo",

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -322,7 +322,7 @@ Object {
     "h": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJuYXR1cmFsIixbMV1d",
+          "cursor": "WyJuYXR1cmFsIiwxXQ==",
           "node": Object {
             "constant": 2,
             "name": "John Smith",
@@ -330,7 +330,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbMl1d",
+          "cursor": "WyJuYXR1cmFsIiwyXQ==",
           "node": Object {
             "constant": 2,
             "name": "Sara Smith",
@@ -338,7 +338,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbM11d",
+          "cursor": "WyJuYXR1cmFsIiwzXQ==",
           "node": Object {
             "constant": 2,
             "name": "Budd Deey",
@@ -346,7 +346,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbNF1d",
+          "cursor": "WyJuYXR1cmFsIiw0XQ==",
           "node": Object {
             "constant": 2,
             "name": "Kathryn Ramirez",
@@ -354,7 +354,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbNV1d",
+          "cursor": "WyJuYXR1cmFsIiw1XQ==",
           "node": Object {
             "constant": 2,
             "name": "Joe Tucker",
@@ -362,7 +362,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbNl1d",
+          "cursor": "WyJuYXR1cmFsIiw2XQ==",
           "node": Object {
             "constant": 2,
             "name": "Twenty Seventwo",
@@ -374,7 +374,7 @@ Object {
     "i": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDFdXQ==",
+          "cursor": "WyJjb25zdGFudF9hc2MiLDFd",
           "node": Object {
             "constant": 2,
             "name": "John Smith",
@@ -382,7 +382,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDJdXQ==",
+          "cursor": "WyJjb25zdGFudF9hc2MiLDJd",
           "node": Object {
             "constant": 2,
             "name": "Sara Smith",
@@ -390,7 +390,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDNdXQ==",
+          "cursor": "WyJjb25zdGFudF9hc2MiLDNd",
           "node": Object {
             "constant": 2,
             "name": "Budd Deey",
@@ -398,7 +398,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDRdXQ==",
+          "cursor": "WyJjb25zdGFudF9hc2MiLDRd",
           "node": Object {
             "constant": 2,
             "name": "Kathryn Ramirez",
@@ -406,7 +406,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDVdXQ==",
+          "cursor": "WyJjb25zdGFudF9hc2MiLDVd",
           "node": Object {
             "constant": 2,
             "name": "Joe Tucker",
@@ -414,7 +414,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb25zdGFudF9hc2MiLFsyLDZdXQ==",
+          "cursor": "WyJjb25zdGFudF9hc2MiLDZd",
           "node": Object {
             "constant": 2,
             "name": "Twenty Seventwo",
@@ -2597,7 +2597,7 @@ Object {
     "a": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJuYXR1cmFsIixbMV1d",
+          "cursor": "WyJuYXR1cmFsIiwxXQ==",
           "node": Object {
             "col1": 11,
             "col2": 21,
@@ -2605,7 +2605,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbMl1d",
+          "cursor": "WyJuYXR1cmFsIiwyXQ==",
           "node": Object {
             "col1": 12,
             "col2": 22,
@@ -2613,7 +2613,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIixbM11d",
+          "cursor": "WyJuYXR1cmFsIiwzXQ==",
           "node": Object {
             "col1": 13,
             "col2": 23,
@@ -2625,7 +2625,7 @@ Object {
     "b": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJjb2wxX2Rlc2MiLFsxMywzXV0=",
+          "cursor": "WyJjb2wxX2Rlc2MiLDNd",
           "node": Object {
             "col1": 13,
             "col2": 23,
@@ -2633,7 +2633,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb2wxX2Rlc2MiLFsxMiwyXV0=",
+          "cursor": "WyJjb2wxX2Rlc2MiLDJd",
           "node": Object {
             "col1": 12,
             "col2": 22,
@@ -2641,7 +2641,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb2wxX2Rlc2MiLFsxMSwxXV0=",
+          "cursor": "WyJjb2wxX2Rlc2MiLDFd",
           "node": Object {
             "col1": 11,
             "col2": 21,

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -2590,3 +2590,66 @@ Object {
   },
 }
 `;
+
+exports[`view.graphql 1`] = `
+Object {
+  "data": Object {
+    "a": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJ2aWV3X3VuaXF1ZV9rZXlfYXNjIixbMV1d",
+          "node": Object {
+            "col1": 11,
+            "col2": 21,
+            "testviewid": 1,
+          },
+        },
+        Object {
+          "cursor": "WyJ2aWV3X3VuaXF1ZV9rZXlfYXNjIixbMl1d",
+          "node": Object {
+            "col1": 12,
+            "col2": 22,
+            "testviewid": 2,
+          },
+        },
+        Object {
+          "cursor": "WyJ2aWV3X3VuaXF1ZV9rZXlfYXNjIixbM11d",
+          "node": Object {
+            "col1": 13,
+            "col2": 23,
+            "testviewid": 3,
+          },
+        },
+      ],
+    },
+    "b": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJjb2wxX2Rlc2MiLFsxMywzXV0=",
+          "node": Object {
+            "col1": 13,
+            "col2": 23,
+            "testviewid": 3,
+          },
+        },
+        Object {
+          "cursor": "WyJjb2wxX2Rlc2MiLFsxMiwyXV0=",
+          "node": Object {
+            "col1": 12,
+            "col2": 22,
+            "testviewid": 2,
+          },
+        },
+        Object {
+          "cursor": "WyJjb2wxX2Rlc2MiLFsxMSwxXV0=",
+          "node": Object {
+            "col1": 11,
+            "col2": 21,
+            "testviewid": 1,
+          },
+        },
+      ],
+    },
+  },
+}
+`;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -2932,6 +2932,35 @@ type CreateSimilarTable2Payload {
   ): SimilarTable2SEdge
 }
 
+# All input for the create \`Testview\` mutation.
+input CreateTestviewInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Testview\` to be created by this mutation.
+  testview: TestviewInput!
+}
+
+# The output of our create \`Testview\` mutation.
+type CreateTestviewPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Testview\` that was created by this mutation.
+  testview: Testview
+
+  # An edge for the type. May be used by Relay 1.
+  testviewEdge(
+    # The method to use when ordering \`Testview\`.
+    orderBy: TestviewsOrderBy = NATURAL
+  ): TestviewsEdge
+}
+
 # All input for the create \`Type\` mutation.
 input CreateTypeInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -2988,6 +3017,35 @@ type CreateUpdatableViewPayload {
     # The method to use when ordering \`UpdatableView\`.
     orderBy: UpdatableViewsOrderBy = NATURAL
   ): UpdatableViewsEdge
+}
+
+# All input for the create \`ViewTable\` mutation.
+input CreateViewTableInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ViewTable\` to be created by this mutation.
+  viewTable: ViewTableInput!
+}
+
+# The output of our create \`ViewTable\` mutation.
+type CreateViewTablePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`ViewTable\` that was created by this mutation.
+  viewTable: ViewTable
+
+  # An edge for the type. May be used by Relay 1.
+  viewTableEdge(
+    # The method to use when ordering \`ViewTable\`.
+    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+  ): ViewTablesEdge
 }
 
 # A location in a connection that can be used for resuming pagination.
@@ -3383,6 +3441,44 @@ type DeleteTypePayload {
     # The method to use when ordering \`Type\`.
     orderBy: TypesOrderBy = PRIMARY_KEY_ASC
   ): TypesEdge
+}
+
+# All input for the \`deleteViewTableById\` mutation.
+input DeleteViewTableByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteViewTable\` mutation.
+input DeleteViewTableInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ViewTable\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`ViewTable\` mutation.
+type DeleteViewTablePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedViewTableId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`ViewTable\` that was deleted by this mutation.
+  viewTable: ViewTable
+
+  # An edge for the type. May be used by Relay 1.
+  viewTableEdge(
+    # The method to use when ordering \`ViewTable\`.
+    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+  ): ViewTablesEdge
 }
 
 type EdgeCase {
@@ -3946,6 +4042,12 @@ type Mutation {
     input: CreateSimilarTable2Input!
   ): CreateSimilarTable2Payload
 
+  # Creates a single \`Testview\`.
+  createTestview(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateTestviewInput!
+  ): CreateTestviewPayload
+
   # Creates a single \`Type\`.
   createType(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -3957,6 +4059,12 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: CreateUpdatableViewInput!
   ): CreateUpdatableViewPayload
+
+  # Creates a single \`ViewTable\`.
+  createViewTable(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateViewTableInput!
+  ): CreateViewTablePayload
 
   # Deletes a single \`CompoundKey\` using its globally unique id.
   deleteCompoundKey(
@@ -4047,6 +4155,18 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: DeleteTypeByIdInput!
   ): DeleteTypePayload
+
+  # Deletes a single \`ViewTable\` using its globally unique id.
+  deleteViewTable(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteViewTableInput!
+  ): DeleteViewTablePayload
+
+  # Deletes a single \`ViewTable\` using a unique key.
+  deleteViewTableById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteViewTableByIdInput!
+  ): DeleteViewTablePayload
   guidFn(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: GuidFnInput!
@@ -4205,6 +4325,18 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: UpdateTypeByIdInput!
   ): UpdateTypePayload
+
+  # Updates a single \`ViewTable\` using its globally unique id and a patch.
+  updateViewTable(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateViewTableInput!
+  ): UpdateViewTablePayload
+
+  # Updates a single \`ViewTable\` using a unique key and a patch.
+  updateViewTableById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateViewTableByIdInput!
+  ): UpdateViewTablePayload
 }
 
 type NestedCompoundType {
@@ -4867,6 +4999,31 @@ type Query implements Node {
     orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
   ): SimilarTable2SConnection
 
+  # Reads and enables pagination through a set of \`Testview\`.
+  allTestviews(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: TestviewCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Testview\`.
+    orderBy: TestviewsOrderBy = NATURAL
+  ): TestviewsConnection
+
   # Reads and enables pagination through a set of \`Type\`.
   allTypes(
     # Read all values in the set after (below) this cursor.
@@ -4916,6 +5073,31 @@ type Query implements Node {
     # The method to use when ordering \`UpdatableView\`.
     orderBy: UpdatableViewsOrderBy = NATURAL
   ): UpdatableViewsConnection
+
+  # Reads and enables pagination through a set of \`ViewTable\`.
+  allViewTables(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ViewTableCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ViewTable\`.
+    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+  ): ViewTablesConnection
 
   # Reads a single \`CompoundKey\` using its globally unique \`ID\`.
   compoundKey(
@@ -5107,6 +5289,13 @@ type Query implements Node {
   ): Type
   typeById(id: Int!): Type
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+
+  # Reads a single \`ViewTable\` using its globally unique \`ID\`.
+  viewTable(
+    # The globally unique \`ID\` to be used in selecting a single \`ViewTable\`.
+    nodeId: ID!
+  ): ViewTable
+  viewTableById(id: Int!): ViewTable
 }
 
 # All input for the \`returnVoidMutation\` mutation.
@@ -5431,6 +5620,67 @@ type TableSetMutationPayload {
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
+}
+
+type Testview {
+  col1: Int
+  col2: Int
+  testviewid: Int
+}
+
+# A condition to be used against \`Testview\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input TestviewCondition {
+  # Checks for equality with the object’s \`col1\` field.
+  col1: Int
+
+  # Checks for equality with the object’s \`col2\` field.
+  col2: Int
+
+  # Checks for equality with the object’s \`testviewid\` field.
+  testviewid: Int
+}
+
+# An input for mutations affecting \`Testview\`
+input TestviewInput {
+  col1: Int
+  col2: Int
+  testviewid: Int
+}
+
+# A connection to a list of \`Testview\` values.
+type TestviewsConnection {
+  # A list of edges which contains the \`Testview\` and cursor to aid in pagination.
+  edges: [TestviewsEdge!]!
+
+  # A list of \`Testview\` objects.
+  nodes: [Testview]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Testview\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Testview\` edge in the connection.
+type TestviewsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Testview\` at the end of the edge.
+  node: Testview!
+}
+
+# Methods to use when ordering \`Testview\`.
+enum TestviewsOrderBy {
+  COL1_ASC
+  COL1_DESC
+  COL2_ASC
+  COL2_DESC
+  NATURAL
+  TESTVIEWID_ASC
+  TESTVIEWID_DESC
 }
 
 # The exact time of day, does not include the date. May or may not have a timezone offset.
@@ -6119,8 +6369,124 @@ type UpdateTypePayload {
   ): TypesEdge
 }
 
+# All input for the \`updateViewTableById\` mutation.
+input UpdateViewTableByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`ViewTable\` being updated.
+  viewTablePatch: ViewTablePatch!
+}
+
+# All input for the \`updateViewTable\` mutation.
+input UpdateViewTableInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ViewTable\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`ViewTable\` being updated.
+  viewTablePatch: ViewTablePatch!
+}
+
+# The output of our update \`ViewTable\` mutation.
+type UpdateViewTablePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`ViewTable\` that was updated by this mutation.
+  viewTable: ViewTable
+
+  # An edge for the type. May be used by Relay 1.
+  viewTableEdge(
+    # The method to use when ordering \`ViewTable\`.
+    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+  ): ViewTablesEdge
+}
+
 # A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
 scalar UUID
+
+type ViewTable implements Node {
+  col1: Int
+  col2: Int
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`ViewTable\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input ViewTableCondition {
+  # Checks for equality with the object’s \`col1\` field.
+  col1: Int
+
+  # Checks for equality with the object’s \`col2\` field.
+  col2: Int
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`ViewTable\`
+input ViewTableInput {
+  col1: Int
+  col2: Int
+  id: Int
+}
+
+# Represents an update to a \`ViewTable\`. Fields that are set will be updated.
+input ViewTablePatch {
+  col1: Int
+  col2: Int
+  id: Int
+}
+
+# A connection to a list of \`ViewTable\` values.
+type ViewTablesConnection {
+  # A list of edges which contains the \`ViewTable\` and cursor to aid in pagination.
+  edges: [ViewTablesEdge!]!
+
+  # A list of \`ViewTable\` objects.
+  nodes: [ViewTable]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ViewTable\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`ViewTable\` edge in the connection.
+type ViewTablesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ViewTable\` at the end of the edge.
+  node: ViewTable!
+}
+
+# Methods to use when ordering \`ViewTable\`.
+enum ViewTablesOrderBy {
+  COL1_ASC
+  COL1_DESC
+  COL2_ASC
+  COL2_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 "
 `;
 

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -66,14 +66,13 @@ beforeAll(() => {
           // Get the appropriate GraphQL schema for this fixture. We want to test
           // some specific fixtures against a schema configured slightly
           // differently.
-          const gqlSchema =
-            fileName === "classic-ids.graphql"
-              ? gqlSchemas.classicIds
-              : fileName === "dynamic-json.graphql"
-                ? gqlSchemas.dynamicJson
-                : fileName === "view.graphql"
-                  ? gqlSchemas.viewUniqueKey
-                  : gqlSchemas.normal;
+          const schemas = {
+            "classic-ids.graphql": gqlSchemas.classicIds,
+            "dynamic-json.graphql": gqlSchemas.dynamicJson,
+            "view.graphql": gqlSchemas.viewUniqueKey,
+          };
+          const gqlSchema = (schemas[fileName]) ? schemas[fileName] : gqlSchemas.normal;
+
           // Return the result of our GraphQL query.
           const result = await graphql(gqlSchema, query, null, {
             pgClient: pgClient,

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -28,16 +28,18 @@ beforeAll(() => {
     // Different fixtures need different schemas with different configurations.
     // Make all of the different schemas with different configurations that we
     // need and wait for them to be created in parallel.
-    const [normal, classicIds, dynamicJson] = await Promise.all([
+    const [normal, classicIds, dynamicJson, viewUniqueKey] = await Promise.all([
       createPostGraphQLSchema(pgClient, ["a", "b", "c"]),
       createPostGraphQLSchema(pgClient, ["a", "b", "c"], { classicIds: true }),
       createPostGraphQLSchema(pgClient, ["a", "b", "c"], { dynamicJson: true }),
+      createPostGraphQLSchema(pgClient, ["a", "b", "c"], { viewUniqueKey: "testviewid" }),
     ]);
     debug(printSchema(normal));
     return {
       normal,
       classicIds,
       dynamicJson,
+      viewUniqueKey,
     };
   });
 
@@ -69,7 +71,9 @@ beforeAll(() => {
               ? gqlSchemas.classicIds
               : fileName === "dynamic-json.graphql"
                 ? gqlSchemas.dynamicJson
-                : gqlSchemas.normal;
+                : fileName === "view.graphql"
+                  ? gqlSchemas.viewUniqueKey
+                  : gqlSchemas.normal;
           // Return the result of our GraphQL query.
           const result = await graphql(gqlSchema, query, null, {
             pgClient: pgClient,

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -87,3 +87,8 @@ insert into a.similar_table_2 (id, col4, col5, col3) values
 
 insert into a.default_value (id, null_value) values
   (1, 'someValue!');
+
+insert into a.view_table (id, col1, col2) values
+  (1, 11, 21),
+  (2, 12, 22),
+  (3, 13, 23);

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -240,3 +240,13 @@ CREATE TABLE a.default_value (
     id serial primary key,
     null_value text DEFAULT 'defaultValue!'
 );
+
+create table a.view_table (
+  id serial primary key,
+  col1 int,
+  col2 int
+);
+
+create view a.testview as
+  select id as testviewid, col1, col2
+  from a.view_table;

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -34,6 +34,7 @@ type PostGraphQLOptions = {
   jwtPgTypeIdentifier?: string,
   jwtSecret?: string,
   inflector?: Inflector,
+  viewUniqueKey?: string,
 };
 
 type PgConfig = Client | Pool | string;
@@ -76,6 +77,7 @@ const getPostGraphQLBuilder = async (
     disableDefaultMutations,
     graphqlBuildOptions,
     inflector,
+    viewUniqueKey,
   } = options;
   if (replaceAllPlugins) {
     ensureValidPlugins("replaceAllPlugins", replaceAllPlugins);
@@ -113,6 +115,7 @@ const getPostGraphQLBuilder = async (
         pgJwtTypeIdentifier: jwtPgTypeIdentifier,
         pgJwtSecret: jwtSecret,
         pgDisableDefaultMutations: disableDefaultMutations,
+        pgViewUniqueKey: viewUniqueKey,
       },
       graphqlBuildOptions
     )


### PR DESCRIPTION
## Reason
Postgres views do not support constraints like the primary key constraint. graphile uses the primary key constraint to set the default orderBy which is used to create the unique cursors. The view cursors end up working only when the graphql orderBy parameter is always unique.

## Implementation (Method 1)
* Add pg class relkind to introspection query
* Add check for pg class relkind view and uniqueId attribute.
* In the case of no primary key and no configured view unique key then default to row number. ref #104

NOTE: ~~When creating the view in postgres view one of the columns needs to be named specifically **uniqueId**. e.g. `create view testview as select id as "uniqueId", name from device;`~~ If viewUniqueKey option is set to a column then it will be used.

## Verification
Added two test queries w/ a configured viewUniqueKey and updated the snapshot. The previous view queries have updated snapshot data because of the new default.

The existing tests continue to work. Manually tested queries against the view and the cursors now contain
```
echo WyJ1bmlxdWVfaWRfYXNjIixbImYyNjkzMjNjLThkZjctNTQ3MS05NTdjLTFmMjAwN2M3OTJhZiJdXQ== | base64 -d
["unique_id_asc",["f269323c-8df7-5471-957c-1f2007c792af"]]%
```
 and when there's an orderBy it looks like this
```
echo WyJoZWFydGJlYXRfZGVzYyIsWyIyMDE3LTA5LTEyVDA5OjA1OjQ2LjU1MyswMzowMCIsImYyNjkzMjNjLThkZjctNTQ3MS05NTdjLTFmMjAwN2M3OTJhZiJdXQ== | base64 -d
["heartbeat_desc",["2017-09-12T09:05:46.553+03:00","f269323c-8df7-5471-957c-1f2007c792af"]]%
```