### PR TITLE
Add pg view unique id cursor plugin (Method 2)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-runtime", "transform-es2015-modules-commonjs"],
+  "plugins": ["transform-runtime", "transform-es2015-modules-commonjs", "transform-object-rest-spread"],
   "presets": [
     ["env", {
       "targets": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint packages",
     "flow": "flow",
     "flow:check": "flow check",
-    "test": "lerna run test",
+    "test": "lerna run test && npm run lint",
     "prepublish:all": "for I in packages/*/; do echo \"cd $I && npm run prepublish\" | perl -p -e 's/\\n/\\0/;'; done | xargs -0 node_modules/.bin/concurrently",
     "watch": "for I in packages/*/; do echo \"cd $I && npm run watch\" | perl -p -e 's/\\n/\\0/;'; done | xargs -0 node_modules/.bin/concurrently --kill-others"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-flow": "^6.23.0",
     "flow-bin": "^0.52.0",

--- a/packages/graphile-build-pg/src/index.js
+++ b/packages/graphile-build-pg/src/index.js
@@ -8,6 +8,7 @@ import PgConnectionArgFirstLastBeforeAfter from "./plugins/PgConnectionArgFirstL
 import PgConnectionArgOrderBy from "./plugins/PgConnectionArgOrderBy";
 import PgConnectionArgCondition from "./plugins/PgConnectionArgCondition";
 import PgAllRows from "./plugins/PgAllRows";
+import PgViewPlugin from "./plugins/PgViewPlugin";
 import PgColumnsPlugin from "./plugins/PgColumnsPlugin";
 import PgForwardRelationPlugin from "./plugins/PgForwardRelationPlugin";
 import PgBackwardRelationPlugin from "./plugins/PgBackwardRelationPlugin";
@@ -53,6 +54,7 @@ export const defaultPlugins = [
   PgScalarFunctionConnectionPlugin, // For PostGraphQL compatibility
   PageInfoStartEndCursor, // For PostGraphQL compatibility
   PgConnectionTotalCount,
+  PgViewPlugin,
 
   // Mutations
   PgMutationCreatePlugin,
@@ -86,6 +88,7 @@ export {
   PgScalarFunctionConnectionPlugin,
   PageInfoStartEndCursor,
   PgConnectionTotalCount,
+  PgViewPlugin,
   PgMutationCreatePlugin,
   PgMutationUpdateDeletePlugin,
   PgMutationProceduresPlugin,

--- a/packages/graphile-build-pg/src/plugins/PgViewPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgViewPlugin.js
@@ -1,0 +1,91 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _queryFromResolveData = require("../queryFromResolveData");
+
+var _queryFromResolveData2 = _interopRequireDefault(_queryFromResolveData);
+
+var _debug = require("debug");
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _addStartEndCursor = require("./addStartEndCursor");
+
+var _addStartEndCursor2 = _interopRequireDefault(_addStartEndCursor);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const debugSql = (0, _debug2.default)("graphile-build-pg:sql");
+
+exports.default = async function PgViewPlugin(builder, { pgInflection: inflection }) {
+  builder.hook("GraphQLObjectType:fields", (fields, {
+    parseResolveInfo,
+    getTypeByName,
+    pgSql: sql,
+    pgIntrospectionResultsByKind: introspectionResultsByKind
+  }, { fieldWithHooks, scope: { isRootQuery } }) => {
+    if (!isRootQuery) {
+      return fields;
+    }
+
+    const views = introspectionResultsByKind.class
+          .filter(table => table.isSelectable)
+          .filter(table => table.namespace)
+          .filter(table => table.classKind === 'v')
+          .reduce((memo, table) => {
+          const tableTypeName = inflection.tableType(table.name, table.namespace.name);
+      const TableType = getTypeByName(tableTypeName);
+      const ConnectionType = getTypeByName(inflection.connection(TableType.name));
+      if (!TableType) {
+        throw new Error(`Could not find GraphQL type for table '${table.name}'`);
+      }
+      const attributes = introspectionResultsByKind.attribute.filter(attr => attr.classId === table.id);
+      if (!ConnectionType) {
+        throw new Error(`Could not find GraphQL connection type for table '${table.name}'`);
+      }
+      const hasUniqueId = a => !!a.find(elem => elem.name === 'uniqueId');
+      const schema = table.namespace;
+      const sqlFullTableName = sql.identifier(schema.name, table.name);
+      if (TableType && ConnectionType && hasUniqueId(attributes)) {
+        const fieldName = inflection.allRows(table.name, schema.name);
+        memo[fieldName] = fieldWithHooks(fieldName, ({ getDataFromParsedResolveInfoFragment }) => {
+          return {
+            description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
+            type: ConnectionType,
+            args: {},
+            async resolve(parent, args, { pgClient }, resolveInfo) {
+              const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
+              const resolveData = getDataFromParsedResolveInfoFragment(parsedResolveInfoFragment, resolveInfo.returnType);
+              const query = (0, _queryFromResolveData2.default)(sqlFullTableName, undefined, resolveData, {
+                withPaginationAsFields: true
+              }, builder => {
+                builder.beforeLock("orderBy", () => {
+                  builder.data.cursorPrefix = ["unique_id_asc"];
+                  builder.orderBy(
+                    sql.fragment`${builder.getTableAlias()}.${sql.identifier('uniqueId')}`,
+                    true
+                  );
+                  builder.setOrderIsUnique();
+                });
+              });
+              const { text, values } = sql.compile(query);
+              if (debugSql.enabled) debugSql(text);
+              const { rows: [row] } = await pgClient.query(text, values);
+              return (0, _addStartEndCursor2.default)(row);
+            }
+          };
+        }, {
+          isPgConnectionField: true,
+          pgIntrospection: table
+        });
+      }
+      return memo;
+    }, {});
+
+    return { ...fields, ...views };
+  });
+};
+//# sourceMappingURL=PgViewPlugin.js.map

--- a/packages/graphile-build-pg/src/plugins/PgViewPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgViewPlugin.js
@@ -1,8 +1,6 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
+Object.defineProperty(exports, "__esModule", { value: true });
 
 var _queryFromResolveData = require("../queryFromResolveData");
 
@@ -16,76 +14,119 @@ var _addStartEndCursor = require("./addStartEndCursor");
 
 var _addStartEndCursor2 = _interopRequireDefault(_addStartEndCursor);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
 
 const debugSql = (0, _debug2.default)("graphile-build-pg:sql");
 
-exports.default = async function PgViewPlugin(builder, { pgInflection: inflection }) {
-  builder.hook("GraphQLObjectType:fields", (fields, {
-    parseResolveInfo,
-    getTypeByName,
-    pgSql: sql,
-    pgIntrospectionResultsByKind: introspectionResultsByKind
-  }, { fieldWithHooks, scope: { isRootQuery } }) => {
-    if (!isRootQuery) {
-      return fields;
+exports.default = async function PgViewPlugin(
+  builder,
+  { pgInflection: inflection }
+) {
+  builder.hook(
+    "GraphQLObjectType:fields",
+    (
+      fields,
+      {
+        parseResolveInfo,
+        getTypeByName,
+        pgSql: sql,
+        pgIntrospectionResultsByKind: introspectionResultsByKind,
+      },
+      { fieldWithHooks, scope: { isRootQuery } }
+    ) => {
+      if (!isRootQuery) {
+        return fields;
+      }
+
+      const views = introspectionResultsByKind.class
+        .filter(table => table.isSelectable)
+        .filter(table => table.namespace)
+        .filter(table => table.classKind === "v")
+        .reduce((memo, table) => {
+          const tableTypeName = inflection.tableType(
+            table.name,
+            table.namespace.name
+          );
+          const TableType = getTypeByName(tableTypeName);
+          const ConnectionType = getTypeByName(
+            inflection.connection(TableType.name)
+          );
+          if (!TableType) {
+            throw new Error(
+              `Could not find GraphQL type for table '${table.name}'`
+            );
+          }
+          const attributes = introspectionResultsByKind.attribute.filter(
+            attr => attr.classId === table.id
+          );
+          if (!ConnectionType) {
+            throw new Error(
+              `Could not find GraphQL connection type for table '${table.name}'`
+            );
+          }
+          const hasUniqueId = a => !!a.find(elem => elem.name === "uniqueId");
+          const schema = table.namespace;
+          const sqlFullTableName = sql.identifier(schema.name, table.name);
+          if (TableType && ConnectionType && hasUniqueId(attributes)) {
+            const fieldName = inflection.allRows(table.name, schema.name);
+            memo[fieldName] = fieldWithHooks(
+              fieldName,
+              ({ getDataFromParsedResolveInfoFragment }) => {
+                return {
+                  description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
+                  type: ConnectionType,
+                  args: {},
+                  async resolve(parent, args, { pgClient }, resolveInfo) {
+                    const parsedResolveInfoFragment = parseResolveInfo(
+                      resolveInfo
+                    );
+                    const resolveData = getDataFromParsedResolveInfoFragment(
+                      parsedResolveInfoFragment,
+                      resolveInfo.returnType
+                    );
+                    const query = (
+                      0,
+                      _queryFromResolveData2.default
+                    )(
+                      sqlFullTableName,
+                      undefined,
+                      resolveData,
+                      {
+                        withPaginationAsFields: true,
+                      },
+                      builder => {
+                        builder.beforeLock("orderBy", () => {
+                          builder.data.cursorPrefix = ["unique_id_asc"];
+                          builder.orderBy(
+                            sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                              "uniqueId"
+                            )}`,
+                            true
+                          );
+                          builder.setOrderIsUnique();
+                        });
+                      }
+                    );
+                    const { text, values } = sql.compile(query);
+                    if (debugSql.enabled) debugSql(text);
+                    const { rows: [row] } = await pgClient.query(text, values);
+                    return (0, _addStartEndCursor2.default)(row);
+                  },
+                };
+              },
+              {
+                isPgConnectionField: true,
+                pgIntrospection: table,
+              }
+            );
+          }
+          return memo;
+        }, {});
+
+      return { ...fields, ...views };
     }
-
-    const views = introspectionResultsByKind.class
-          .filter(table => table.isSelectable)
-          .filter(table => table.namespace)
-          .filter(table => table.classKind === 'v')
-          .reduce((memo, table) => {
-          const tableTypeName = inflection.tableType(table.name, table.namespace.name);
-      const TableType = getTypeByName(tableTypeName);
-      const ConnectionType = getTypeByName(inflection.connection(TableType.name));
-      if (!TableType) {
-        throw new Error(`Could not find GraphQL type for table '${table.name}'`);
-      }
-      const attributes = introspectionResultsByKind.attribute.filter(attr => attr.classId === table.id);
-      if (!ConnectionType) {
-        throw new Error(`Could not find GraphQL connection type for table '${table.name}'`);
-      }
-      const hasUniqueId = a => !!a.find(elem => elem.name === 'uniqueId');
-      const schema = table.namespace;
-      const sqlFullTableName = sql.identifier(schema.name, table.name);
-      if (TableType && ConnectionType && hasUniqueId(attributes)) {
-        const fieldName = inflection.allRows(table.name, schema.name);
-        memo[fieldName] = fieldWithHooks(fieldName, ({ getDataFromParsedResolveInfoFragment }) => {
-          return {
-            description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
-            type: ConnectionType,
-            args: {},
-            async resolve(parent, args, { pgClient }, resolveInfo) {
-              const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
-              const resolveData = getDataFromParsedResolveInfoFragment(parsedResolveInfoFragment, resolveInfo.returnType);
-              const query = (0, _queryFromResolveData2.default)(sqlFullTableName, undefined, resolveData, {
-                withPaginationAsFields: true
-              }, builder => {
-                builder.beforeLock("orderBy", () => {
-                  builder.data.cursorPrefix = ["unique_id_asc"];
-                  builder.orderBy(
-                    sql.fragment`${builder.getTableAlias()}.${sql.identifier('uniqueId')}`,
-                    true
-                  );
-                  builder.setOrderIsUnique();
-                });
-              });
-              const { text, values } = sql.compile(query);
-              if (debugSql.enabled) debugSql(text);
-              const { rows: [row] } = await pgClient.query(text, values);
-              return (0, _addStartEndCursor2.default)(row);
-            }
-          };
-        }, {
-          isPgConnectionField: true,
-          pgIntrospection: table
-        });
-      }
-      return memo;
-    }, {});
-
-    return { ...fields, ...views };
-  });
+  );
 };
 //# sourceMappingURL=PgViewPlugin.js.map

--- a/packages/graphile-build-pg/src/plugins/PgViewPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgViewPlugin.js
@@ -1,26 +1,13 @@
-"use strict";
+// @flow
+import queryFromResolveData from "../queryFromResolveData";
+import debugFactory from "debug";
+import addStartEndCursor from "./addStartEndCursor";
 
-Object.defineProperty(exports, "__esModule", { value: true });
+import type { Plugin } from "graphile-build";
 
-var _queryFromResolveData = require("../queryFromResolveData");
+const debugSql = debugFactory("graphile-build-pg:sql");
 
-var _queryFromResolveData2 = _interopRequireDefault(_queryFromResolveData);
-
-var _debug = require("debug");
-
-var _debug2 = _interopRequireDefault(_debug);
-
-var _addStartEndCursor = require("./addStartEndCursor");
-
-var _addStartEndCursor2 = _interopRequireDefault(_addStartEndCursor);
-
-function _interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : { default: obj };
-}
-
-const debugSql = (0, _debug2.default)("graphile-build-pg:sql");
-
-exports.default = async function PgViewPlugin(
+export default (async function PgViewPlugin(
   builder,
   { pgInflection: inflection }
 ) {
@@ -86,10 +73,7 @@ exports.default = async function PgViewPlugin(
                       parsedResolveInfoFragment,
                       resolveInfo.returnType
                     );
-                    const query = (
-                      0,
-                      _queryFromResolveData2.default
-                    )(
+                    const query = queryFromResolveData(
                       sqlFullTableName,
                       undefined,
                       resolveData,
@@ -112,7 +96,7 @@ exports.default = async function PgViewPlugin(
                     const { text, values } = sql.compile(query);
                     if (debugSql.enabled) debugSql(text);
                     const { rows: [row] } = await pgClient.query(text, values);
-                    return (0, _addStartEndCursor2.default)(row);
+                    return addStartEndCursor(row);
                   },
                 };
               },
@@ -128,5 +112,4 @@ exports.default = async function PgViewPlugin(
       return { ...fields, ...views };
     }
   );
-};
-//# sourceMappingURL=PgViewPlugin.js.map
+}: Plugin);

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,6 +443,10 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -638,6 +642,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
@@ -730,6 +741,13 @@ babel-register@^6.24.1:
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
@@ -3399,6 +3417,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
## Reason
Postgres views do not support constraints like the primary key constraint. graphile uses the primary key constraint to set the default orderBy which is used to create the unique cursors. The view cursors end up working only when the graphql orderBy parameter is always unique.

## Implementation (Method 2)
* Add plugin for replacing the resolver in the views with uniqueId
* Add PgViewPlugin someplace after PgAllRows.
* Add spread operator to babel

NOTE: When creating the view in postgres view one of the columns needs to be named specifically **uniqueId**. e.g. `create view testview as select id as "uniqueId", name from device;`

## Verification
The existing tests continue to work. Manually tested queries against the view and the cursors now contain
```
echo WyJ1bmlxdWVfaWRfYXNjIixbImYyNjkzMjNjLThkZjctNTQ3MS05NTdjLTFmMjAwN2M3OTJhZiJdXQ== | base64 -d
["unique_id_asc",["f269323c-8df7-5471-957c-1f2007c792af"]]%
```
 and when there's an orderBy it looks like this
```
echo WyJoZWFydGJlYXRfZGVzYyIsWyIyMDE3LTA5LTEyVDA5OjA1OjQ2LjU1MyswMzowMCIsImYyNjkzMjNjLThkZjctNTQ3MS05NTdjLTFmMjAwN2M3OTJhZiJdXQ== | base64 -d
["heartbeat_desc",["2017-09-12T09:05:46.553+03:00","f269323c-8df7-5471-957c-1f2007c792af"]]%
```