### PR TITLE
Issues with custom types / malformed record literal

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -69,46 +69,54 @@ export default (function PgColumnsPlugin(
                 pgGetGqlTypeByTypeId(attr.typeId) || GraphQLString;
               addDataGenerator(parsedResolveInfoFragment => {
                 const { alias } = parsedResolveInfoFragment;
-                if (attr.type.type === "c") {
-                  return {
-                    pgQuery: queryBuilder => {
-                      // json_build_object
-                      /*
-                      queryBuilder.select(
-                        sql.identifier(queryBuilder.getTableAlias(), attr.name),
-                        alias
-                      );
-                      */
-                      const resolveData = getDataFromParsedResolveInfoFragment(
-                        parsedResolveInfoFragment,
-                        ReturnType
-                      );
-                      const jsonBuildObject = queryFromResolveData(
-                        sql.identifier(Symbol()), // Ignore!
+                return {
+                  pgQuery: queryBuilder => {
+                    const blahForType = (sqlFullName, type) => {
+                      if (type.arrayItemType) {
+                        const ident = sql.identifier(Symbol());
+                        return sql.fragment`
+                          (
+                            select json_agg(${blahForType(
+                              ident,
+                              type.arrayItemType
+                            )})
+                            from unnest(${sqlFullName}) as ${ident}
+                          )
+                        `;
+                      } else if (type.type === "c") {
+                        // json_build_object
+                        /*
+                          queryBuilder.select(
+                            sql.identifier(queryBuilder.getTableAlias(), name),
+                            alias
+                          );
+                          */
+                        const resolveData = getDataFromParsedResolveInfoFragment(
+                          parsedResolveInfoFragment,
+                          ReturnType
+                        );
+                        const jsonBuildObject = queryFromResolveData(
+                          sql.identifier(Symbol()), // Ignore!
+                          sqlFullName,
+                          resolveData,
+                          { onlyJsonField: true }
+                        );
+                        return jsonBuildObject;
+                      } else {
+                        return pgTweakFragmentForType(sqlFullName, type);
+                      }
+                    };
+                    queryBuilder.select(
+                      blahForType(
                         sql.fragment`(${queryBuilder.getTableAlias()}.${sql.identifier(
                           attr.name
                         )})`, // The brackets are necessary to stop the parser getting confused, ref: https://www.postgresql.org/docs/9.6/static/rowtypes.html#ROWTYPES-ACCESSING
-                        resolveData,
-                        { onlyJsonField: true }
-                      );
-                      queryBuilder.select(jsonBuildObject, alias);
-                    },
-                  };
-                } else {
-                  return {
-                    pgQuery: queryBuilder => {
-                      queryBuilder.select(
-                        pgTweakFragmentForType(
-                          sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-                            attr.name
-                          )}`,
-                          attr.type
-                        ),
-                        alias
-                      );
-                    },
-                  };
-                }
+                        attr.type
+                      ),
+                      alias
+                    );
+                  },
+                };
               });
               return {
                 description: attr.description,

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -71,12 +71,15 @@ export default (function PgColumnsPlugin(
                 const { alias } = parsedResolveInfoFragment;
                 return {
                   pgQuery: queryBuilder => {
-                    const blahForType = (sqlFullName, type) => {
+                    const getSelectValueForFieldAndType = (
+                      sqlFullName,
+                      type
+                    ) => {
                       if (type.arrayItemType) {
                         const ident = sql.identifier(Symbol());
                         return sql.fragment`
                           (
-                            select json_agg(${blahForType(
+                            select json_agg(${getSelectValueForFieldAndType(
                               ident,
                               type.arrayItemType
                             )})
@@ -84,13 +87,6 @@ export default (function PgColumnsPlugin(
                           )
                         `;
                       } else if (type.type === "c") {
-                        // json_build_object
-                        /*
-                          queryBuilder.select(
-                            sql.identifier(queryBuilder.getTableAlias(), name),
-                            alias
-                          );
-                          */
                         const resolveData = getDataFromParsedResolveInfoFragment(
                           parsedResolveInfoFragment,
                           ReturnType
@@ -107,7 +103,7 @@ export default (function PgColumnsPlugin(
                       }
                     };
                     queryBuilder.select(
-                      blahForType(
+                      getSelectValueForFieldAndType(
                         sql.fragment`(${queryBuilder.getTableAlias()}.${sql.identifier(
                           attr.name
                         )})`, // The brackets are necessary to stop the parser getting confused, ref: https://www.postgresql.org/docs/9.6/static/rowtypes.html#ROWTYPES-ACCESSING

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -136,6 +136,16 @@ export default (function PgTypesPlugin(
         return pg2GqlMapper[type.id].unmap(val);
       } else if (type.domainBaseType) {
         return gql2pg(val, type.domainBaseType);
+      } else if (type.arrayItemType) {
+        if (!Array.isArray(val)) {
+          throw new Error("Expected array");
+        }
+        return sql.fragment`array[${sql.join(
+          val.map(v => gql2pg(v, type.arrayItemType)),
+          ", "
+        )}]::${sql.identifier(type.namespaceName)}.${sql.identifier(
+          type.name
+        )}`;
       } else {
         return sql.value(val);
       }

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -124,6 +124,11 @@ export default (function PgTypesPlugin(
         return pg2GqlMapper[type.id].map(val);
       } else if (type.domainBaseType) {
         return pg2gql(val, type.domainBaseType);
+      } else if (type.arrayItemType) {
+        if (!Array.isArray(val)) {
+          throw new Error("Expected array");
+        }
+        return val.map(v => pg2gql(v, type.arrayItemType));
       } else {
         return val;
       }

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -262,6 +262,16 @@ export default (function PgTypesPlugin(
         return tweaker(fragment);
       } else if (type.domainBaseType) {
         return pgTweakFragmentForType(fragment, type.domainBaseType);
+      } else if (type.arrayItemType) {
+        const error = new Error(
+          "Internal graphile-build-pg error: should not attempt to tweak an array, please process array before tweaking (type: `${type.namespaceName}.${type.name}`)"
+        );
+        if (process.env.NODE_ENV === "test") {
+          throw error;
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(error);
+        }
       } else {
         return fragment;
       }

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -126,7 +126,9 @@ export default (function PgTypesPlugin(
         return pg2gql(val, type.domainBaseType);
       } else if (type.arrayItemType) {
         if (!Array.isArray(val)) {
-          throw new Error("Expected array");
+          throw new Error(
+            `Expected array when converting PostgreSQL data into GraphQL; failing type: '${type.namespaceName}.${type.name}'`
+          );
         }
         return val.map(v => pg2gql(v, type.arrayItemType));
       } else {
@@ -143,7 +145,12 @@ export default (function PgTypesPlugin(
         return gql2pg(val, type.domainBaseType);
       } else if (type.arrayItemType) {
         if (!Array.isArray(val)) {
-          throw new Error("Expected array");
+          throw new Error(
+            `Expected array when converting GraphQL data into PostgreSQL data; failing type: '${type.namespaceName}.${type.name}' (type: ${type ===
+            null
+              ? "null"
+              : typeof type})`
+          );
         }
         return sql.fragment`array[${sql.join(
           val.map(v => gql2pg(v, type.arrayItemType)),
@@ -268,10 +275,10 @@ export default (function PgTypesPlugin(
         );
         if (process.env.NODE_ENV === "test") {
           throw error;
-        } else {
-          // eslint-disable-next-line no-console
-          console.error(error);
         }
+        // eslint-disable-next-line no-console
+        console.error(error);
+        return fragment;
       } else {
         return fragment;
       }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
@@ -239,7 +239,7 @@ mutation {
       headline
       comptypes {
         schedule
-        is_optimised: isOptimised
+        isOptimised
       }
     }
   }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
@@ -218,18 +218,30 @@ mutation {
   j: createPost(input: {
     post: {
       headline: "super headline",
-      body: "this is the body",
-      authorId: 9000,
-      enums: AWAITING,
-      comptypes: {
-        schedule: "2009-10-24 10:23:54+02",
-        isOptimised: true
-      }
+      comptypes: [
+        {
+          schedule: "2009-10-24 10:23:54+02",
+          isOptimised: true
+        },
+        {
+          schedule: "2008-10-24 10:23:54+02",
+          isOptimised: false
+        },
+        {
+          schedule: "2007-10-24 10:23:54+02",
+          isOptimised: null
+        }
+      ]
     }
   }) {
-	  post {
-		  id
-	  }
+    post {
+      id
+      headline
+      comptypes {
+        schedule
+        is_optimised: isOptimised
+      }
+    }
   }
 }
 

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
@@ -184,7 +184,7 @@ mutation {
     }
     query { nodeId }
   }
-  g: createPerson(input: {
+  g: createPerso(input: {
     person: {
       id: 1998
       name: "Budd Deey"
@@ -214,6 +214,22 @@ mutation {
       id
       nullValue
     }
+  }
+  j: createPost(input: {
+    post: {
+      headline: "super headline",
+      body: "this is the body",
+      authorId: 9000,
+      enums: AWAITING,
+      comptypes: {
+        schedule: "2009-10-24 10:23:54+02",
+        isOptimised: true
+      }
+    }
+  }) {
+	  post {
+		  id
+	  }
   }
 }
 

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-create.graphql
@@ -184,7 +184,7 @@ mutation {
     }
     query { nodeId }
   }
-  g: createPerso(input: {
+  g: createPerson(input: {
     person: {
       id: 1998
       name: "Budd Deey"

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -24,5 +24,5 @@ mutation {
   returnVoidMutation(input: {}) { __typename }
   guidFn(input: {g: null}) { guid }
   guidFn2: guidFn(input: {g: "0123456789abcde"}) { guid }
-  postMany(input: {posts: [{headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: true}}]}) { posts { id } }
+  postMany(input: {posts: [{id: 7, headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: true}}]}) { posts { id headline comptypes { schedule isOptimised } } }
 }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -24,5 +24,9 @@ mutation {
   returnVoidMutation(input: {}) { __typename }
   guidFn(input: {g: null}) { guid }
   guidFn2: guidFn(input: {g: "0123456789abcde"}) { guid }
-  postMany(input: {posts: [{id: 7, headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: true}}]}) { posts { id headline comptypes { schedule isOptimised } } }
+  postMany(input: {posts: [
+    {id: 7, headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: true}},
+    {id: 8, headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: null}},
+    {id: 9, headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: false}}
+  ]}) { posts { id headline comptypes { schedule isOptimised } } }
 }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -24,4 +24,5 @@ mutation {
   returnVoidMutation(input: {}) { __typename }
   guidFn(input: {g: null}) { guid }
   guidFn2: guidFn(input: {g: "0123456789abcde"}) { guid }
+  postMany(input: {posts: [{headline: "headline", body: "body", authorId: 9000, enums: AWAITING, comptypes: {schedule: "2009-10-24 10:23:54+02", isOptimised: true}}]}) { posts { id } }
 }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -813,6 +813,26 @@ Object {
           "headline": "headline",
           "id": 7,
         },
+        Object {
+          "comptypes": Array [
+            Object {
+              "isOptimised": null,
+              "schedule": "2009-10-24T04:23:54-04:00",
+            },
+          ],
+          "headline": "headline",
+          "id": 8,
+        },
+        Object {
+          "comptypes": Array [
+            Object {
+              "isOptimised": false,
+              "schedule": "2009-10-24T04:23:54-04:00",
+            },
+          ],
+          "headline": "headline",
+          "id": 9,
+        },
       ],
     },
     "returnVoidMutation": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -351,6 +351,26 @@ Object {
         "nullValue": null,
       },
     },
+    "j": Object {
+      "post": Object {
+        "comptypes": Array [
+          Object {
+            "isOptimised": true,
+            "schedule": "2009-10-24T04:23:54-04:00",
+          },
+          Object {
+            "isOptimised": false,
+            "schedule": "2008-10-24T04:23:54-04:00",
+          },
+          Object {
+            "isOptimised": null,
+            "schedule": "2007-10-24T04:23:54-04:00",
+          },
+        ],
+        "headline": "super headline",
+        "id": 12,
+      },
+    },
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -801,6 +801,20 @@ Object {
       "clientMutationId": "x",
       "integer": 2,
     },
+    "postMany": Object {
+      "posts": Array [
+        Object {
+          "comptypes": Array [
+            Object {
+              "isOptimised": true,
+              "schedule": "2009-10-24T04:23:54-04:00",
+            },
+          ],
+          "headline": "headline",
+          "id": 7,
+        },
+      ],
+    },
     "returnVoidMutation": Object {
       "__typename": "ReturnVoidMutationPayload",
     },

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -4245,6 +4245,12 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: NormalRandInput!
   ): NormalRandPayload
+
+  # Reads and enables pagination through a set of \`Post\`.
+  postMany(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: PostManyInput!
+  ): PostManyPayload
   returnVoidMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: ReturnVoidMutationInput!
@@ -4751,6 +4757,34 @@ input PostInput {
   enums: [AnEnum]
   headline: String!
   id: Int
+}
+
+# All input for the \`postMany\` mutation.
+input PostManyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  posts: [PostInput]
+}
+
+# The output of our \`postMany\` mutation.
+type PostManyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # An edge for the type. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+  posts: [Post]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
 }
 
 # Represents an update to a \`Post\`. Fields that are set will be updated.
@@ -8143,6 +8177,12 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: NormalRandInput!
   ): NormalRandPayload
+
+  # Reads and enables pagination through a set of \`Post\`.
+  postMany(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: PostManyInput!
+  ): PostManyPayload
   returnVoidMutation(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: ReturnVoidMutationInput!
@@ -8333,6 +8373,31 @@ input PostInput {
   comptypes: [ComptypeInput]
   enums: [AnEnum]
   id: Int
+}
+
+# All input for the \`postMany\` mutation.
+input PostManyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  posts: [PostInput]
+}
+
+# The output of our \`postMany\` mutation.
+type PostManyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # An edge for the type. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+  posts: [Post]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
 }
 
 # Represents an update to a \`Post\`. Fields that are set will be updated.

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -218,6 +218,7 @@ create function c.compound_type_computed_field(compound_type c.compound_type) re
 create function a.post_headline_trimmed(post a.post, length int default 10, omission text default '…') returns text as $$ select substr(post.headline, 0, length) || omission $$ language sql stable;
 create function a.post_headline_trimmed_strict(post a.post, length int default 10, omission text default '…') returns text as $$ select substr(post.headline, 0, length) || omission $$ language sql stable strict;
 create function a.post_headline_trimmed_no_defaults(post a.post, length int, omission text) returns text as $$ select substr(post.headline, 0, length) || omission $$ language sql stable;
+create function a.post_many(posts a.post[]) returns setof a.post as $$ declare current_post a.post; begin foreach current_post in array posts loop return next current_post; end loop; end; $$ language plpgsql;
 
 create type b.jwt_token as (
   role text,


### PR DESCRIPTION
I added some tests for the apparent issue with `viaTemporaryTable` . While doing that I found another  `malformed record literal` issue related with the `comptypes`. I added a test for that on `mutation-create`.

As per our discussion we found this other [issue](https://github.com/postgraphql/postgraphql/blob/607f6629986735139e2b77d5a9b1143846c4f691/src/postgraphql/withPostGraphQLContext.ts#L218-L230) where the queries are logged before execution, so if the second query never gets logged then it's never ran and thus the error does not exist there.
