### PR TITLE
Fix example in README.md

### DIFF
--- a/packages/postgraphile-core/README.md
+++ b/packages/postgraphile-core/README.md
@@ -37,11 +37,14 @@ const schema = await createPostGraphQLSchema(
 Full example:
 
 ```js
-const { createPostGraphQLSchema } = require('graphile-build-pg');
-const pg = require('pg');
+const { createPostGraphQLSchema } = require("postgraphile-core");
+const { graphql } = require("graphql");
+const pg = require("pg");
 
 // Create a postgres pool for efficiency
-const pgPool = new pg.Pool(process.env.DATABASE_URL);
+const pgPool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+});
 
 async function runQuery(query, variables) {
 
@@ -98,7 +101,7 @@ runQuery(
   "query MyQuery { allPosts { nodes { id, title, author: userByAuthorId { username } } } }"
 ).then(result => {
   console.dir(result);
-  pgPool.release();
+  pgPool.end();
 }).catch(e => {
   console.error(e);
   process.exit(1);


### PR DESCRIPTION
With these changes, the approach in this example can be executed (assuming the proper schema is already in place).

FYI, there is a very similar example in graphile.github.io/src/pages/graphile-build-pg/security.md, so if/when this is merged, I can clean up that file as well.

That said.. is there any reason you're not using the forum example schema here?  In general, I think the examples would be a lot more useful if they could be run against a known schema.