### PR TITLE
fix(fields): make fieldWithHooks much more consistent

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PageInfoStartEndCursor.js
+++ b/packages/graphile-build-pg/src/plugins/PageInfoStartEndCursor.js
@@ -10,20 +10,32 @@ export default (function PageInfoStartEndCursor(builder) {
       }
       const Cursor = getTypeByName("Cursor");
       return extend(fields, {
-        startCursor: fieldWithHooks("startCursor", ({ addDataGenerator }) => {
-          addDataGenerator(() => ({ usesCursor: [true] }));
-          return {
-            description: "When paginating backwards, the cursor to continue.",
-            type: Cursor,
-          };
-        }),
-        endCursor: fieldWithHooks("endCursor", ({ addDataGenerator }) => {
-          addDataGenerator(() => ({ usesCursor: [true] }));
-          return {
-            description: "When paginating forwards, the cursor to continue.",
-            type: Cursor,
-          };
-        }),
+        startCursor: fieldWithHooks(
+          "startCursor",
+          ({ addDataGenerator }) => {
+            addDataGenerator(() => ({ usesCursor: [true] }));
+            return {
+              description: "When paginating backwards, the cursor to continue.",
+              type: Cursor,
+            };
+          },
+          {
+            isPageInfoStartCursorField: true,
+          }
+        ),
+        endCursor: fieldWithHooks(
+          "endCursor",
+          ({ addDataGenerator }) => {
+            addDataGenerator(() => ({ usesCursor: [true] }));
+            return {
+              description: "When paginating forwards, the cursor to continue.",
+              type: Cursor,
+            };
+          },
+          {
+            isPageInfoStartCursorField: true,
+          }
+        ),
       });
     }
   );

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -136,8 +136,8 @@ export default (async function PgAllRows(
                   };
                 },
                 {
-                  isPgConnectionField: true,
-                  pgIntrospection: table,
+                  isPgFieldConnection: true,
+                  pgFieldIntrospection: table,
                 }
               );
             }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -178,8 +178,8 @@ export default (function PgBackwardRelationPlugin(
               };
             },
             {
-              isPgConnectionField: true,
-              pgIntrospection: table,
+              isPgFieldConnection: true,
+              pgFieldIntrospection: table,
             }
           );
           return memo;

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -60,9 +60,7 @@ export default (function PgColumnsPlugin(
               `Two columns produce the same GraphQL field name '${fieldName}' on class '${table.namespaceName}.${table.name}'; one of them is '${attr.name}'`
             );
           }
-          memo[
-            fieldName
-          ] = fieldWithHooks(
+          memo[fieldName] = fieldWithHooks(
             fieldName,
             ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
               const ReturnType =
@@ -125,7 +123,8 @@ export default (function PgColumnsPlugin(
                   return pg2gql(data[alias], attr.type);
                 },
               };
-            }
+            },
+            { pgFieldIntrospection: attr }
           );
           return memo;
         }, {})

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -76,11 +76,11 @@ export default (function PgConnectionArgCondition(
         pgIntrospectionResultsByKind: introspectionResultsByKind,
       } = build;
       const {
-        scope: { isPgConnectionField, pgIntrospection: table },
+        scope: { isPgFieldConnection, pgFieldIntrospection: table },
         addArgDataGenerator,
       } = context;
       if (
-        !isPgConnectionField ||
+        !isPgFieldConnection ||
         !table ||
         table.kind !== "class" ||
         !table.namespace

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
@@ -10,12 +10,12 @@ export default (function PgConnectionArgs(builder) {
       args,
       { extend, getTypeByName, graphql: { GraphQLInt } },
       {
-        scope: { isPgConnectionField, pgIntrospection: source },
+        scope: { isPgFieldConnection, pgFieldIntrospection: source },
         addArgDataGenerator,
       }
     ) => {
       if (
-        !isPgConnectionField ||
+        !isPgFieldConnection ||
         !source ||
         (source.kind !== "class" && source.kind !== "procedure")
       ) {

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -54,12 +54,12 @@ export default (function PgConnectionArgOrderBy(
       args,
       { extend, getTypeByName, pgGetGqlTypeByTypeId, pgSql: sql },
       {
-        scope: { isPgConnectionField, pgIntrospection: table },
+        scope: { isPgFieldConnection, pgFieldIntrospection: table },
         addArgDataGenerator,
       }
     ) => {
       if (
-        !isPgConnectionField ||
+        !isPgFieldConnection ||
         !table ||
         table.kind !== "class" ||
         !table.namespace ||

--- a/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
@@ -25,17 +25,23 @@ export default (function PgConnectionTotalCount(builder) {
         table.namespace.name
       );
       return extend(fields, {
-        totalCount: fieldWithHooks("totalCount", ({ addDataGenerator }) => {
-          addDataGenerator(() => {
+        totalCount: fieldWithHooks(
+          "totalCount",
+          ({ addDataGenerator }) => {
+            addDataGenerator(() => {
+              return {
+                pgCalculateTotalCount: true,
+              };
+            });
             return {
-              pgCalculateTotalCount: true,
+              description: `The count of *all* \`${tableTypeName}\` you could get from the connection.`,
+              type: GraphQLInt,
             };
-          });
-          return {
-            description: `The count of *all* \`${tableTypeName}\` you could get from the connection.`,
-            type: GraphQLInt,
-          };
-        }),
+          },
+          {
+            isPgConnectionTotalCountField: true,
+          }
+        ),
       });
     }
   );

--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -104,9 +104,7 @@ export default (function PgForwardRelationPlugin(
             foreignTable.namespace.name
           );
 
-          memo[
-            fieldName
-          ] = fieldWithHooks(
+          memo[fieldName] = fieldWithHooks(
             fieldName,
             ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
               addDataGenerator(parsedResolveInfoFragment => {
@@ -149,6 +147,9 @@ export default (function PgForwardRelationPlugin(
                   return data[alias];
                 },
               };
+            },
+            {
+              pgFieldIntrospection: constraint,
             }
           );
           return memo;

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -63,9 +63,7 @@ export default (async function PgRowByUniqueConstraint(
                   table.name,
                   table.namespace.name
                 );
-                memo[
-                  fieldName
-                ] = fieldWithHooks(
+                memo[fieldName] = fieldWithHooks(
                   fieldName,
                   ({ getDataFromParsedResolveInfoFragment }) => {
                     return {
@@ -129,6 +127,10 @@ export default (async function PgRowByUniqueConstraint(
                         return row;
                       },
                     };
+                  },
+                  {
+                    isPgRowByUniqueConstraintField: true,
+                    pgFieldIntrospection: constraint,
                   }
                 );
               });

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -127,9 +127,7 @@ export default (async function PgRowByUniqueConstraint(
                 table.name,
                 table.namespace.name
               );
-              memo[
-                fieldName
-              ] = fieldWithHooks(
+              memo[fieldName] = fieldWithHooks(
                 fieldName,
                 ({ getDataFromParsedResolveInfoFragment }) => {
                   return {
@@ -192,6 +190,10 @@ export default (async function PgRowByUniqueConstraint(
                       }
                     },
                   };
+                },
+                {
+                  isPgNodeQuery: true,
+                  pgFieldIntrospection: table,
                 }
               );
             }

--- a/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
@@ -44,18 +44,24 @@ export default (function PgTablesPlugin(builder, { pgInflection: inflection }) {
               description: `A \`${NodeType.name}\` edge in the connection.`,
               fields: ({ fieldWithHooks }) => {
                 return {
-                  cursor: fieldWithHooks("cursor", ({ addDataGenerator }) => {
-                    addDataGenerator(() => ({
-                      usesCursor: [true],
-                    }));
-                    return {
-                      description: "A cursor for use in pagination.",
-                      type: Cursor,
-                      resolve(data) {
-                        return base64(JSON.stringify(data.__cursor));
-                      },
-                    };
-                  }),
+                  cursor: fieldWithHooks(
+                    "cursor",
+                    ({ addDataGenerator }) => {
+                      addDataGenerator(() => ({
+                        usesCursor: [true],
+                      }));
+                      return {
+                        description: "A cursor for use in pagination.",
+                        type: Cursor,
+                        resolve(data) {
+                          return base64(JSON.stringify(data.__cursor));
+                        },
+                      };
+                    },
+                    {
+                      isCursorField: true,
+                    }
+                  ),
                   node: {
                     description: `The \`${NodeType.name}\` at the end of the edge.`,
                     type: NodeType,

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -236,20 +236,27 @@ export default (function PgTablesPlugin(
               fields: ({ fieldWithHooks, recurseDataGeneratorsForField }) => {
                 recurseDataGeneratorsForField("node");
                 return {
-                  cursor: fieldWithHooks("cursor", ({ addDataGenerator }) => {
-                    addDataGenerator(() => ({
-                      usesCursor: [true],
-                    }));
-                    return {
-                      description: "A cursor for use in pagination.",
-                      type: Cursor,
-                      resolve(data) {
-                        return (
-                          data.__cursor && base64(JSON.stringify(data.__cursor))
-                        );
-                      },
-                    };
-                  }),
+                  cursor: fieldWithHooks(
+                    "cursor",
+                    ({ addDataGenerator }) => {
+                      addDataGenerator(() => ({
+                        usesCursor: [true],
+                      }));
+                      return {
+                        description: "A cursor for use in pagination.",
+                        type: Cursor,
+                        resolve(data) {
+                          return (
+                            data.__cursor &&
+                            base64(JSON.stringify(data.__cursor))
+                          );
+                        },
+                      };
+                    },
+                    {
+                      isCursorField: true,
+                    }
+                  ),
                   node: {
                     description: `The \`${tableTypeName}\` at the end of the edge.`,
                     type: new GraphQLNonNull(TableType),

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -107,8 +107,10 @@ export default function makeProcField(
     );
   }
   let type;
-  const scope = {};
-  scope.pgIntrospection = proc;
+  const fieldScope = {};
+  const payloadTypeScope = {};
+  fieldScope.pgFieldIntrospection = proc;
+  payloadTypeScope.pgIntrospection = proc;
   let returnFirstValueAsValue = false;
   const TableType =
     returnTypeTable && pgGetGqlTypeByTypeId(returnTypeTable.type.id);
@@ -131,15 +133,17 @@ export default function makeProcField(
           );
         }
         type = new GraphQLNonNull(ConnectionType);
-        scope.isPgConnectionField = true;
+        fieldScope.isPgFieldConnection = true;
       }
-      scope.pgIntrospectionTable = returnTypeTable;
+      fieldScope.pgFieldIntrospectionTable = returnTypeTable;
+      payloadTypeScope.pgIntrospectionTable = returnTypeTable;
     } else {
       type = TableType;
       if (rawReturnType.arrayItemType) {
         type = new GraphQLList(type);
       }
-      scope.pgIntrospectionTable = returnTypeTable;
+      fieldScope.pgFieldIntrospectionTable = returnTypeTable;
+      payloadTypeScope.pgIntrospectionTable = returnTypeTable;
     }
   } else {
     const Type = pgGetGqlTypeByTypeId(returnType.id) || GraphQLString;
@@ -156,7 +160,7 @@ export default function makeProcField(
           returnFirstValueAsValue = true;
         } else {
           type = new GraphQLNonNull(ConnectionType);
-          scope.isPgConnectionField = true;
+          fieldScope.isPgFieldConnection = true;
         }
       } else {
         returnFirstValueAsValue = true;
@@ -345,7 +349,7 @@ export default function makeProcField(
             {
               isMutationPayload: true,
             },
-            scope
+            payloadTypeScope
           )
         );
         ReturnType = PayloadType;
@@ -497,6 +501,6 @@ export default function makeProcField(
             },
       };
     },
-    scope
+    fieldScope
   );
 }

--- a/packages/graphile-build/__tests__/fieldData.test.js
+++ b/packages/graphile-build/__tests__/fieldData.test.js
@@ -276,7 +276,8 @@ const DummyConnectionPlugin = async builder => {
                 return ret;
               },
             };
-          }
+          },
+          { isDummyConnectionField: true }
         ),
       });
     }

--- a/packages/graphile-build/__tests__/watch.test.js
+++ b/packages/graphile-build/__tests__/watch.test.js
@@ -81,7 +81,8 @@ const makePluginEtc = (defaultCounter = 0) => {
                   return {};
                 },
               };
-            }
+            },
+            { isDummyField: true }
           ),
         });
       }

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -1,0 +1,15 @@
+// @flow
+
+export default function extend<Obj1: *, Obj2: *>(
+  base: Obj1,
+  extra: Obj2
+): Obj1 & Obj2 {
+  const keysA = Object.keys(base);
+  const keysB = Object.keys(extra);
+  for (const key of keysB) {
+    if (keysA.indexOf(key) >= 0) {
+      throw new Error(`Overwriting key '${key}' is not allowed!`);
+    }
+  }
+  return Object.assign({}, base, extra);
+}

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -440,10 +440,11 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
               const fieldSpec = fieldsSpec[fieldName];
               if (processedFields.indexOf(fieldSpec) < 0) {
                 // We've not processed this yet; process it now!
-                fieldsSpec[fieldName] = fieldsContext.fieldWithHooks(
-                  fieldName,
-                  fieldSpec
-                );
+                fieldsSpec[
+                  fieldName
+                ] = fieldsContext.fieldWithHooks(fieldName, fieldSpec, {
+                  autoField: true, // We don't have any additional information
+                });
               }
             }
             return fieldsSpec;
@@ -516,10 +517,11 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
               const fieldSpec = fieldsSpec[fieldName];
               if (processedFields.indexOf(fieldSpec) < 0) {
                 // We've not processed this yet; process it now!
-                fieldsSpec[fieldName] = fieldsContext.fieldWithHooks(
-                  fieldName,
-                  fieldSpec
-                );
+                fieldsSpec[
+                  fieldName
+                ] = fieldsContext.fieldWithHooks(fieldName, fieldSpec, {
+                  autoField: true, // We don't have any additional information
+                });
               }
             }
             return fieldsSpec;

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -314,10 +314,21 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
               recurseDataGeneratorsForField,
               Self,
               GraphQLObjectType: rawSpec,
-              fieldWithHooks: ((fieldName, spec, fieldScope = {}) => {
+              fieldWithHooks: ((fieldName, spec, fieldScope) => {
                 if (!isString(fieldName)) {
                   throw new Error(
                     "It looks like you forgot to pass the fieldName to `fieldWithHooks`, we're sorry this is current necessary."
+                  );
+                }
+                if (!fieldScope) {
+                  throw new Error(
+                    "All calls to `fieldWithHooks` must specify a `fieldScope` " +
+                      "argument that gives additional context about the field so " +
+                      "that further plugins may more easily understand the field. " +
+                      "Keys within this object should contain the phrase 'field' " +
+                      "since they will be merged into the parent objects scope and " +
+                      "are not allowed to clash. If you really have no additional " +
+                      "information to give, please just pass `{}`."
                   );
                 }
                 let argDataGenerators = [];

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -22,6 +22,8 @@ import type SchemaBuilder, {
   DataForType,
 } from "./SchemaBuilder";
 
+import extend from "./extend";
+
 const isString = str => typeof str === "string";
 const isDev = ["test", "development"].indexOf(process.env.NODE_ENV) >= 0;
 const debug = debugFactory("graphile-build");
@@ -178,16 +180,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
     getTypeByName(typeName) {
       return allTypes[typeName];
     },
-    extend<Obj1: *, Obj2: *>(base: Obj1, extra: Obj2): Obj1 & Obj2 {
-      const keysA = Object.keys(base);
-      const keysB = Object.keys(extra);
-      for (const key of keysB) {
-        if (keysA.indexOf(key) >= 0) {
-          throw new Error(`Overwriting key '${key}' is not allowed!`);
-        }
-      }
-      return Object.assign({}, base, extra);
-    },
+    extend,
     newWithHooks<T: GraphQLNamedType | GraphQLSchema, ConfigType: *>(
       Type: Class<T>,
       spec: ConfigType,
@@ -396,12 +389,10 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                     }
                     return data;
                   },
-                  scope: Object.assign(
-                    {},
-                    scope,
-                    {
+                  scope: extend(
+                    extend(scope, {
                       fieldName,
-                    },
+                    }),
                     fieldScope
                   ),
                 });
@@ -486,12 +477,10 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                   );
                 }
                 let context = Object.assign({}, commonContext, {
-                  scope: Object.assign(
-                    {},
-                    scope,
-                    {
+                  scope: extend(
+                    extend(scope, {
                       fieldName,
-                    },
+                    }),
                     fieldScope
                   ),
                 });

--- a/packages/graphile-build/src/plugins/NodePlugin.js
+++ b/packages/graphile-build/src/plugins/NodePlugin.js
@@ -217,7 +217,10 @@ export default (function NodePlugin(
                 return null;
               }
             },
-          })
+          }),
+          {
+            isRootNodeField: true,
+          }
         ),
       });
     }

--- a/packages/graphile-build/src/plugins/StandardTypesPlugin.js
+++ b/packages/graphile-build/src/plugins/StandardTypesPlugin.js
@@ -56,7 +56,8 @@ export default (function StandardTypesPlugin(builder) {
                     "When paginating forwards, are there more items?",
                   type: new GraphQLNonNull(GraphQLBoolean),
                 };
-              }
+              },
+              { isPageInfoHasNextPageField: true }
             ),
             hasPreviousPage: fieldWithHooks(
               "hasPreviousPage",
@@ -71,7 +72,8 @@ export default (function StandardTypesPlugin(builder) {
                     "When paginating backwards, are there more items?",
                   type: new GraphQLNonNull(GraphQLBoolean),
                 };
-              }
+              },
+              { isPageInfoHasPreviousPageField: true }
             ),
           }),
         },


### PR DESCRIPTION
Fixes https://github.com/postgraphql/postgraphql/issues/590
Enables https://github.com/postgraphql/postgraphql/issues/473

This PR adds a lot more consistency to `fieldWithHook`, but in doing so it includes 🔥 BREAKING CHANGES🔥  for anyone who's using third-party plugins!

- The third argument (`fieldScope`) to `fieldWithHooks` is now required
- `fieldScope` may *no longer* overwrite the parent object's scope - so ⚠️  things like `pgIntrospection` have changed to `pgFieldIntrospection` ⚠️  when they specifically relate to the field (thus the `pgIntrospection` of the parent object is still available)
- `isPgConnectionField` has changed to `isPgFieldConnection` (everywhere you've used `isPgFieldConnection` you'll also need to change `pgIntrospection` for `pgFieldIntrospection` also