### PR TITLE
fix(sql): don't return null for empty arrays

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -77,11 +77,18 @@ export default (function PgColumnsPlugin(
                         const ident = sql.identifier(Symbol());
                         return sql.fragment`
                           (
-                            select json_agg(${getSelectValueForFieldAndType(
-                              ident,
-                              type.arrayItemType
-                            )})
-                            from unnest(${sqlFullName}) as ${ident}
+                            case
+                            when ${sqlFullName} is null then null
+                            when coalesce(array_length(${sqlFullName}, 1), 0) = 0 then '[]'::json
+                            else
+                              (
+                                select json_agg(${getSelectValueForFieldAndType(
+                                  ident,
+                                  type.arrayItemType
+                                )})
+                                from unnest(${sqlFullName}) as ${ident}
+                              )
+                            end
                           )
                         `;
                       } else if (type.type === "c") {

--- a/packages/postgraphile-core/__tests__/fixtures/queries/empty-array.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/empty-array.graphql
@@ -1,12 +1,9 @@
 query {
-  allPeople {
-    edges {
-      cursor
-      node {
-        id
-        name
-        aliases
-      }
+  allPeople(first: 1) {
+    nodes {
+      id
+      name
+      aliases
     }
   }
 }

--- a/packages/postgraphile-core/__tests__/fixtures/queries/empty-array.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/empty-array.graphql
@@ -1,0 +1,12 @@
+query {
+  allPeople {
+    edges {
+      cursor
+      node {
+        id
+        name
+        aliases
+      }
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -817,11 +817,16 @@ Object {
 exports[`empty-array.graphql 1`] = `
 Object {
   "data": Object {
-    "allPeople": null,
+    "allPeople": Object {
+      "nodes": Array [
+        Object {
+          "aliases": Array [],
+          "id": 1,
+          "name": "John Smith",
+        },
+      ],
+    },
   },
-  "errors": Array [
-    [GraphQLError: Cannot return null for non-nullable field Person.aliases.],
-  ],
 }
 `;
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -814,6 +814,17 @@ Object {
 }
 `;
 
+exports[`empty-array.graphql 1`] = `
+Object {
+  "data": Object {
+    "allPeople": null,
+  },
+  "errors": Array [
+    [GraphQLError: Cannot return null for non-nullable field Person.aliases.],
+  ],
+}
+`;
+
 exports[`node.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -734,6 +734,8 @@ type PeopleEdge {
 enum PeopleOrderBy {
   ABOUT_ASC
   ABOUT_DESC
+  ALIASES_ASC
+  ALIASES_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   EMAIL_ASC
@@ -752,6 +754,7 @@ enum PeopleOrderBy {
 # Person test comment
 type Person implements Node {
   about: String
+  aliases: [String]!
 
   # Reads and enables pagination through a set of \`CompoundKey\`.
   compoundKeysByPersonId1(
@@ -843,6 +846,9 @@ input PersonCondition {
   # Checks for equality with the object’s \`about\` field.
   about: String
 
+  # Checks for equality with the object’s \`aliases\` field.
+  aliases: [String]
+
   # Checks for equality with the object’s \`createdAt\` field.
   createdAt: Datetime
 
@@ -862,6 +868,7 @@ input PersonCondition {
 # An input for mutations affecting \`Person\`
 input PersonInput {
   about: String
+  aliases: [String]
   createdAt: Datetime
   email: Email!
 
@@ -874,6 +881,7 @@ input PersonInput {
 # Represents an update to a \`Person\`. Fields that are set will be updated.
 input PersonPatch {
   about: String
+  aliases: [String]
   createdAt: Datetime
   email: Email
 
@@ -4522,6 +4530,8 @@ type PeopleEdge {
 enum PeopleOrderBy {
   ABOUT_ASC
   ABOUT_DESC
+  ALIASES_ASC
+  ALIASES_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   EMAIL_ASC
@@ -4540,6 +4550,7 @@ enum PeopleOrderBy {
 # Person test comment
 type Person implements Node {
   about: String
+  aliases: [String]!
 
   # Reads and enables pagination through a set of \`CompoundKey\`.
   compoundKeysByPersonId1(
@@ -4681,6 +4692,9 @@ input PersonCondition {
   # Checks for equality with the object’s \`about\` field.
   about: String
 
+  # Checks for equality with the object’s \`aliases\` field.
+  aliases: [String]
+
   # Checks for equality with the object’s \`createdAt\` field.
   createdAt: Datetime
 
@@ -4700,6 +4714,7 @@ input PersonCondition {
 # An input for mutations affecting \`Person\`
 input PersonInput {
   about: String
+  aliases: [String]
   createdAt: Datetime
   email: Email!
   id: Int
@@ -4712,6 +4727,7 @@ input PersonInput {
 # Represents an update to a \`Person\`. Fields that are set will be updated.
 input PersonPatch {
   about: String
+  aliases: [String]
   createdAt: Datetime
   email: Email
   id: Int
@@ -7083,6 +7099,8 @@ type PeopleEdge {
 enum PeopleOrderBy {
   ABOUT_ASC
   ABOUT_DESC
+  ALIASES_ASC
+  ALIASES_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   EMAIL_ASC
@@ -7101,6 +7119,7 @@ enum PeopleOrderBy {
 # Person test comment
 type Person implements Node {
   about: String
+  aliases: [String]!
 
   # Reads and enables pagination through a set of \`CompoundKey\`.
   compoundKeysByPersonId1(
@@ -7191,6 +7210,9 @@ type Person implements Node {
 input PersonCondition {
   # Checks for equality with the object’s \`about\` field.
   about: String
+
+  # Checks for equality with the object’s \`aliases\` field.
+  aliases: [String]
 
   # Checks for equality with the object’s \`createdAt\` field.
   createdAt: Datetime

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -22,6 +22,7 @@ create domain b.email as text
 create table c.person (
   id serial primary key,
   name varchar not null,
+  aliases text[] not null default '{}',
   about text,
   email b.email not null unique,
   site b.wrapped_url default null,


### PR DESCRIPTION
Adds a failing test for empty arrays being resolved to null, causing an error to be thrown when the array column is `not null` in postgres.

postgraphql/postgraphql#648