### PR TITLE
chore(refactor): move pgColumnFilter onto build

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -2,15 +2,22 @@
 import sql from "pg-sql2";
 import type { Plugin } from "graphile-build";
 
+const defaultPgColumnFilter = (_attr, _build, _context) => true;
+
 export default (function PgBasicsPlugin(
   builder,
-  { pgInflection, pgStrictFunctions = false }
+  {
+    pgInflection,
+    pgStrictFunctions = false,
+    pgColumnFilter = defaultPgColumnFilter,
+  }
 ) {
   builder.hook("build", build => {
     return build.extend(build, {
       pgSql: sql,
       pgInflection,
       pgStrictFunctions,
+      pgColumnFilter,
     });
   });
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -5,11 +5,9 @@ import type { Plugin } from "graphile-build";
 const nullableIf = (GraphQLNonNull, condition, Type) =>
   condition ? Type : new GraphQLNonNull(Type);
 
-const defaultPgColumnFilter = (_attr, _build, _context) => true;
-
 export default (function PgColumnsPlugin(
   builder,
-  { pgInflection: inflection, pgColumnFilter = defaultPgColumnFilter }
+  { pgInflection: inflection }
 ) {
   builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
     const {
@@ -21,6 +19,7 @@ export default (function PgColumnsPlugin(
       graphql: { GraphQLString, GraphQLNonNull },
       getAliasFromResolveInfo,
       pgTweakFragmentForType,
+      pgColumnFilter,
     } = build;
     const {
       scope: { isPgRowType, isPgCompoundType, pgIntrospection: table },
@@ -144,6 +143,7 @@ export default (function PgColumnsPlugin(
       pgGetGqlInputTypeByTypeId,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       graphql: { GraphQLString, GraphQLNonNull },
+      pgColumnFilter,
     } = build;
     const {
       scope: {

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -1,11 +1,9 @@
 // @flow
 import type { Plugin } from "graphile-build";
 
-const defaultPgColumnFilter = (_attr, _build, _context) => true;
-
 export default (function PgConnectionArgCondition(
   builder,
-  { pgInflection: inflection, pgColumnFilter = defaultPgColumnFilter }
+  { pgInflection: inflection }
 ) {
   builder.hook("init", (_, build) => {
     const {
@@ -13,6 +11,7 @@ export default (function PgConnectionArgCondition(
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgGetGqlInputTypeByTypeId,
       graphql: { GraphQLInputObjectType, GraphQLString },
+      pgColumnFilter,
     } = build;
     introspectionResultsByKind.class
       .filter(table => table.isSelectable)
@@ -74,6 +73,7 @@ export default (function PgConnectionArgCondition(
         getTypeByName,
         pgGetGqlTypeByTypeId,
         pgIntrospectionResultsByKind: introspectionResultsByKind,
+        pgColumnFilter,
       } = build;
       const {
         scope: { isPgFieldConnection, pgFieldIntrospection: table },

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -8,11 +8,7 @@ const debug = debugFactory("graphile-build-pg");
 
 export default (function PgMutationCreatePlugin(
   builder,
-  {
-    pgInflection: inflection,
-    pgDisableDefaultMutations,
-    pgColumnFilter = (_attr, _build, _context) => true,
-  }
+  { pgInflection: inflection, pgDisableDefaultMutations }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -35,6 +31,7 @@ export default (function PgMutationCreatePlugin(
           GraphQLNonNull,
           GraphQLString,
         },
+        pgColumnFilter,
       } = build;
       if (!isRootMutation) {
         return fields;

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -11,11 +11,7 @@ const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 
 export default (async function PgMutationUpdateDeletePlugin(
   builder,
-  {
-    pgInflection: inflection,
-    pgDisableDefaultMutations,
-    pgColumnFilter = (_attr, _build, _context) => true,
-  }
+  { pgInflection: inflection, pgDisableDefaultMutations }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -44,6 +40,7 @@ export default (async function PgMutationUpdateDeletePlugin(
           GraphQLObjectType,
           GraphQLID,
         },
+        pgColumnFilter,
       } = build;
       if (!isRootMutation) {
         return fields;

--- a/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
@@ -3,15 +3,13 @@ import type { Plugin } from "graphile-build";
 
 export default (function PgOrderAllColumnsPlugin(
   builder,
-  {
-    pgInflection: inflection,
-    pgColumnFilter = (_attr, _build, _context) => true,
-  }
+  { pgInflection: inflection }
 ) {
   builder.hook("GraphQLEnumType:values", (values, build, context) => {
     const {
       extend,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
+      pgColumnFilter,
     } = build;
     const { scope: { isPgRowSortEnum, pgIntrospection: table } } = context;
     if (!isPgRowSortEnum || !table || table.kind !== "class") {

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -2,13 +2,7 @@
 import type { Plugin } from "graphile-build";
 const base64 = str => new Buffer(String(str)).toString("base64");
 
-export default (function PgTablesPlugin(
-  builder,
-  {
-    pgInflection: inflection,
-    pgColumnFilter = (_attr, _build, _context) => true,
-  }
-) {
+export default (function PgTablesPlugin(builder, { pgInflection: inflection }) {
   builder.hook("init", (_, build) => {
     const {
       getNodeIdForTypeAndIdentifiers,
@@ -30,6 +24,7 @@ export default (function PgTablesPlugin(
         GraphQLList,
         GraphQLInputObjectType,
       },
+      pgColumnFilter,
     } = build;
     const Cursor = getTypeByName("Cursor");
     introspectionResultsByKind.class.forEach(table => {


### PR DESCRIPTION
This will allow plugins to "enhance" pgColumnFilter over and above what the user provides.

For example, the user might say `pgColumnFilter: attr => attr.name !== 'secret'` to hide a secret column

But someone could write a plugin that would then enhance this pgColumnFilter to also hide any fields beginning with `_`; something like:

```js
function PgHideUnderscoresPlugin(builder) {
  builder.hook("build", build => {
    const previousPgColumnFilter = build.pgColumnFilter;
    return {
      ...build,
      pgColumnFilter(attr, ...rest) {
        if (attr.name[0] === '_') {
          return false;
        } else if (previousPgColumnFilter) {
          return previousPgColumnFilter(attr, ...rest);
        } else {
          return true;
        }
      }
    };
  });
}
```
⚠️  Code example was written off the top of my head direct into the GitHub comment box - it might not even compile, let alone work. ⚠️ 

cc @mattbretl because I know you're interested in this topic