### PR TITLE
feat(cache): enable memoizing time-intensive tasks to disk

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -1,6 +1,7 @@
 // @flow
 import sql from "pg-sql2";
 import type { Plugin } from "graphile-build";
+import { version } from "../../package.json";
 
 const defaultPgColumnFilter = (_attr, _build, _context) => true;
 
@@ -14,6 +15,7 @@ export default (function PgBasicsPlugin(
 ) {
   builder.hook("build", build => {
     return build.extend(build, {
+      graphileBuildPgVersion: version,
       pgSql: sql,
       pgInflection,
       pgStrictFunctions,

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -40,6 +40,7 @@ export type DataForType = {
 };
 
 export type Build = {|
+  graphileBuildVersion: string,
   graphql: {
     GraphQLSchema: typeof graphql.GraphQLSchema,
     GraphQLScalarType: typeof graphql.GraphQLScalarType,

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -24,6 +24,8 @@ import type SchemaBuilder, {
 
 import extend from "./extend";
 
+import { version } from "../package.json";
+
 const isString = str => typeof str === "string";
 const isDev = ["test", "development"].indexOf(process.env.NODE_ENV) >= 0;
 const debug = debugFactory("graphile-build");
@@ -158,6 +160,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
   const fieldDataGeneratorsByType = new Map();
 
   return {
+    graphileBuildVersion: version,
     graphql,
     parseResolveInfo,
     simplifyParsedResolveInfoFragmentWithType,

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+import fs from 'fs';
 import { defaultPlugins, getBuilder } from "graphile-build";
 import {
   defaultPlugins as pgDefaultPlugins,
@@ -40,6 +41,9 @@ type PostGraphQLOptions = {
   pgColumnFilter?: (mixed, Build, Context) => boolean,
   viewUniqueKey?: string,
   enableTags?: boolean,
+  readCache?: string,
+  writeCache?: string,
+  setWriteCacheCallback?: (fn: Function) => Promise<void>,
 };
 
 type PgConfig = Client | Pool | string;
@@ -67,6 +71,14 @@ export const postGraphQLClassicIdsInflection = inflections.newInflector(
   Object.assign({}, postGraphQLBaseOverrides, postGraphQLClassicIdsOverrides)
 );
 
+const awaitKeys = async obj => {
+  const result = {};
+  for (const k in obj) {
+    result[k] = await obj[k];
+  }
+  return result;
+}
+
 const getPostGraphQLBuilder = async (
   pgConfig,
   schemas,
@@ -87,6 +99,9 @@ const getPostGraphQLBuilder = async (
     pgColumnFilter,
     viewUniqueKey,
     enableTags = true,
+    readCache,
+    writeCache,
+    setWriteCacheCallback,
   } = options;
   if (replaceAllPlugins) {
     ensureValidPlugins("replaceAllPlugins", replaceAllPlugins);
@@ -99,6 +114,57 @@ const getPostGraphQLBuilder = async (
       );
     }
   }
+  if (readCache && writeCache) {
+    throw new Error("Use `readCache` or `writeCache` - not both.");
+  }
+
+  let persistentMemoizeWithKey = undefined; // NOT null, otherwise it won't default correctly.
+  let memoizeCache = {};
+
+  if (readCache) {
+    memoizeCache = JSON.parse(await new Promise((resolve, reject) => {
+      fs.readFile(readCache, 'utf8', (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      })
+    }));
+  }
+  if (readCache || writeCache) {
+    persistentMemoizeWithKey = (key, fn) => {
+      if (!(key in memoizeCache)) {
+        if (readCache) {
+          throw new Error(`Expected cache to contain key: ${key}`);
+        }
+        memoizeCache[key] = fn();
+        if (memoizeCache[key] === undefined) {
+          throw new Error(`Cannot memoize 'undefined' - use 'null' instead`);
+        }
+      }
+      return memoizeCache[key];
+    }
+  }
+
+  if (writeCache && setWriteCacheCallback) {
+    setWriteCacheCallback(() => awaitKeys(memoizeCache).then((obj) => new Promise((resolve, reject) => {
+      fs.writeFile(writeCache, JSON.stringify(obj), (err) => {
+        memoizeCache = {}
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+
+    })));
+  } else if (writeCache) {
+    throw new Error("Cannot write cache without 'setWriteCacheCallback'");
+  } else if (setWriteCacheCallback) {
+    setWriteCacheCallback(() => Promise.resolve());
+  }
+
   ensureValidPlugins("prependPlugins", prependPlugins);
   ensureValidPlugins("appendPlugins", appendPlugins);
   ensureValidPlugins("skipPlugins", skipPlugins);
@@ -129,6 +195,7 @@ const getPostGraphQLBuilder = async (
         pgDisableDefaultMutations: disableDefaultMutations,
         pgViewUniqueKey: viewUniqueKey,
         pgEnableTags: enableTags,
+        persistentMemoizeWithKey,
       },
       graphileBuildOptions,
       graphqlBuildOptions // DEPRECATED!
@@ -136,13 +203,26 @@ const getPostGraphQLBuilder = async (
   );
 };
 
+function abort(e) {
+  console.error("Error occured whilst writing cache");
+  console.error(e);
+  process.exit(1);
+}
+
 export const createPostGraphQLSchema = async (
   pgConfig: PgConfig,
   schemas: Array<string> | string,
   options: PostGraphQLOptions = {}
 ) => {
-  const builder = await getPostGraphQLBuilder(pgConfig, schemas, options);
-  return builder.buildSchema();
+  let writeCache;
+  const builder = await getPostGraphQLBuilder(pgConfig, schemas, Object.assign({}, options, {
+    setWriteCacheCallback(fn) {
+      writeCache = fn;
+    }
+  }));
+  const schema = builder.buildSchema();
+  if (writeCache) writeCache().catch(abort);
+  return schema;
 };
 
 /*
@@ -159,9 +239,21 @@ export const watchPostGraphQLSchema = async (
       "You cannot call watchPostGraphQLSchema without a function to pass new schemas to"
     );
   }
-  const builder = await getPostGraphQLBuilder(pgConfig, schemas, options);
+  if (options.readCache) {
+    throw new Error("Using readCache in watch mode does not make sense.");
+  }
+  let writeCache;
+  const builder = await getPostGraphQLBuilder(pgConfig, schemas, Object.assign({}, options, {
+    setWriteCacheCallback(fn) {
+      writeCache = fn;
+    }
+  }));
   let released = false;
-  await builder.watchSchema(onNewSchema);
+  function handleNewSchema(...args) {
+    if (writeCache) writeCache().catch(abort);
+    onNewSchema(...args);
+  }
+  await builder.watchSchema(handleNewSchema);
 
   return async function release() {
     if (released) return;


### PR DESCRIPTION
Fixes #118

This PR allows you to wrap expensive functions during plugin initialisation with `persistentMemoizeWithKey` (as you can see in the PgIntrospectionPlugin). By default this doesn't do much, but in `postgraphile-core` we enable these results to be written out to a JSON file so that they can be loaded on production (or wherever) to reduce startup time. Particularly useful for people using Lambda.

Plugins that utilise this are required to ensure that the cache keys they use:

- are globally unique (suggest you prefix the cache key with the name of the plugin)
- contain everything required to ensure that the cache will be invalidated if the logic changes (e.g. you might use the plugin version, in some cases you might need to combine this with the version numbers of other plugins also)

e.g.

```js
import { version } from "../../package.json";
const pluginName = "PgIntrospectionPlugin";

export default function MyPlugin(builder, { persistentMemoizeWithKey = (fn) => fn() }) => {
  // ...
  const introspectionResultsByKind = persistentMemoizeWithKey(
    `${pluginName}-v${version}-introspectionResultsByKind`,
    async () => { /* figure out the introspection results */ }
  );
  // ...
})
```

In this PR, this feature is only used for caching the introspection results.