### PR TITLE
fix(clash): Auto-rename clashing _input/_patch tables

### DIFF
--- a/packages/graphile-build-pg/src/inflections.js
+++ b/packages/graphile-build-pg/src/inflections.js
@@ -39,8 +39,15 @@ export const newInflector = (
     pluralize,
     singularize,
   }: InflectorUtils = defaultUtils
-): Inflector =>
-  Object.assign(
+): Inflector => {
+  function singularizeTable(tableName: string): string {
+    return singularize(tableName).replace(
+      /.(?:(?:[_-]i|I)nput|(?:[_-]p|P)atch)$/,
+      "$&_record"
+    );
+  }
+
+  return Object.assign(
     {
       pluralize,
       argument(name: ?string, index: number) {
@@ -88,13 +95,10 @@ export const newInflector = (
         return camelCase(`${itemName}-patch`);
       },
       tableName(name: string, _schema: ?string) {
-        return camelCase(singularize(name)).replace(
-          /.(?:Input|Patch)$/,
-          "$&Record"
-        );
+        return camelCase(singularizeTable(name));
       },
       tableNode(name: string, _schema: ?string) {
-        return camelCase(singularize(name));
+        return camelCase(singularizeTable(name));
       },
       allRows(name: string, schema: ?string) {
         return camelCase(`all-${this.pluralize(this.tableName(name, schema))}`);
@@ -143,10 +147,10 @@ export const newInflector = (
         );
       },
       updateNode(name: string, _schema: ?string) {
-        return camelCase(`update-${singularize(name)}`);
+        return camelCase(`update-${singularizeTable(name)}`);
       },
       deleteNode(name: string, _schema: ?string) {
-        return camelCase(`delete-${singularize(name)}`);
+        return camelCase(`delete-${singularizeTable(name)}`);
       },
       updateByKeysInputType(
         detailedKeys: Keys,
@@ -154,7 +158,7 @@ export const newInflector = (
         _schema: ?string
       ) {
         return upperCamelCase(
-          `update-${singularize(name)}-by-${detailedKeys
+          `update-${singularizeTable(name)}-by-${detailedKeys
             .map(key => this.column(key.column, key.table, key.schema))
             .join("-and-")}-input`
         );
@@ -165,16 +169,16 @@ export const newInflector = (
         _schema: ?string
       ) {
         return upperCamelCase(
-          `delete-${singularize(name)}-by-${detailedKeys
+          `delete-${singularizeTable(name)}-by-${detailedKeys
             .map(key => this.column(key.column, key.table, key.schema))
             .join("-and-")}-input`
         );
       },
       updateNodeInputType(name: string, _schema: ?string) {
-        return upperCamelCase(`update-${singularize(name)}-input`);
+        return upperCamelCase(`update-${singularizeTable(name)}-input`);
       },
       deleteNodeInputType(name: string, _schema: ?string) {
-        return upperCamelCase(`delete-${singularize(name)}-input`);
+        return upperCamelCase(`delete-${singularizeTable(name)}-input`);
       },
       manyRelationByKeys(
         detailedKeys: Keys,
@@ -195,7 +199,7 @@ export const newInflector = (
         return upperCamelCase(`${pluralize(typeName)}-edge`);
       },
       edgeField(name: string, _schema: ?string) {
-        return camelCase(`${singularize(name)}-edge`);
+        return camelCase(`${singularizeTable(name)}-edge`);
       },
       connection(typeName: string) {
         return upperCamelCase(`${this.pluralize(typeName)}-connection`);
@@ -207,22 +211,23 @@ export const newInflector = (
         return upperCamelCase(`${procName}-edge`);
       },
       createField(name: string, _schema: ?string) {
-        return camelCase(`create-${singularize(name)}`);
+        return camelCase(`create-${singularizeTable(name)}`);
       },
       createInputType(name: string, _schema: ?string) {
-        return upperCamelCase(`create-${singularize(name)}-input`);
+        return upperCamelCase(`create-${singularizeTable(name)}-input`);
       },
       createPayloadType(name: string, _schema: ?string) {
-        return upperCamelCase(`create-${singularize(name)}-payload`);
+        return upperCamelCase(`create-${singularizeTable(name)}-payload`);
       },
       updatePayloadType(name: string, _schema: ?string) {
-        return upperCamelCase(`update-${singularize(name)}-payload`);
+        return upperCamelCase(`update-${singularizeTable(name)}-payload`);
       },
       deletePayloadType(name: string, _schema: ?string) {
-        return upperCamelCase(`delete-${singularize(name)}-payload`);
+        return upperCamelCase(`delete-${singularizeTable(name)}-payload`);
       },
     },
     overrides
   );
+};
 
 export const defaultInflection = newInflector();

--- a/packages/graphile-build-pg/src/inflections.js
+++ b/packages/graphile-build-pg/src/inflections.js
@@ -89,7 +89,7 @@ export const newInflector = (
       },
       tableName(name: string, _schema: ?string) {
         return camelCase(singularize(name)).replace(
-          /(Input|Patch)$/,
+          /.(?:Input|Patch)$/,
           "$&Record"
         );
       },

--- a/packages/graphile-build-pg/src/inflections.js
+++ b/packages/graphile-build-pg/src/inflections.js
@@ -88,7 +88,10 @@ export const newInflector = (
         return camelCase(`${itemName}-patch`);
       },
       tableName(name: string, _schema: ?string) {
-        return camelCase(singularize(name));
+        return camelCase(singularize(name)).replace(
+          /(Input|Patch)$/,
+          "$&Record"
+        );
       },
       tableNode(name: string, _schema: ?string) {
         return camelCase(singularize(name));

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -6397,8 +6397,7 @@ input ReservedPatch {
   id: Int
 }
 
-# \`reserved_patchs\` table should get renamed to ReservedPatchRecord to prevent
-# clashes with ReservedPatch from \`reserved\` table
+# \`reservedPatchs\` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from \`reserved\` table
 type ReservedPatchRecord implements Node {
   id: Int!
 
@@ -12345,8 +12344,7 @@ input ReservedPatch {
   id: Int
 }
 
-# \`reserved_patchs\` table should get renamed to ReservedPatchRecord to prevent
-# clashes with ReservedPatch from \`reserved\` table
+# \`reservedPatchs\` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from \`reserved\` table
 type ReservedPatchRecord implements Node {
   id: Int!
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -3015,6 +3015,93 @@ type CreatePostPayload {
   query: Query
 }
 
+# All input for the create \`Reserved\` mutation.
+input CreateReservedInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Reserved\` to be created by this mutation.
+  reserved: ReservedInput!
+}
+
+# All input for the create \`ReservedInputRecord\` mutation.
+input CreateReservedInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ReservedInputRecord\` to be created by this mutation.
+  reservedInputRecord: ReservedInputRecordInput!
+}
+
+# The output of our create \`ReservedInputRecord\` mutation.
+type CreateReservedInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedInputEdge(
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedInputRecordsEdge
+
+  # The \`ReservedInputRecord\` that was created by this mutation.
+  reservedInputRecord: ReservedInputRecord
+}
+
+# All input for the create \`ReservedPatchRecord\` mutation.
+input CreateReservedPatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ReservedPatchRecord\` to be created by this mutation.
+  reservedPatchRecord: ReservedPatchRecordInput!
+}
+
+# The output of our create \`ReservedPatchRecord\` mutation.
+type CreateReservedPatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedPatchEdge(
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedPatchRecordsEdge
+
+  # The \`ReservedPatchRecord\` that was created by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+}
+
+# The output of our create \`Reserved\` mutation.
+type CreateReservedPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Reserved\` that was created by this mutation.
+  reserved: Reserved
+
+  # An edge for the type. May be used by Relay 1.
+  reservedEdge(
+    # The method to use when ordering \`Reserved\`.
+    orderBy: ReservedsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedsEdge
+}
+
 # All input for the create \`SimilarTable1\` mutation.
 input CreateSimilarTable1Input {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -3468,6 +3555,120 @@ type DeletePostPayload {
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
+}
+
+# All input for the \`deleteReservedById\` mutation.
+input DeleteReservedByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteReserved\` mutation.
+input DeleteReservedInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Reserved\` to be deleted.
+  nodeId: ID!
+}
+
+# All input for the \`deleteReservedInputRecordById\` mutation.
+input DeleteReservedInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteReservedInput\` mutation.
+input DeleteReservedInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedInputRecord\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`ReservedInputRecord\` mutation.
+type DeleteReservedInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedReservedInputId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedInputEdge(
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedInputRecordsEdge
+
+  # The \`ReservedInputRecord\` that was deleted by this mutation.
+  reservedInputRecord: ReservedInputRecord
+}
+
+# All input for the \`deleteReservedPatchRecordById\` mutation.
+input DeleteReservedPatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteReservedPatch\` mutation.
+input DeleteReservedPatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedPatchRecord\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`ReservedPatchRecord\` mutation.
+type DeleteReservedPatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedReservedPatchId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedPatchEdge(
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedPatchRecordsEdge
+
+  # The \`ReservedPatchRecord\` that was deleted by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+}
+
+# The output of our delete \`Reserved\` mutation.
+type DeleteReservedPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedReservedId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Reserved\` that was deleted by this mutation.
+  reserved: Reserved
+
+  # An edge for the type. May be used by Relay 1.
+  reservedEdge(
+    # The method to use when ordering \`Reserved\`.
+    orderBy: ReservedsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedsEdge
 }
 
 # All input for the \`deleteSimilarTable1ById\` mutation.
@@ -4153,6 +4354,24 @@ type Mutation {
     input: CreatePostInput!
   ): CreatePostPayload
 
+  # Creates a single \`Reserved\`.
+  createReserved(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateReservedInput!
+  ): CreateReservedPayload
+
+  # Creates a single \`ReservedInputRecord\`.
+  createReservedInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateReservedInputInput!
+  ): CreateReservedInputPayload
+
+  # Creates a single \`ReservedPatchRecord\`.
+  createReservedPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateReservedPatchInput!
+  ): CreateReservedPatchPayload
+
   # Creates a single \`SimilarTable1\`.
   createSimilarTable1(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -4242,6 +4461,42 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: DeletePostByIdInput!
   ): DeletePostPayload
+
+  # Deletes a single \`Reserved\` using its globally unique id.
+  deleteReserved(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedInput!
+  ): DeleteReservedPayload
+
+  # Deletes a single \`Reserved\` using a unique key.
+  deleteReservedById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedByIdInput!
+  ): DeleteReservedPayload
+
+  # Deletes a single \`ReservedInputRecord\` using its globally unique id.
+  deleteReservedInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedInputInput!
+  ): DeleteReservedInputPayload
+
+  # Deletes a single \`ReservedInputRecord\` using a unique key.
+  deleteReservedInputRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedInputByIdInput!
+  ): DeleteReservedInputPayload
+
+  # Deletes a single \`ReservedPatchRecord\` using its globally unique id.
+  deleteReservedPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedPatchInput!
+  ): DeleteReservedPatchPayload
+
+  # Deletes a single \`ReservedPatchRecord\` using a unique key.
+  deleteReservedPatchRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedPatchByIdInput!
+  ): DeleteReservedPatchPayload
 
   # Deletes a single \`SimilarTable1\` using its globally unique id.
   deleteSimilarTable1(
@@ -4424,6 +4679,42 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: UpdatePostByIdInput!
   ): UpdatePostPayload
+
+  # Updates a single \`Reserved\` using its globally unique id and a patch.
+  updateReserved(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedInput!
+  ): UpdateReservedPayload
+
+  # Updates a single \`Reserved\` using a unique key and a patch.
+  updateReservedById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedByIdInput!
+  ): UpdateReservedPayload
+
+  # Updates a single \`ReservedInputRecord\` using its globally unique id and a patch.
+  updateReservedInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedInputInput!
+  ): UpdateReservedInputPayload
+
+  # Updates a single \`ReservedInputRecord\` using a unique key and a patch.
+  updateReservedInputRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedInputByIdInput!
+  ): UpdateReservedInputPayload
+
+  # Updates a single \`ReservedPatchRecord\` using its globally unique id and a patch.
+  updateReservedPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedPatchInput!
+  ): UpdateReservedPatchPayload
+
+  # Updates a single \`ReservedPatchRecord\` using a unique key and a patch.
+  updateReservedPatchRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedPatchByIdInput!
+  ): UpdateReservedPatchPayload
 
   # Updates a single \`SimilarTable1\` using its globally unique id and a patch.
   updateSimilarTable1(
@@ -5185,6 +5476,81 @@ type Query implements Node {
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsConnection
 
+  # Reads and enables pagination through a set of \`ReservedInputRecord\`.
+  allReservedInputRecords(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ReservedInputRecordCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReservedInputRecordsConnection
+
+  # Reads and enables pagination through a set of \`ReservedPatchRecord\`.
+  allReservedPatchRecords(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ReservedPatchRecordCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReservedPatchRecordsConnection
+
+  # Reads and enables pagination through a set of \`Reserved\`.
+  allReserveds(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ReservedCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Reserved\`.
+    orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReservedsConnection
+
   # Reads and enables pagination through a set of \`SimilarTable1\`.
   allSimilarTable1S(
     # Read all values in the set after (below) this cursor.
@@ -5487,6 +5853,27 @@ type Query implements Node {
   # which can only query top level fields if they are in a particular form.
   query: Query!
 
+  # Reads a single \`Reserved\` using its globally unique \`ID\`.
+  reserved(
+    # The globally unique \`ID\` to be used in selecting a single \`Reserved\`.
+    nodeId: ID!
+  ): Reserved
+  reservedById(id: Int!): Reserved
+
+  # Reads a single \`ReservedInputRecord\` using its globally unique \`ID\`.
+  reservedInput(
+    # The globally unique \`ID\` to be used in selecting a single \`ReservedInputRecord\`.
+    nodeId: ID!
+  ): ReservedInputRecord
+  reservedInputRecordById(id: Int!): ReservedInputRecord
+
+  # Reads a single \`ReservedPatchRecord\` using its globally unique \`ID\`.
+  reservedPatch(
+    # The globally unique \`ID\` to be used in selecting a single \`ReservedPatchRecord\`.
+    nodeId: ID!
+  ): ReservedPatchRecord
+  reservedPatchRecordById(id: Int!): ReservedPatchRecord
+
   # Reads a single \`SimilarTable1\` using its globally unique \`ID\`.
   similarTable1(
     # The globally unique \`ID\` to be used in selecting a single \`SimilarTable1\`.
@@ -5537,6 +5924,180 @@ type Query implements Node {
     nodeId: ID!
   ): ViewTable
   viewTableById(id: Int!): ViewTable
+}
+
+type Reserved implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Reserved\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input ReservedCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`Reserved\`
+input ReservedInput {
+  id: Int
+}
+
+# \`reserved_input\` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from \`reserved\` table
+type ReservedInputRecord implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`ReservedInputRecord\` object types. All fields
+# are tested for equality and combined with a logical ‘and.’
+input ReservedInputRecordCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`ReservedInputRecord\`
+input ReservedInputRecordInput {
+  id: Int
+}
+
+# Represents an update to a \`ReservedInputRecord\`. Fields that are set will be updated.
+input ReservedInputRecordPatch {
+  id: Int
+}
+
+# A connection to a list of \`ReservedInputRecord\` values.
+type ReservedInputRecordsConnection {
+  # A list of edges which contains the \`ReservedInputRecord\` and cursor to aid in pagination.
+  edges: [ReservedInputRecordsEdge!]!
+
+  # A list of \`ReservedInputRecord\` objects.
+  nodes: [ReservedInputRecord]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ReservedInputRecord\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`ReservedInputRecord\` edge in the connection.
+type ReservedInputRecordsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ReservedInputRecord\` at the end of the edge.
+  node: ReservedInputRecord!
+}
+
+# Methods to use when ordering \`ReservedInputRecord\`.
+enum ReservedInputRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# Represents an update to a \`Reserved\`. Fields that are set will be updated.
+input ReservedPatch {
+  id: Int
+}
+
+# \`reserved_patchs\` table should get renamed to ReservedPatchRecord to prevent
+# clashes with ReservedPatch from \`reserved\` table
+type ReservedPatchRecord implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`ReservedPatchRecord\` object types. All fields
+# are tested for equality and combined with a logical ‘and.’
+input ReservedPatchRecordCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`ReservedPatchRecord\`
+input ReservedPatchRecordInput {
+  id: Int
+}
+
+# Represents an update to a \`ReservedPatchRecord\`. Fields that are set will be updated.
+input ReservedPatchRecordPatch {
+  id: Int
+}
+
+# A connection to a list of \`ReservedPatchRecord\` values.
+type ReservedPatchRecordsConnection {
+  # A list of edges which contains the \`ReservedPatchRecord\` and cursor to aid in pagination.
+  edges: [ReservedPatchRecordsEdge!]!
+
+  # A list of \`ReservedPatchRecord\` objects.
+  nodes: [ReservedPatchRecord]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ReservedPatchRecord\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`ReservedPatchRecord\` edge in the connection.
+type ReservedPatchRecordsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ReservedPatchRecord\` at the end of the edge.
+  node: ReservedPatchRecord!
+}
+
+# Methods to use when ordering \`ReservedPatchRecord\`.
+enum ReservedPatchRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# A connection to a list of \`Reserved\` values.
+type ReservedsConnection {
+  # A list of edges which contains the \`Reserved\` and cursor to aid in pagination.
+  edges: [ReservedsEdge!]!
+
+  # A list of \`Reserved\` objects.
+  nodes: [Reserved]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Reserved\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Reserved\` edge in the connection.
+type ReservedsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Reserved\` at the end of the edge.
+  node: Reserved!
+}
+
+# Methods to use when ordering \`Reserved\`.
+enum ReservedsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
 }
 
 # All input for the \`returnVoidMutation\` mutation.
@@ -6511,6 +7072,135 @@ type UpdatePostPayload {
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
+}
+
+# All input for the \`updateReservedById\` mutation.
+input UpdateReservedByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Reserved\` being updated.
+  reservedPatch: ReservedPatch!
+}
+
+# All input for the \`updateReserved\` mutation.
+input UpdateReservedInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Reserved\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Reserved\` being updated.
+  reservedPatch: ReservedPatch!
+}
+
+# All input for the \`updateReservedInputRecordById\` mutation.
+input UpdateReservedInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`ReservedInputRecord\` being updated.
+  reservedInputRecordPatch: ReservedInputRecordPatch!
+}
+
+# All input for the \`updateReservedInput\` mutation.
+input UpdateReservedInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedInputRecord\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`ReservedInputRecord\` being updated.
+  reservedInputRecordPatch: ReservedInputRecordPatch!
+}
+
+# The output of our update \`ReservedInputRecord\` mutation.
+type UpdateReservedInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedInputEdge(
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedInputRecordsEdge
+
+  # The \`ReservedInputRecord\` that was updated by this mutation.
+  reservedInputRecord: ReservedInputRecord
+}
+
+# All input for the \`updateReservedPatchRecordById\` mutation.
+input UpdateReservedPatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`ReservedPatchRecord\` being updated.
+  reservedPatchRecordPatch: ReservedPatchRecordPatch!
+}
+
+# All input for the \`updateReservedPatch\` mutation.
+input UpdateReservedPatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedPatchRecord\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`ReservedPatchRecord\` being updated.
+  reservedPatchRecordPatch: ReservedPatchRecordPatch!
+}
+
+# The output of our update \`ReservedPatchRecord\` mutation.
+type UpdateReservedPatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedPatchEdge(
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedPatchRecordsEdge
+
+  # The \`ReservedPatchRecord\` that was updated by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+}
+
+# The output of our update \`Reserved\` mutation.
+type UpdateReservedPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Reserved\` that was updated by this mutation.
+  reserved: Reserved
+
+  # An edge for the type. May be used by Relay 1.
+  reservedEdge(
+    # The method to use when ordering \`Reserved\`.
+    orderBy: ReservedsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedsEdge
 }
 
 # All input for the \`updateSimilarTable1ById\` mutation.
@@ -9092,6 +9782,93 @@ type CreatePostPayload {
   query: Query
 }
 
+# All input for the create \`Reserved\` mutation.
+input CreateReservedInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Reserved\` to be created by this mutation.
+  reserved: ReservedInput!
+}
+
+# All input for the create \`ReservedInputRecord\` mutation.
+input CreateReservedInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ReservedInputRecord\` to be created by this mutation.
+  reservedInputRecord: ReservedInputRecordInput!
+}
+
+# The output of our create \`ReservedInputRecord\` mutation.
+type CreateReservedInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedInputEdge(
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedInputRecordsEdge
+
+  # The \`ReservedInputRecord\` that was created by this mutation.
+  reservedInputRecord: ReservedInputRecord
+}
+
+# All input for the create \`ReservedPatchRecord\` mutation.
+input CreateReservedPatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ReservedPatchRecord\` to be created by this mutation.
+  reservedPatchRecord: ReservedPatchRecordInput!
+}
+
+# The output of our create \`ReservedPatchRecord\` mutation.
+type CreateReservedPatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedPatchEdge(
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedPatchRecordsEdge
+
+  # The \`ReservedPatchRecord\` that was created by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+}
+
+# The output of our create \`Reserved\` mutation.
+type CreateReservedPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Reserved\` that was created by this mutation.
+  reserved: Reserved
+
+  # An edge for the type. May be used by Relay 1.
+  reservedEdge(
+    # The method to use when ordering \`Reserved\`.
+    orderBy: ReservedsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedsEdge
+}
+
 # All input for the create \`SimilarTable1\` mutation.
 input CreateSimilarTable1Input {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -9356,6 +10133,120 @@ type DeletePostPayload {
   query: Query
 }
 
+# All input for the \`deleteReservedById\` mutation.
+input DeleteReservedByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteReserved\` mutation.
+input DeleteReservedInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Reserved\` to be deleted.
+  nodeId: ID!
+}
+
+# All input for the \`deleteReservedInputRecordById\` mutation.
+input DeleteReservedInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteReservedInput\` mutation.
+input DeleteReservedInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedInputRecord\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`ReservedInputRecord\` mutation.
+type DeleteReservedInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedReservedInputId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedInputEdge(
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedInputRecordsEdge
+
+  # The \`ReservedInputRecord\` that was deleted by this mutation.
+  reservedInputRecord: ReservedInputRecord
+}
+
+# All input for the \`deleteReservedPatchRecordById\` mutation.
+input DeleteReservedPatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteReservedPatch\` mutation.
+input DeleteReservedPatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedPatchRecord\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`ReservedPatchRecord\` mutation.
+type DeleteReservedPatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedReservedPatchId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedPatchEdge(
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedPatchRecordsEdge
+
+  # The \`ReservedPatchRecord\` that was deleted by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+}
+
+# The output of our delete \`Reserved\` mutation.
+type DeleteReservedPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedReservedId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Reserved\` that was deleted by this mutation.
+  reserved: Reserved
+
+  # An edge for the type. May be used by Relay 1.
+  reservedEdge(
+    # The method to use when ordering \`Reserved\`.
+    orderBy: ReservedsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedsEdge
+}
+
 # All input for the \`deleteSimilarTable1ById\` mutation.
 input DeleteSimilarTable1ByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -9579,6 +10470,24 @@ type Mutation {
     input: CreatePostInput!
   ): CreatePostPayload
 
+  # Creates a single \`Reserved\`.
+  createReserved(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateReservedInput!
+  ): CreateReservedPayload
+
+  # Creates a single \`ReservedInputRecord\`.
+  createReservedInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateReservedInputInput!
+  ): CreateReservedInputPayload
+
+  # Creates a single \`ReservedPatchRecord\`.
+  createReservedPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateReservedPatchInput!
+  ): CreateReservedPatchPayload
+
   # Creates a single \`SimilarTable1\`.
   createSimilarTable1(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -9626,6 +10535,42 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: DeletePostByIdInput!
   ): DeletePostPayload
+
+  # Deletes a single \`Reserved\` using its globally unique id.
+  deleteReserved(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedInput!
+  ): DeleteReservedPayload
+
+  # Deletes a single \`Reserved\` using a unique key.
+  deleteReservedById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedByIdInput!
+  ): DeleteReservedPayload
+
+  # Deletes a single \`ReservedInputRecord\` using its globally unique id.
+  deleteReservedInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedInputInput!
+  ): DeleteReservedInputPayload
+
+  # Deletes a single \`ReservedInputRecord\` using a unique key.
+  deleteReservedInputRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedInputByIdInput!
+  ): DeleteReservedInputPayload
+
+  # Deletes a single \`ReservedPatchRecord\` using its globally unique id.
+  deleteReservedPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedPatchInput!
+  ): DeleteReservedPatchPayload
+
+  # Deletes a single \`ReservedPatchRecord\` using a unique key.
+  deleteReservedPatchRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteReservedPatchByIdInput!
+  ): DeleteReservedPatchPayload
 
   # Deletes a single \`SimilarTable1\` using its globally unique id.
   deleteSimilarTable1(
@@ -9706,6 +10651,42 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: UpdatePostByIdInput!
   ): UpdatePostPayload
+
+  # Updates a single \`Reserved\` using its globally unique id and a patch.
+  updateReserved(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedInput!
+  ): UpdateReservedPayload
+
+  # Updates a single \`Reserved\` using a unique key and a patch.
+  updateReservedById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedByIdInput!
+  ): UpdateReservedPayload
+
+  # Updates a single \`ReservedInputRecord\` using its globally unique id and a patch.
+  updateReservedInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedInputInput!
+  ): UpdateReservedInputPayload
+
+  # Updates a single \`ReservedInputRecord\` using a unique key and a patch.
+  updateReservedInputRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedInputByIdInput!
+  ): UpdateReservedInputPayload
+
+  # Updates a single \`ReservedPatchRecord\` using its globally unique id and a patch.
+  updateReservedPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedPatchInput!
+  ): UpdateReservedPatchPayload
+
+  # Updates a single \`ReservedPatchRecord\` using a unique key and a patch.
+  updateReservedPatchRecordById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateReservedPatchByIdInput!
+  ): UpdateReservedPatchPayload
 
   # Updates a single \`SimilarTable1\` using its globally unique id and a patch.
   updateSimilarTable1(
@@ -10085,6 +11066,81 @@ type Query implements Node {
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsConnection
 
+  # Reads and enables pagination through a set of \`ReservedInputRecord\`.
+  allReservedInputRecords(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ReservedInputRecordCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReservedInputRecordsConnection
+
+  # Reads and enables pagination through a set of \`ReservedPatchRecord\`.
+  allReservedPatchRecords(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ReservedPatchRecordCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReservedPatchRecordsConnection
+
+  # Reads and enables pagination through a set of \`Reserved\`.
+  allReserveds(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ReservedCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Reserved\`.
+    orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReservedsConnection
+
   # Reads and enables pagination through a set of \`SimilarTable1\`.
   allSimilarTable1S(
     # Read all values in the set after (below) this cursor.
@@ -10277,6 +11333,27 @@ type Query implements Node {
   # which can only query top level fields if they are in a particular form.
   query: Query!
 
+  # Reads a single \`Reserved\` using its globally unique \`ID\`.
+  reserved(
+    # The globally unique \`ID\` to be used in selecting a single \`Reserved\`.
+    nodeId: ID!
+  ): Reserved
+  reservedById(id: Int!): Reserved
+
+  # Reads a single \`ReservedInputRecord\` using its globally unique \`ID\`.
+  reservedInput(
+    # The globally unique \`ID\` to be used in selecting a single \`ReservedInputRecord\`.
+    nodeId: ID!
+  ): ReservedInputRecord
+  reservedInputRecordById(id: Int!): ReservedInputRecord
+
+  # Reads a single \`ReservedPatchRecord\` using its globally unique \`ID\`.
+  reservedPatch(
+    # The globally unique \`ID\` to be used in selecting a single \`ReservedPatchRecord\`.
+    nodeId: ID!
+  ): ReservedPatchRecord
+  reservedPatchRecordById(id: Int!): ReservedPatchRecord
+
   # Reads a single \`SimilarTable1\` using its globally unique \`ID\`.
   similarTable1(
     # The globally unique \`ID\` to be used in selecting a single \`SimilarTable1\`.
@@ -10297,6 +11374,180 @@ type Query implements Node {
     nodeId: ID!
   ): ViewTable
   viewTableById(id: Int!): ViewTable
+}
+
+type Reserved implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Reserved\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input ReservedCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`Reserved\`
+input ReservedInput {
+  id: Int
+}
+
+# \`reserved_input\` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from \`reserved\` table
+type ReservedInputRecord implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`ReservedInputRecord\` object types. All fields
+# are tested for equality and combined with a logical ‘and.’
+input ReservedInputRecordCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`ReservedInputRecord\`
+input ReservedInputRecordInput {
+  id: Int
+}
+
+# Represents an update to a \`ReservedInputRecord\`. Fields that are set will be updated.
+input ReservedInputRecordPatch {
+  id: Int
+}
+
+# A connection to a list of \`ReservedInputRecord\` values.
+type ReservedInputRecordsConnection {
+  # A list of edges which contains the \`ReservedInputRecord\` and cursor to aid in pagination.
+  edges: [ReservedInputRecordsEdge!]!
+
+  # A list of \`ReservedInputRecord\` objects.
+  nodes: [ReservedInputRecord]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ReservedInputRecord\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`ReservedInputRecord\` edge in the connection.
+type ReservedInputRecordsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ReservedInputRecord\` at the end of the edge.
+  node: ReservedInputRecord!
+}
+
+# Methods to use when ordering \`ReservedInputRecord\`.
+enum ReservedInputRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# Represents an update to a \`Reserved\`. Fields that are set will be updated.
+input ReservedPatch {
+  id: Int
+}
+
+# \`reserved_patchs\` table should get renamed to ReservedPatchRecord to prevent
+# clashes with ReservedPatch from \`reserved\` table
+type ReservedPatchRecord implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`ReservedPatchRecord\` object types. All fields
+# are tested for equality and combined with a logical ‘and.’
+input ReservedPatchRecordCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`ReservedPatchRecord\`
+input ReservedPatchRecordInput {
+  id: Int
+}
+
+# Represents an update to a \`ReservedPatchRecord\`. Fields that are set will be updated.
+input ReservedPatchRecordPatch {
+  id: Int
+}
+
+# A connection to a list of \`ReservedPatchRecord\` values.
+type ReservedPatchRecordsConnection {
+  # A list of edges which contains the \`ReservedPatchRecord\` and cursor to aid in pagination.
+  edges: [ReservedPatchRecordsEdge!]!
+
+  # A list of \`ReservedPatchRecord\` objects.
+  nodes: [ReservedPatchRecord]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ReservedPatchRecord\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`ReservedPatchRecord\` edge in the connection.
+type ReservedPatchRecordsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ReservedPatchRecord\` at the end of the edge.
+  node: ReservedPatchRecord!
+}
+
+# Methods to use when ordering \`ReservedPatchRecord\`.
+enum ReservedPatchRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# A connection to a list of \`Reserved\` values.
+type ReservedsConnection {
+  # A list of edges which contains the \`Reserved\` and cursor to aid in pagination.
+  edges: [ReservedsEdge!]!
+
+  # A list of \`Reserved\` objects.
+  nodes: [Reserved]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Reserved\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Reserved\` edge in the connection.
+type ReservedsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Reserved\` at the end of the edge.
+  node: Reserved!
+}
+
+# Methods to use when ordering \`Reserved\`.
+enum ReservedsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
 }
 
 # All input for the \`returnVoidMutation\` mutation.
@@ -10716,6 +11967,135 @@ type UpdatePostPayload {
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
+}
+
+# All input for the \`updateReservedById\` mutation.
+input UpdateReservedByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Reserved\` being updated.
+  reservedPatch: ReservedPatch!
+}
+
+# All input for the \`updateReserved\` mutation.
+input UpdateReservedInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Reserved\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Reserved\` being updated.
+  reservedPatch: ReservedPatch!
+}
+
+# All input for the \`updateReservedInputRecordById\` mutation.
+input UpdateReservedInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`ReservedInputRecord\` being updated.
+  reservedInputRecordPatch: ReservedInputRecordPatch!
+}
+
+# All input for the \`updateReservedInput\` mutation.
+input UpdateReservedInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedInputRecord\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`ReservedInputRecord\` being updated.
+  reservedInputRecordPatch: ReservedInputRecordPatch!
+}
+
+# The output of our update \`ReservedInputRecord\` mutation.
+type UpdateReservedInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedInputEdge(
+    # The method to use when ordering \`ReservedInputRecord\`.
+    orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedInputRecordsEdge
+
+  # The \`ReservedInputRecord\` that was updated by this mutation.
+  reservedInputRecord: ReservedInputRecord
+}
+
+# All input for the \`updateReservedPatchRecordById\` mutation.
+input UpdateReservedPatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`ReservedPatchRecord\` being updated.
+  reservedPatchRecordPatch: ReservedPatchRecordPatch!
+}
+
+# All input for the \`updateReservedPatch\` mutation.
+input UpdateReservedPatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`ReservedPatchRecord\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`ReservedPatchRecord\` being updated.
+  reservedPatchRecordPatch: ReservedPatchRecordPatch!
+}
+
+# The output of our update \`ReservedPatchRecord\` mutation.
+type UpdateReservedPatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # An edge for the type. May be used by Relay 1.
+  reservedPatchEdge(
+    # The method to use when ordering \`ReservedPatchRecord\`.
+    orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedPatchRecordsEdge
+
+  # The \`ReservedPatchRecord\` that was updated by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+}
+
+# The output of our update \`Reserved\` mutation.
+type UpdateReservedPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Reserved\` that was updated by this mutation.
+  reserved: Reserved
+
+  # An edge for the type. May be used by Relay 1.
+  reservedEdge(
+    # The method to use when ordering \`Reserved\`.
+    orderBy: ReservedsOrderBy = PRIMARY_KEY_ASC
+  ): ReservedsEdge
 }
 
 # All input for the \`updateSimilarTable1ById\` mutation.

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -3084,7 +3084,7 @@ input CreateReservedInput {
 }
 
 # All input for the create \`ReservedInputRecord\` mutation.
-input CreateReservedInputInput {
+input CreateReservedInputRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -3094,7 +3094,7 @@ input CreateReservedInputInput {
 }
 
 # The output of our create \`ReservedInputRecord\` mutation.
-type CreateReservedInputPayload {
+type CreateReservedInputRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -3102,18 +3102,18 @@ type CreateReservedInputPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedInputRecord\` that was created by this mutation.
+  reservedInputRecord: ReservedInputRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedInputEdge(
+  reservedInputRecordEdge(
     # The method to use when ordering \`ReservedInputRecord\`.
     orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedInputRecordsEdge
-
-  # The \`ReservedInputRecord\` that was created by this mutation.
-  reservedInputRecord: ReservedInputRecord
 }
 
 # All input for the create \`ReservedPatchRecord\` mutation.
-input CreateReservedPatchInput {
+input CreateReservedPatchRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -3123,7 +3123,7 @@ input CreateReservedPatchInput {
 }
 
 # The output of our create \`ReservedPatchRecord\` mutation.
-type CreateReservedPatchPayload {
+type CreateReservedPatchRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -3131,14 +3131,14 @@ type CreateReservedPatchPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedPatchRecord\` that was created by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedPatchEdge(
+  reservedPatchRecordEdge(
     # The method to use when ordering \`ReservedPatchRecord\`.
     orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedPatchRecordsEdge
-
-  # The \`ReservedPatchRecord\` that was created by this mutation.
-  reservedPatchRecord: ReservedPatchRecord
 }
 
 # The output of our create \`Reserved\` mutation.
@@ -3710,15 +3710,15 @@ input DeleteReservedInput {
 }
 
 # All input for the \`deleteReservedInputRecordById\` mutation.
-input DeleteReservedInputByIdInput {
+input DeleteReservedInputRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
   id: Int!
 }
 
-# All input for the \`deleteReservedInput\` mutation.
-input DeleteReservedInputInput {
+# All input for the \`deleteReservedInputRecord\` mutation.
+input DeleteReservedInputRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -3728,7 +3728,7 @@ input DeleteReservedInputInput {
 }
 
 # The output of our delete \`ReservedInputRecord\` mutation.
-type DeleteReservedInputPayload {
+type DeleteReservedInputRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -3737,26 +3737,26 @@ type DeleteReservedInputPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedInputRecord\` that was deleted by this mutation.
+  reservedInputRecord: ReservedInputRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedInputEdge(
+  reservedInputRecordEdge(
     # The method to use when ordering \`ReservedInputRecord\`.
     orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedInputRecordsEdge
-
-  # The \`ReservedInputRecord\` that was deleted by this mutation.
-  reservedInputRecord: ReservedInputRecord
 }
 
 # All input for the \`deleteReservedPatchRecordById\` mutation.
-input DeleteReservedPatchByIdInput {
+input DeleteReservedPatchRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
   id: Int!
 }
 
-# All input for the \`deleteReservedPatch\` mutation.
-input DeleteReservedPatchInput {
+# All input for the \`deleteReservedPatchRecord\` mutation.
+input DeleteReservedPatchRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -3766,7 +3766,7 @@ input DeleteReservedPatchInput {
 }
 
 # The output of our delete \`ReservedPatchRecord\` mutation.
-type DeleteReservedPatchPayload {
+type DeleteReservedPatchRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -3775,14 +3775,14 @@ type DeleteReservedPatchPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedPatchRecord\` that was deleted by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedPatchEdge(
+  reservedPatchRecordEdge(
     # The method to use when ordering \`ReservedPatchRecord\`.
     orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedPatchRecordsEdge
-
-  # The \`ReservedPatchRecord\` that was deleted by this mutation.
-  reservedPatchRecord: ReservedPatchRecord
 }
 
 # The output of our delete \`Reserved\` mutation.
@@ -4564,16 +4564,16 @@ type Mutation {
   ): CreateReservedPayload
 
   # Creates a single \`ReservedInputRecord\`.
-  createReservedInput(
+  createReservedInputRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: CreateReservedInputInput!
-  ): CreateReservedInputPayload
+    input: CreateReservedInputRecordInput!
+  ): CreateReservedInputRecordPayload
 
   # Creates a single \`ReservedPatchRecord\`.
-  createReservedPatch(
+  createReservedPatchRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: CreateReservedPatchInput!
-  ): CreateReservedPatchPayload
+    input: CreateReservedPatchRecordInput!
+  ): CreateReservedPatchRecordPayload
 
   # Creates a single \`SimilarTable1\`.
   createSimilarTable1(
@@ -4702,28 +4702,28 @@ type Mutation {
   ): DeleteReservedPayload
 
   # Deletes a single \`ReservedInputRecord\` using its globally unique id.
-  deleteReservedInput(
+  deleteReservedInputRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedInputInput!
-  ): DeleteReservedInputPayload
+    input: DeleteReservedInputRecordInput!
+  ): DeleteReservedInputRecordPayload
 
   # Deletes a single \`ReservedInputRecord\` using a unique key.
   deleteReservedInputRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedInputByIdInput!
-  ): DeleteReservedInputPayload
+    input: DeleteReservedInputRecordByIdInput!
+  ): DeleteReservedInputRecordPayload
 
   # Deletes a single \`ReservedPatchRecord\` using its globally unique id.
-  deleteReservedPatch(
+  deleteReservedPatchRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedPatchInput!
-  ): DeleteReservedPatchPayload
+    input: DeleteReservedPatchRecordInput!
+  ): DeleteReservedPatchRecordPayload
 
   # Deletes a single \`ReservedPatchRecord\` using a unique key.
   deleteReservedPatchRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedPatchByIdInput!
-  ): DeleteReservedPatchPayload
+    input: DeleteReservedPatchRecordByIdInput!
+  ): DeleteReservedPatchRecordPayload
 
   # Deletes a single \`SimilarTable1\` using its globally unique id.
   deleteSimilarTable1(
@@ -4944,28 +4944,28 @@ type Mutation {
   ): UpdateReservedPayload
 
   # Updates a single \`ReservedInputRecord\` using its globally unique id and a patch.
-  updateReservedInput(
+  updateReservedInputRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedInputInput!
-  ): UpdateReservedInputPayload
+    input: UpdateReservedInputRecordInput!
+  ): UpdateReservedInputRecordPayload
 
   # Updates a single \`ReservedInputRecord\` using a unique key and a patch.
   updateReservedInputRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedInputByIdInput!
-  ): UpdateReservedInputPayload
+    input: UpdateReservedInputRecordByIdInput!
+  ): UpdateReservedInputRecordPayload
 
   # Updates a single \`ReservedPatchRecord\` using its globally unique id and a patch.
-  updateReservedPatch(
+  updateReservedPatchRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedPatchInput!
-  ): UpdateReservedPatchPayload
+    input: UpdateReservedPatchRecordInput!
+  ): UpdateReservedPatchRecordPayload
 
   # Updates a single \`ReservedPatchRecord\` using a unique key and a patch.
   updateReservedPatchRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedPatchByIdInput!
-  ): UpdateReservedPatchPayload
+    input: UpdateReservedPatchRecordByIdInput!
+  ): UpdateReservedPatchRecordPayload
 
   # Updates a single \`SimilarTable1\` using its globally unique id and a patch.
   updateSimilarTable1(
@@ -6233,14 +6233,14 @@ type Query implements Node {
   reservedById(id: Int!): Reserved
 
   # Reads a single \`ReservedInputRecord\` using its globally unique \`ID\`.
-  reservedInput(
+  reservedInputRecord(
     # The globally unique \`ID\` to be used in selecting a single \`ReservedInputRecord\`.
     nodeId: ID!
   ): ReservedInputRecord
   reservedInputRecordById(id: Int!): ReservedInputRecord
 
   # Reads a single \`ReservedPatchRecord\` using its globally unique \`ID\`.
-  reservedPatch(
+  reservedPatchRecord(
     # The globally unique \`ID\` to be used in selecting a single \`ReservedPatchRecord\`.
     nodeId: ID!
   ): ReservedPatchRecord
@@ -7592,7 +7592,7 @@ input UpdateReservedInput {
 }
 
 # All input for the \`updateReservedInputRecordById\` mutation.
-input UpdateReservedInputByIdInput {
+input UpdateReservedInputRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -7602,8 +7602,8 @@ input UpdateReservedInputByIdInput {
   reservedInputRecordPatch: ReservedInputRecordPatch!
 }
 
-# All input for the \`updateReservedInput\` mutation.
-input UpdateReservedInputInput {
+# All input for the \`updateReservedInputRecord\` mutation.
+input UpdateReservedInputRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -7616,7 +7616,7 @@ input UpdateReservedInputInput {
 }
 
 # The output of our update \`ReservedInputRecord\` mutation.
-type UpdateReservedInputPayload {
+type UpdateReservedInputRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -7624,18 +7624,18 @@ type UpdateReservedInputPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedInputRecord\` that was updated by this mutation.
+  reservedInputRecord: ReservedInputRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedInputEdge(
+  reservedInputRecordEdge(
     # The method to use when ordering \`ReservedInputRecord\`.
     orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedInputRecordsEdge
-
-  # The \`ReservedInputRecord\` that was updated by this mutation.
-  reservedInputRecord: ReservedInputRecord
 }
 
 # All input for the \`updateReservedPatchRecordById\` mutation.
-input UpdateReservedPatchByIdInput {
+input UpdateReservedPatchRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -7645,8 +7645,8 @@ input UpdateReservedPatchByIdInput {
   reservedPatchRecordPatch: ReservedPatchRecordPatch!
 }
 
-# All input for the \`updateReservedPatch\` mutation.
-input UpdateReservedPatchInput {
+# All input for the \`updateReservedPatchRecord\` mutation.
+input UpdateReservedPatchRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -7659,7 +7659,7 @@ input UpdateReservedPatchInput {
 }
 
 # The output of our update \`ReservedPatchRecord\` mutation.
-type UpdateReservedPatchPayload {
+type UpdateReservedPatchRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -7667,14 +7667,14 @@ type UpdateReservedPatchPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedPatchRecord\` that was updated by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedPatchEdge(
+  reservedPatchRecordEdge(
     # The method to use when ordering \`ReservedPatchRecord\`.
     orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedPatchRecordsEdge
-
-  # The \`ReservedPatchRecord\` that was updated by this mutation.
-  reservedPatchRecord: ReservedPatchRecord
 }
 
 # The output of our update \`Reserved\` mutation.
@@ -10349,7 +10349,7 @@ input CreateReservedInput {
 }
 
 # All input for the create \`ReservedInputRecord\` mutation.
-input CreateReservedInputInput {
+input CreateReservedInputRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -10359,7 +10359,7 @@ input CreateReservedInputInput {
 }
 
 # The output of our create \`ReservedInputRecord\` mutation.
-type CreateReservedInputPayload {
+type CreateReservedInputRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -10367,18 +10367,18 @@ type CreateReservedInputPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedInputRecord\` that was created by this mutation.
+  reservedInputRecord: ReservedInputRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedInputEdge(
+  reservedInputRecordEdge(
     # The method to use when ordering \`ReservedInputRecord\`.
     orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedInputRecordsEdge
-
-  # The \`ReservedInputRecord\` that was created by this mutation.
-  reservedInputRecord: ReservedInputRecord
 }
 
 # All input for the create \`ReservedPatchRecord\` mutation.
-input CreateReservedPatchInput {
+input CreateReservedPatchRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -10388,7 +10388,7 @@ input CreateReservedPatchInput {
 }
 
 # The output of our create \`ReservedPatchRecord\` mutation.
-type CreateReservedPatchPayload {
+type CreateReservedPatchRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -10396,14 +10396,14 @@ type CreateReservedPatchPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedPatchRecord\` that was created by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedPatchEdge(
+  reservedPatchRecordEdge(
     # The method to use when ordering \`ReservedPatchRecord\`.
     orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedPatchRecordsEdge
-
-  # The \`ReservedPatchRecord\` that was created by this mutation.
-  reservedPatchRecord: ReservedPatchRecord
 }
 
 # The output of our create \`Reserved\` mutation.
@@ -10784,15 +10784,15 @@ input DeleteReservedInput {
 }
 
 # All input for the \`deleteReservedInputRecordById\` mutation.
-input DeleteReservedInputByIdInput {
+input DeleteReservedInputRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
   id: Int!
 }
 
-# All input for the \`deleteReservedInput\` mutation.
-input DeleteReservedInputInput {
+# All input for the \`deleteReservedInputRecord\` mutation.
+input DeleteReservedInputRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -10802,7 +10802,7 @@ input DeleteReservedInputInput {
 }
 
 # The output of our delete \`ReservedInputRecord\` mutation.
-type DeleteReservedInputPayload {
+type DeleteReservedInputRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -10811,26 +10811,26 @@ type DeleteReservedInputPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedInputRecord\` that was deleted by this mutation.
+  reservedInputRecord: ReservedInputRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedInputEdge(
+  reservedInputRecordEdge(
     # The method to use when ordering \`ReservedInputRecord\`.
     orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedInputRecordsEdge
-
-  # The \`ReservedInputRecord\` that was deleted by this mutation.
-  reservedInputRecord: ReservedInputRecord
 }
 
 # All input for the \`deleteReservedPatchRecordById\` mutation.
-input DeleteReservedPatchByIdInput {
+input DeleteReservedPatchRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
   id: Int!
 }
 
-# All input for the \`deleteReservedPatch\` mutation.
-input DeleteReservedPatchInput {
+# All input for the \`deleteReservedPatchRecord\` mutation.
+input DeleteReservedPatchRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -10840,7 +10840,7 @@ input DeleteReservedPatchInput {
 }
 
 # The output of our delete \`ReservedPatchRecord\` mutation.
-type DeleteReservedPatchPayload {
+type DeleteReservedPatchRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -10849,14 +10849,14 @@ type DeleteReservedPatchPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedPatchRecord\` that was deleted by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedPatchEdge(
+  reservedPatchRecordEdge(
     # The method to use when ordering \`ReservedPatchRecord\`.
     orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedPatchRecordsEdge
-
-  # The \`ReservedPatchRecord\` that was deleted by this mutation.
-  reservedPatchRecord: ReservedPatchRecord
 }
 
 # The output of our delete \`Reserved\` mutation.
@@ -11178,16 +11178,16 @@ type Mutation {
   ): CreateReservedPayload
 
   # Creates a single \`ReservedInputRecord\`.
-  createReservedInput(
+  createReservedInputRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: CreateReservedInputInput!
-  ): CreateReservedInputPayload
+    input: CreateReservedInputRecordInput!
+  ): CreateReservedInputRecordPayload
 
   # Creates a single \`ReservedPatchRecord\`.
-  createReservedPatch(
+  createReservedPatchRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: CreateReservedPatchInput!
-  ): CreateReservedPatchPayload
+    input: CreateReservedPatchRecordInput!
+  ): CreateReservedPatchRecordPayload
 
   # Creates a single \`SimilarTable1\`.
   createSimilarTable1(
@@ -11274,28 +11274,28 @@ type Mutation {
   ): DeleteReservedPayload
 
   # Deletes a single \`ReservedInputRecord\` using its globally unique id.
-  deleteReservedInput(
+  deleteReservedInputRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedInputInput!
-  ): DeleteReservedInputPayload
+    input: DeleteReservedInputRecordInput!
+  ): DeleteReservedInputRecordPayload
 
   # Deletes a single \`ReservedInputRecord\` using a unique key.
   deleteReservedInputRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedInputByIdInput!
-  ): DeleteReservedInputPayload
+    input: DeleteReservedInputRecordByIdInput!
+  ): DeleteReservedInputRecordPayload
 
   # Deletes a single \`ReservedPatchRecord\` using its globally unique id.
-  deleteReservedPatch(
+  deleteReservedPatchRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedPatchInput!
-  ): DeleteReservedPatchPayload
+    input: DeleteReservedPatchRecordInput!
+  ): DeleteReservedPatchRecordPayload
 
   # Deletes a single \`ReservedPatchRecord\` using a unique key.
   deleteReservedPatchRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: DeleteReservedPatchByIdInput!
-  ): DeleteReservedPatchPayload
+    input: DeleteReservedPatchRecordByIdInput!
+  ): DeleteReservedPatchRecordPayload
 
   # Deletes a single \`SimilarTable1\` using its globally unique id.
   deleteSimilarTable1(
@@ -11414,28 +11414,28 @@ type Mutation {
   ): UpdateReservedPayload
 
   # Updates a single \`ReservedInputRecord\` using its globally unique id and a patch.
-  updateReservedInput(
+  updateReservedInputRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedInputInput!
-  ): UpdateReservedInputPayload
+    input: UpdateReservedInputRecordInput!
+  ): UpdateReservedInputRecordPayload
 
   # Updates a single \`ReservedInputRecord\` using a unique key and a patch.
   updateReservedInputRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedInputByIdInput!
-  ): UpdateReservedInputPayload
+    input: UpdateReservedInputRecordByIdInput!
+  ): UpdateReservedInputRecordPayload
 
   # Updates a single \`ReservedPatchRecord\` using its globally unique id and a patch.
-  updateReservedPatch(
+  updateReservedPatchRecord(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedPatchInput!
-  ): UpdateReservedPatchPayload
+    input: UpdateReservedPatchRecordInput!
+  ): UpdateReservedPatchRecordPayload
 
   # Updates a single \`ReservedPatchRecord\` using a unique key and a patch.
   updateReservedPatchRecordById(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    input: UpdateReservedPatchByIdInput!
-  ): UpdateReservedPatchPayload
+    input: UpdateReservedPatchRecordByIdInput!
+  ): UpdateReservedPatchRecordPayload
 
   # Updates a single \`SimilarTable1\` using its globally unique id and a patch.
   updateSimilarTable1(
@@ -12211,14 +12211,14 @@ type Query implements Node {
   reservedById(id: Int!): Reserved
 
   # Reads a single \`ReservedInputRecord\` using its globally unique \`ID\`.
-  reservedInput(
+  reservedInputRecord(
     # The globally unique \`ID\` to be used in selecting a single \`ReservedInputRecord\`.
     nodeId: ID!
   ): ReservedInputRecord
   reservedInputRecordById(id: Int!): ReservedInputRecord
 
   # Reads a single \`ReservedPatchRecord\` using its globally unique \`ID\`.
-  reservedPatch(
+  reservedPatchRecord(
     # The globally unique \`ID\` to be used in selecting a single \`ReservedPatchRecord\`.
     nodeId: ID!
   ): ReservedPatchRecord
@@ -12985,7 +12985,7 @@ input UpdateReservedInput {
 }
 
 # All input for the \`updateReservedInputRecordById\` mutation.
-input UpdateReservedInputByIdInput {
+input UpdateReservedInputRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -12995,8 +12995,8 @@ input UpdateReservedInputByIdInput {
   reservedInputRecordPatch: ReservedInputRecordPatch!
 }
 
-# All input for the \`updateReservedInput\` mutation.
-input UpdateReservedInputInput {
+# All input for the \`updateReservedInputRecord\` mutation.
+input UpdateReservedInputRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -13009,7 +13009,7 @@ input UpdateReservedInputInput {
 }
 
 # The output of our update \`ReservedInputRecord\` mutation.
-type UpdateReservedInputPayload {
+type UpdateReservedInputRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -13017,18 +13017,18 @@ type UpdateReservedInputPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedInputRecord\` that was updated by this mutation.
+  reservedInputRecord: ReservedInputRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedInputEdge(
+  reservedInputRecordEdge(
     # The method to use when ordering \`ReservedInputRecord\`.
     orderBy: ReservedInputRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedInputRecordsEdge
-
-  # The \`ReservedInputRecord\` that was updated by this mutation.
-  reservedInputRecord: ReservedInputRecord
 }
 
 # All input for the \`updateReservedPatchRecordById\` mutation.
-input UpdateReservedPatchByIdInput {
+input UpdateReservedPatchRecordByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -13038,8 +13038,8 @@ input UpdateReservedPatchByIdInput {
   reservedPatchRecordPatch: ReservedPatchRecordPatch!
 }
 
-# All input for the \`updateReservedPatch\` mutation.
-input UpdateReservedPatchInput {
+# All input for the \`updateReservedPatchRecord\` mutation.
+input UpdateReservedPatchRecordInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
   # payload verbatim. May be used to track mutations by the client.
   clientMutationId: String
@@ -13052,7 +13052,7 @@ input UpdateReservedPatchInput {
 }
 
 # The output of our update \`ReservedPatchRecord\` mutation.
-type UpdateReservedPatchPayload {
+type UpdateReservedPatchRecordPayload {
   # The exact same \`clientMutationId\` that was provided in the mutation input,
   # unchanged and unused. May be used by a client to track mutations.
   clientMutationId: String
@@ -13060,14 +13060,14 @@ type UpdateReservedPatchPayload {
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
 
+  # The \`ReservedPatchRecord\` that was updated by this mutation.
+  reservedPatchRecord: ReservedPatchRecord
+
   # An edge for the type. May be used by Relay 1.
-  reservedPatchEdge(
+  reservedPatchRecordEdge(
     # The method to use when ordering \`ReservedPatchRecord\`.
     orderBy: ReservedPatchRecordsOrderBy = PRIMARY_KEY_ASC
   ): ReservedPatchRecordsEdge
-
-  # The \`ReservedPatchRecord\` that was updated by this mutation.
-  reservedPatchRecord: ReservedPatchRecord
 }
 
 # The output of our update \`Reserved\` mutation.

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -2954,6 +2954,64 @@ type CreateForeignKeyPayload {
   query: Query
 }
 
+# All input for the create \`Input\` mutation.
+input CreateInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Input\` to be created by this mutation.
+  input: InputInput!
+}
+
+# The output of our create \`Input\` mutation.
+type CreateInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Input\` that was created by this mutation.
+  input: Input
+
+  # An edge for the type. May be used by Relay 1.
+  inputEdge(
+    # The method to use when ordering \`Input\`.
+    orderBy: InputsOrderBy = PRIMARY_KEY_ASC
+  ): InputsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`Patch\` mutation.
+input CreatePatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Patch\` to be created by this mutation.
+  patch: PatchInput!
+}
+
+# The output of our create \`Patch\` mutation.
+type CreatePatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Patch\` that was created by this mutation.
+  patch: Patch
+
+  # An edge for the type. May be used by Relay 1.
+  patchEdge(
+    # The method to use when ordering \`Patch\`.
+    orderBy: PatchesOrderBy = PRIMARY_KEY_ASC
+  ): PatchesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
 # All input for the create \`Person\` mutation.
 input CreatePersonInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -3465,6 +3523,82 @@ type DeleteDefaultValuePayload {
     orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
   ): DefaultValuesEdge
   deletedDefaultValueId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deleteInputById\` mutation.
+input DeleteInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteInput\` mutation.
+input DeleteInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Input\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Input\` mutation.
+type DeleteInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedInputId: ID
+
+  # The \`Input\` that was deleted by this mutation.
+  input: Input
+
+  # An edge for the type. May be used by Relay 1.
+  inputEdge(
+    # The method to use when ordering \`Input\`.
+    orderBy: InputsOrderBy = PRIMARY_KEY_ASC
+  ): InputsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePatchById\` mutation.
+input DeletePatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deletePatch\` mutation.
+input DeletePatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Patch\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Patch\` mutation.
+type DeletePatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedPatchId: ID
+
+  # The \`Patch\` that was deleted by this mutation.
+  patch: Patch
+
+  # An edge for the type. May be used by Relay 1.
+  patchEdge(
+    # The method to use when ordering \`Patch\`.
+    orderBy: PatchesOrderBy = PRIMARY_KEY_ASC
+  ): PatchesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
@@ -4006,6 +4140,63 @@ type GuidFnPayload {
   query: Query
 }
 
+# Should output as Input
+type Input implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Input\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input InputCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`Input\`
+input InputInput {
+  id: Int
+}
+
+# Represents an update to a \`Input\`. Fields that are set will be updated.
+input InputPatch {
+  id: Int
+}
+
+# A connection to a list of \`Input\` values.
+type InputsConnection {
+  # A list of edges which contains the \`Input\` and cursor to aid in pagination.
+  edges: [InputsEdge!]!
+
+  # A list of \`Input\` objects.
+  nodes: [Input]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Input\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Input\` edge in the connection.
+type InputsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Input\` at the end of the edge.
+  node: Input!
+}
+
+# Methods to use when ordering \`Input\`.
+enum InputsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 # An interval of time that has passed where the smallest distinct unit is a second.
 type Interval {
   # A quantity of days.
@@ -4342,6 +4533,18 @@ type Mutation {
     input: CreateForeignKeyInput!
   ): CreateForeignKeyPayload
 
+  # Creates a single \`Input\`.
+  createInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateInputInput!
+  ): CreateInputPayload
+
+  # Creates a single \`Patch\`.
+  createPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePatchInput!
+  ): CreatePatchPayload
+
   # Creates a single \`Person\`.
   createPerson(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -4431,6 +4634,30 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: DeleteDefaultValueByIdInput!
   ): DeleteDefaultValuePayload
+
+  # Deletes a single \`Input\` using its globally unique id.
+  deleteInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteInputInput!
+  ): DeleteInputPayload
+
+  # Deletes a single \`Input\` using a unique key.
+  deleteInputById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteInputByIdInput!
+  ): DeleteInputPayload
+
+  # Deletes a single \`Patch\` using its globally unique id.
+  deletePatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePatchInput!
+  ): DeletePatchPayload
+
+  # Deletes a single \`Patch\` using a unique key.
+  deletePatchById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePatchByIdInput!
+  ): DeletePatchPayload
 
   # Deletes a single \`Person\` using its globally unique id.
   deletePerson(
@@ -4649,6 +4876,30 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: UpdateDefaultValueByIdInput!
   ): UpdateDefaultValuePayload
+
+  # Updates a single \`Input\` using its globally unique id and a patch.
+  updateInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateInputInput!
+  ): UpdateInputPayload
+
+  # Updates a single \`Input\` using a unique key and a patch.
+  updateInputById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateInputByIdInput!
+  ): UpdateInputPayload
+
+  # Updates a single \`Patch\` using its globally unique id and a patch.
+  updatePatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePatchInput!
+  ): UpdatePatchPayload
+
+  # Updates a single \`Patch\` using a unique key and a patch.
+  updatePatchById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePatchByIdInput!
+  ): UpdatePatchPayload
 
   # Updates a single \`Person\` using its globally unique id and a patch.
   updatePerson(
@@ -4881,6 +5132,63 @@ type PageInfo {
 
   # When paginating backwards, the cursor to continue.
   startCursor: Cursor
+}
+
+# Should output as Patch
+type Patch implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Patch\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PatchCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# A connection to a list of \`Patch\` values.
+type PatchesConnection {
+  # A list of edges which contains the \`Patch\` and cursor to aid in pagination.
+  edges: [PatchesEdge!]!
+
+  # A list of \`Patch\` objects.
+  nodes: [Patch]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Patch\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Patch\` edge in the connection.
+type PatchesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Patch\` at the end of the edge.
+  node: Patch!
+}
+
+# Methods to use when ordering \`Patch\`.
+enum PatchesOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# An input for mutations affecting \`Patch\`
+input PatchInput {
+  id: Int
+}
+
+# Represents an update to a \`Patch\`. Fields that are set will be updated.
+input PatchPatch {
+  id: Int
 }
 
 # A connection to a list of \`Person\` values.
@@ -5401,6 +5709,31 @@ type Query implements Node {
     orderBy: [ForeignKeysOrderBy!] = [NATURAL]
   ): ForeignKeysConnection
 
+  # Reads and enables pagination through a set of \`Input\`.
+  allInputs(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: InputCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Input\`.
+    orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): InputsConnection
+
   # Reads and enables pagination through a set of \`NonUpdatableView\`.
   allNonUpdatableViews(
     # Read all values in the set after (below) this cursor.
@@ -5425,6 +5758,31 @@ type Query implements Node {
     # The method to use when ordering \`NonUpdatableView\`.
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
+
+  # Reads and enables pagination through a set of \`Patch\`.
+  allPatches(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PatchCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Patch\`.
+    orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PatchesConnection
 
   # Reads and enables pagination through a set of \`Person\`.
   allPeople(
@@ -5796,6 +6154,13 @@ type Query implements Node {
     nodeId: ID!
   ): DefaultValue
   defaultValueById(id: Int!): DefaultValue
+
+  # Reads a single \`Input\` using its globally unique \`ID\`.
+  input(
+    # The globally unique \`ID\` to be used in selecting a single \`Input\`.
+    nodeId: ID!
+  ): Input
+  inputById(id: Int!): Input
   intSetQuery(
     # Read all values in the set after (below) this cursor.
     after: Cursor
@@ -5833,6 +6198,13 @@ type Query implements Node {
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
   optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
   optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
+
+  # Reads a single \`Patch\` using its globally unique \`ID\`.
+  patch(
+    # The globally unique \`ID\` to be used in selecting a single \`Patch\`.
+    nodeId: ID!
+  ): Patch
+  patchById(id: Int!): Patch
 
   # Reads a single \`Person\` using its globally unique \`ID\`.
   person(
@@ -6969,6 +7341,92 @@ type UpdateDefaultValuePayload {
     # The method to use when ordering \`DefaultValue\`.
     orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
   ): DefaultValuesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updateInputById\` mutation.
+input UpdateInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Input\` being updated.
+  inputPatch: InputPatch!
+}
+
+# All input for the \`updateInput\` mutation.
+input UpdateInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`Input\` being updated.
+  inputPatch: InputPatch!
+
+  # The globally unique \`ID\` which will identify a single \`Input\` to be updated.
+  nodeId: ID!
+}
+
+# The output of our update \`Input\` mutation.
+type UpdateInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Input\` that was updated by this mutation.
+  input: Input
+
+  # An edge for the type. May be used by Relay 1.
+  inputEdge(
+    # The method to use when ordering \`Input\`.
+    orderBy: InputsOrderBy = PRIMARY_KEY_ASC
+  ): InputsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePatchById\` mutation.
+input UpdatePatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Patch\` being updated.
+  patchPatch: PatchPatch!
+}
+
+# All input for the \`updatePatch\` mutation.
+input UpdatePatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Patch\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Patch\` being updated.
+  patchPatch: PatchPatch!
+}
+
+# The output of our update \`Patch\` mutation.
+type UpdatePatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Patch\` that was updated by this mutation.
+  patch: Patch
+
+  # An edge for the type. May be used by Relay 1.
+  patchEdge(
+    # The method to use when ordering \`Patch\`.
+    orderBy: PatchesOrderBy = PRIMARY_KEY_ASC
+  ): PatchesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query
@@ -9753,6 +10211,64 @@ type CreateForeignKeyPayload {
   query: Query
 }
 
+# All input for the create \`Input\` mutation.
+input CreateInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Input\` to be created by this mutation.
+  input: InputInput!
+}
+
+# The output of our create \`Input\` mutation.
+type CreateInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Input\` that was created by this mutation.
+  input: Input
+
+  # An edge for the type. May be used by Relay 1.
+  inputEdge(
+    # The method to use when ordering \`Input\`.
+    orderBy: InputsOrderBy = PRIMARY_KEY_ASC
+  ): InputsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`Patch\` mutation.
+input CreatePatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Patch\` to be created by this mutation.
+  patch: PatchInput!
+}
+
+# The output of our create \`Patch\` mutation.
+type CreatePatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Patch\` that was created by this mutation.
+  patch: Patch
+
+  # An edge for the type. May be used by Relay 1.
+  patchEdge(
+    # The method to use when ordering \`Patch\`.
+    orderBy: PatchesOrderBy = PRIMARY_KEY_ASC
+  ): PatchesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
 # All input for the create \`Post\` mutation.
 input CreatePostInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -10095,6 +10611,82 @@ type DeleteDefaultValuePayload {
   query: Query
 }
 
+# All input for the \`deleteInputById\` mutation.
+input DeleteInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteInput\` mutation.
+input DeleteInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Input\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Input\` mutation.
+type DeleteInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedInputId: ID
+
+  # The \`Input\` that was deleted by this mutation.
+  input: Input
+
+  # An edge for the type. May be used by Relay 1.
+  inputEdge(
+    # The method to use when ordering \`Input\`.
+    orderBy: InputsOrderBy = PRIMARY_KEY_ASC
+  ): InputsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePatchById\` mutation.
+input DeletePatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deletePatch\` mutation.
+input DeletePatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Patch\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Patch\` mutation.
+type DeletePatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedPatchId: ID
+
+  # The \`Patch\` that was deleted by this mutation.
+  patch: Patch
+
+  # An edge for the type. May be used by Relay 1.
+  patchEdge(
+    # The method to use when ordering \`Patch\`.
+    orderBy: PatchesOrderBy = PRIMARY_KEY_ASC
+  ): PatchesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
 # All input for the \`deletePostById\` mutation.
 input DeletePostByIdInput {
   # An arbitrary string value with no semantic meaning. Will be included in the
@@ -10422,6 +11014,63 @@ enum ForeignKeysOrderBy {
   PERSON_ID_DESC
 }
 
+# Should output as Input
+type Input implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Input\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input InputCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`Input\`
+input InputInput {
+  id: Int
+}
+
+# Represents an update to a \`Input\`. Fields that are set will be updated.
+input InputPatch {
+  id: Int
+}
+
+# A connection to a list of \`Input\` values.
+type InputsConnection {
+  # A list of edges which contains the \`Input\` and cursor to aid in pagination.
+  edges: [InputsEdge!]!
+
+  # A list of \`Input\` objects.
+  nodes: [Input]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Input\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Input\` edge in the connection.
+type InputsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Input\` at the end of the edge.
+  node: Input!
+}
+
+# Methods to use when ordering \`Input\`.
+enum InputsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 # The root mutation type which contains root level fields which mutate data.
 type Mutation {
   # lol, add some stuff 1 mutation
@@ -10463,6 +11112,18 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: CreateForeignKeyInput!
   ): CreateForeignKeyPayload
+
+  # Creates a single \`Input\`.
+  createInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateInputInput!
+  ): CreateInputPayload
+
+  # Creates a single \`Patch\`.
+  createPatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePatchInput!
+  ): CreatePatchPayload
 
   # Creates a single \`Post\`.
   createPost(
@@ -10523,6 +11184,30 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: DeleteDefaultValueByIdInput!
   ): DeleteDefaultValuePayload
+
+  # Deletes a single \`Input\` using its globally unique id.
+  deleteInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteInputInput!
+  ): DeleteInputPayload
+
+  # Deletes a single \`Input\` using a unique key.
+  deleteInputById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteInputByIdInput!
+  ): DeleteInputPayload
+
+  # Deletes a single \`Patch\` using its globally unique id.
+  deletePatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePatchInput!
+  ): DeletePatchPayload
+
+  # Deletes a single \`Patch\` using a unique key.
+  deletePatchById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePatchByIdInput!
+  ): DeletePatchPayload
 
   # Deletes a single \`Post\` using its globally unique id.
   deletePost(
@@ -10639,6 +11324,30 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: UpdateDefaultValueByIdInput!
   ): UpdateDefaultValuePayload
+
+  # Updates a single \`Input\` using its globally unique id and a patch.
+  updateInput(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateInputInput!
+  ): UpdateInputPayload
+
+  # Updates a single \`Input\` using a unique key and a patch.
+  updateInputById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateInputByIdInput!
+  ): UpdateInputPayload
+
+  # Updates a single \`Patch\` using its globally unique id and a patch.
+  updatePatch(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePatchInput!
+  ): UpdatePatchPayload
+
+  # Updates a single \`Patch\` using a unique key and a patch.
+  updatePatchById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePatchByIdInput!
+  ): UpdatePatchPayload
 
   # Updates a single \`Post\` using its globally unique id and a patch.
   updatePost(
@@ -10808,6 +11517,63 @@ type PageInfo {
 
   # When paginating backwards, the cursor to continue.
   startCursor: Cursor
+}
+
+# Should output as Patch
+type Patch implements Node {
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Patch\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PatchCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# A connection to a list of \`Patch\` values.
+type PatchesConnection {
+  # A list of edges which contains the \`Patch\` and cursor to aid in pagination.
+  edges: [PatchesEdge!]!
+
+  # A list of \`Patch\` objects.
+  nodes: [Patch]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Patch\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Patch\` edge in the connection.
+type PatchesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Patch\` at the end of the edge.
+  node: Patch!
+}
+
+# Methods to use when ordering \`Patch\`.
+enum PatchesOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# An input for mutations affecting \`Patch\`
+input PatchInput {
+  id: Int
+}
+
+# Represents an update to a \`Patch\`. Fields that are set will be updated.
+input PatchPatch {
+  id: Int
 }
 
 type Post implements Node {
@@ -11016,6 +11782,31 @@ type Query implements Node {
     orderBy: [ForeignKeysOrderBy!] = [NATURAL]
   ): ForeignKeysConnection
 
+  # Reads and enables pagination through a set of \`Input\`.
+  allInputs(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: InputCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Input\`.
+    orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): InputsConnection
+
   # Reads and enables pagination through a set of \`NonUpdatableView\`.
   allNonUpdatableViews(
     # Read all values in the set after (below) this cursor.
@@ -11040,6 +11831,31 @@ type Query implements Node {
     # The method to use when ordering \`NonUpdatableView\`.
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
+
+  # Reads and enables pagination through a set of \`Patch\`.
+  allPatches(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PatchCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Patch\`.
+    orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PatchesConnection
 
   # Reads and enables pagination through a set of \`Post\`.
   allPosts(
@@ -11308,6 +12124,13 @@ type Query implements Node {
   ): DefaultValue
   defaultValueById(id: Int!): DefaultValue
 
+  # Reads a single \`Input\` using its globally unique \`ID\`.
+  input(
+    # The globally unique \`ID\` to be used in selecting a single \`Input\`.
+    nodeId: ID!
+  ): Input
+  inputById(id: Int!): Input
+
   # Fetches an object given its globally unique \`ID\`.
   node(
     # The globally unique \`ID\`.
@@ -11321,6 +12144,13 @@ type Query implements Node {
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
   optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
   optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
+
+  # Reads a single \`Patch\` using its globally unique \`ID\`.
+  patch(
+    # The globally unique \`ID\` to be used in selecting a single \`Patch\`.
+    nodeId: ID!
+  ): Patch
+  patchById(id: Int!): Patch
 
   # Reads a single \`Post\` using its globally unique \`ID\`.
   post(
@@ -11921,6 +12751,92 @@ type UpdateDefaultValuePayload {
     # The method to use when ordering \`DefaultValue\`.
     orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
   ): DefaultValuesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updateInputById\` mutation.
+input UpdateInputByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Input\` being updated.
+  inputPatch: InputPatch!
+}
+
+# All input for the \`updateInput\` mutation.
+input UpdateInputInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`Input\` being updated.
+  inputPatch: InputPatch!
+
+  # The globally unique \`ID\` which will identify a single \`Input\` to be updated.
+  nodeId: ID!
+}
+
+# The output of our update \`Input\` mutation.
+type UpdateInputPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Input\` that was updated by this mutation.
+  input: Input
+
+  # An edge for the type. May be used by Relay 1.
+  inputEdge(
+    # The method to use when ordering \`Input\`.
+    orderBy: InputsOrderBy = PRIMARY_KEY_ASC
+  ): InputsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePatchById\` mutation.
+input UpdatePatchByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Patch\` being updated.
+  patchPatch: PatchPatch!
+}
+
+# All input for the \`updatePatch\` mutation.
+input UpdatePatchInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Patch\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Patch\` being updated.
+  patchPatch: PatchPatch!
+}
+
+# The output of our update \`Patch\` mutation.
+type UpdatePatchPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Patch\` that was updated by this mutation.
+  patch: Patch
+
+  # An edge for the type. May be used by Relay 1.
+  patchEdge(
+    # The method to use when ordering \`Patch\`.
+    orderBy: PatchesOrderBy = PRIMARY_KEY_ASC
+  ): PatchesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
   query: Query

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -316,7 +316,7 @@ create table a.reserved_input (
 );
 comment on table a.reserved_input is '`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table';
 
-create table a.reserved_patchs (
+create table a."reservedPatchs" (
   id serial primary key
 );
-comment on table a.reserved_patchs is '`reserved_patchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table';
+comment on table a."reservedPatchs" is '`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table';

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -291,3 +291,15 @@ create function a.post_with_suffix(post a.post,suffix text) returns a.post as $$
   (post.id,post.headline || suffix,post.body,post.author_id,post.enums,post.comptypes)
   returning *; 
 $$ language sql volatile;
+
+create table a.reserved (
+  id serial primary key
+);
+create table a.reserved_input (
+  id serial primary key
+);
+comment on table a.reserved_input is '`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table';
+create table a.reserved_patchs (
+  id serial primary key
+);
+comment on table a.reserved_patchs is '`reserved_patchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table';

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -292,13 +292,25 @@ create function a.post_with_suffix(post a.post,suffix text) returns a.post as $$
   returning *; 
 $$ language sql volatile;
 
+create table a.inputs (
+  id serial primary key
+);
+comment on table a.inputs is 'Should output as Input';
+
+create table a.patchs (
+  id serial primary key
+);
+comment on table a.patchs is 'Should output as Patch';
+
 create table a.reserved (
   id serial primary key
 );
+
 create table a.reserved_input (
   id serial primary key
 );
 comment on table a.reserved_input is '`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table';
+
 create table a.reserved_patchs (
   id serial primary key
 );


### PR DESCRIPTION
🔥  Breaking change if you have any tables that have names that end with "input(s)" or "patch(s)".

Fixes https://github.com/postgraphql/postgraphql/issues/647

Automatically add 'Record' to tables that end in the reserved words 'Input' and 'Patch' to avoid them clashing with other tables that share the same prefix.

Even if they don't clash *right now* there's a risk that they will clash in future; e.g. if you create the table `foo_bar_input` then creating `FooBarInput` and `FooBarInputInput` and `FooBarInputPatch` is fine... But if you later add the table `foo_bar` then `FooBarInput` will clash. So renaming the tables up front means that whether or not you add that table later it'll still be fine without breaking existing functionality.

Tables named like `inputs` and `patchs` should not be affected because they wouldn't clash.

