### PR TITLE
fix(mutations): Fix null cursor on mutations, make orderBy an array too

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -79,7 +79,10 @@ export default (function PgConnectionArgOrderBy(
         inflection.orderByType(tableTypeName)
       );
 
-      addArgDataGenerator(function connectionOrderBy({ orderBy }) {
+      addArgDataGenerator(function connectionOrderBy({ orderBy: rawOrderBy }) {
+        const orderBy = rawOrderBy
+          ? Array.isArray(rawOrderBy) ? rawOrderBy : [rawOrderBy]
+          : null;
         return {
           pgCursorPrefix:
             orderBy && orderBy.some(item => item.alias)

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -62,7 +62,12 @@ export default (function PgMutationPayloadEdgePlugin(
         [fieldName]: fieldWithHooks(
           fieldName,
           ({ addArgDataGenerator }) => {
-            addArgDataGenerator(function connectionOrderBy({ orderBy }) {
+            addArgDataGenerator(function connectionOrderBy({
+              orderBy: rawOrderBy,
+            }) {
+              const orderBy = rawOrderBy
+                ? Array.isArray(rawOrderBy) ? rawOrderBy : [rawOrderBy]
+                : null;
               return {
                 pgQuery: queryBuilder => {
                   if (orderBy != null) {
@@ -127,7 +132,10 @@ export default (function PgMutationPayloadEdgePlugin(
                   defaultValue: defaultValueEnum && defaultValueEnum.value,
                 },
               },
-              resolve(data, { orderBy }) {
+              resolve(data, { orderBy: rawOrderBy }) {
+                const orderBy = rawOrderBy
+                  ? Array.isArray(rawOrderBy) ? rawOrderBy : [rawOrderBy]
+                  : null;
                 const order =
                   orderBy && orderBy.some(item => item.alias)
                     ? orderBy.filter(item => item.alias)

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -87,7 +87,7 @@ export default (function PgMutationPayloadEdgePlugin(
                       if (alias == null) return;
                       aliases.push(alias);
                     });
-                    if (!unique) {
+                    if (!unique && primaryKeys) {
                       // Add PKs
                       primaryKeys.forEach(key => {
                         expressions.push(
@@ -134,7 +134,13 @@ export default (function PgMutationPayloadEdgePlugin(
                     : null;
 
                 if (!order) {
-                  return data.data;
+                  if (data.data.__identifiers) {
+                    return Object.assign({}, data.data, {
+                      __cursor: ["primary_key_asc", data.data.__identifiers],
+                    });
+                  } else {
+                    return data.data;
+                  }
                 }
                 return Object.assign({}, data.data, {
                   __cursor:

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -111,7 +111,9 @@ export type Build = {|
     scope: {},
     returnNullOnInvalid?: boolean
   ): ?T,
-  fieldDataGeneratorsByType: Map<*, *>,
+  fieldDataGeneratorsByType: Map<*, *>, // @deprecated - use fieldDataGeneratorsByFieldNameByType instead
+  fieldDataGeneratorsByFieldNameByType: Map<*, *>,
+  fieldArgDataGeneratorsByFieldNameByType: Map<*, *>,
 |};
 
 export type BuildExtensionQuery = {|

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -257,7 +257,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
               const argDataGenerators =
                 argDataGeneratorsForSelfByFieldName[fieldName];
               for (const gen of argDataGenerators) {
-                const local = ensureArray(gen(args));
+                const local = ensureArray(gen(args, ReturnType, ...rest));
                 if (local) {
                   results.push(...local);
                 }

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -240,6 +240,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
         };
         const recurseDataGeneratorsForField = fieldName => {
           const fn = (parsedResolveInfoFragment, ReturnType, ...rest) => {
+            const { args } = parsedResolveInfoFragment;
             const { fields } = this.simplifyParsedResolveInfoFragmentWithType(
               parsedResolveInfoFragment,
               ReturnType
@@ -249,9 +250,19 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
             const fieldDataGeneratorsByFieldName = fieldDataGeneratorsByFieldNameByType.get(
               StrippedType
             );
-            const fieldArgDataGeneratorsByFieldName = fieldArgDataGeneratorsByFieldNameByType.get(
-              StrippedType
+            const argDataGeneratorsForSelfByFieldName = fieldArgDataGeneratorsByFieldNameByType.get(
+              Self
             );
+            if (argDataGeneratorsForSelfByFieldName) {
+              const argDataGenerators =
+                argDataGeneratorsForSelfByFieldName[fieldName];
+              for (const gen of argDataGenerators) {
+                const local = ensureArray(gen(args));
+                if (local) {
+                  results.push(...local);
+                }
+              }
+            }
             if (
               fieldDataGeneratorsByFieldName &&
               isCompositeType(StrippedType) &&

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -157,7 +157,8 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
   // GraphQLObjectType and whose values are an object (whose keys are
   // arbitrary namespaced keys and whose values are arrays of
   // information of this kind)
-  const fieldDataGeneratorsByType = new Map();
+  const fieldDataGeneratorsByFieldNameByType = new Map();
+  const fieldArgDataGeneratorsByFieldNameByType = new Map();
 
   return {
     graphileBuildVersion: version,
@@ -208,6 +209,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
         );
       }
       const fieldDataGeneratorsByFieldName = {};
+      const fieldArgDataGeneratorsByFieldName = {};
       let newSpec = spec;
       if (
         knownTypes.indexOf(Type) === -1 &&
@@ -244,11 +246,14 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
             );
             const results = [];
             const StrippedType: GraphQLNamedType = getNamedType(ReturnType);
-            const fieldDataGenerators = fieldDataGeneratorsByType.get(
+            const fieldDataGeneratorsByFieldName = fieldDataGeneratorsByFieldNameByType.get(
+              StrippedType
+            );
+            const fieldArgDataGeneratorsByFieldName = fieldArgDataGeneratorsByFieldNameByType.get(
               StrippedType
             );
             if (
-              fieldDataGenerators &&
+              fieldDataGeneratorsByFieldName &&
               isCompositeType(StrippedType) &&
               !isAbstractType(StrippedType)
             ) {
@@ -256,7 +261,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
               for (const alias of Object.keys(fields)) {
                 const field = fields[alias];
                 // Run generators with `field` as the `parsedResolveInfoFragment`, pushing results to `results`
-                const gens = fieldDataGenerators[field.name];
+                const gens = fieldDataGeneratorsByFieldName[field.name];
                 if (gens) {
                   for (const gen of gens) {
                     const local = ensureArray(
@@ -336,7 +341,11 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                       "information to give, please just pass `{}`."
                   );
                 }
+
                 let argDataGenerators = [];
+                fieldArgDataGeneratorsByFieldName[
+                  fieldName
+                ] = argDataGenerators;
 
                 let newSpec = spec;
                 let context = Object.assign({}, commonContext, {
@@ -383,18 +392,18 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                         "It's too early to call this! Call from within resolve"
                       );
                     }
-                    const fieldDataGenerators = fieldDataGeneratorsByType.get(
+                    const fieldDataGeneratorsByFieldName = fieldDataGeneratorsByFieldNameByType.get(
                       Type
                     );
                     if (
-                      fieldDataGenerators &&
+                      fieldDataGeneratorsByFieldName &&
                       isCompositeType(Type) &&
                       !isAbstractType(Type)
                     ) {
                       const typeFields = Type.getFields();
                       for (const alias of Object.keys(fields)) {
                         const field = fields[alias];
-                        const gens = fieldDataGenerators[field.name];
+                        const gens = fieldDataGeneratorsByFieldName[field.name];
                         if (gens) {
                           const FieldReturnType = typeFields[field.name].type;
                           for (const gen of gens) {
@@ -615,9 +624,18 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
         }
         allTypes[finalSpec.name] = Self;
       }
-      fieldDataGeneratorsByType.set(Self, fieldDataGeneratorsByFieldName);
+      fieldDataGeneratorsByFieldNameByType.set(
+        Self,
+        fieldDataGeneratorsByFieldName
+      );
+      fieldArgDataGeneratorsByFieldNameByType.set(
+        Self,
+        fieldArgDataGeneratorsByFieldName
+      );
       return Self;
     },
-    fieldDataGeneratorsByType,
+    fieldDataGeneratorsByType: fieldDataGeneratorsByFieldNameByType, // @deprecated
+    fieldDataGeneratorsByFieldNameByType,
+    fieldArgDataGeneratorsByFieldNameByType,
   };
 }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
@@ -66,7 +66,7 @@ mutation {
   }) { ...updateCompoundKeyPayload }
   j: updatePersonByEmail(input: {
     email: "graphile-build.issue.27.exists@example.com"
-    personPatch(orderBy: [EMAIL_DESC]): {
+    personPatch: {
       email: "somethingelse@example.com"
     }
   }) { ...updatePersonPayload }

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
@@ -93,6 +93,13 @@ fragment updatePersonPayload on UpdatePersonPayload {
     about
     issue27UserExists: exists(email: "graphile-build.issue.27.exists@example.com")
   }
+  personEdge {
+    cursor
+    node {
+      nodeId
+      id
+    }
+  }
   query { nodeId }
 }
 

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/mutation-update.graphql
@@ -66,7 +66,7 @@ mutation {
   }) { ...updateCompoundKeyPayload }
   j: updatePersonByEmail(input: {
     email: "graphile-build.issue.27.exists@example.com"
-    personPatch: {
+    personPatch(orderBy: [EMAIL_DESC]): {
       email: "somethingelse@example.com"
     }
   }) { ...updatePersonPayload }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -558,6 +558,13 @@ Object {
         "name": "John Smith Sr.",
         "nodeId": "WyJwZW9wbGUiLDFd",
       },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 1,
+          "nodeId": "WyJwZW9wbGUiLDFd",
+        },
+      },
       "query": Object {
         "nodeId": "query",
       },
@@ -571,6 +578,13 @@ Object {
         "issue27UserExists": true,
         "name": "Sarah Smith",
         "nodeId": "WyJwZW9wbGUiLDJd",
+      },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 2,
+          "nodeId": "WyJwZW9wbGUiLDJd",
+        },
       },
       "query": Object {
         "nodeId": "query",
@@ -586,6 +600,13 @@ Object {
         "name": "Sarah Smith",
         "nodeId": "WyJwZW9wbGUiLDJd",
       },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 2,
+          "nodeId": "WyJwZW9wbGUiLDJd",
+        },
+      },
       "query": Object {
         "nodeId": "query",
       },
@@ -600,6 +621,13 @@ Object {
         "name": "Best Pal",
         "nodeId": "WyJwZW9wbGUiLDNd",
       },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 3,
+          "nodeId": "WyJwZW9wbGUiLDNd",
+        },
+      },
       "query": Object {
         "nodeId": "query",
       },
@@ -613,6 +641,13 @@ Object {
         "issue27UserExists": true,
         "name": "Kathryn Ramirez",
         "nodeId": "WyJwZW9wbGUiLDRd",
+      },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 4,
+          "nodeId": "WyJwZW9wbGUiLDRd",
+        },
       },
       "query": Object {
         "nodeId": "query",
@@ -688,6 +723,13 @@ Object {
         "name": "Sarah Smith",
         "nodeId": "WyJwZW9wbGUiLDJd",
       },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 2,
+          "nodeId": "WyJwZW9wbGUiLDJd",
+        },
+      },
       "query": Object {
         "nodeId": "query",
       },
@@ -701,6 +743,13 @@ Object {
         "issue27UserExists": false,
         "name": "Twenty Seventwo",
         "nodeId": "WyJwZW9wbGUiLDZd",
+      },
+      "personEdge": Object {
+        "cursor": NOTNULL,
+        "node": Object {
+          "id": 6,
+          "nodeId": "WyJwZW9wbGUiLDZd",
+        },
       },
       "query": Object {
         "nodeId": "query",
@@ -854,7 +903,7 @@ Object {
         "nodeId": "WyJwb3N0cyIsNV0=",
       },
       "postEdge": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
           "id": 5,

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -114,21 +114,21 @@ Object {
     },
     "b": Object {
       "a": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "b": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "c": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
@@ -136,28 +136,28 @@ Object {
       },
       "clientMutationId": null,
       "d": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "e": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "f": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "g": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
@@ -177,21 +177,21 @@ Object {
     },
     "c": Object {
       "a": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "b": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "c": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
@@ -199,28 +199,28 @@ Object {
       },
       "clientMutationId": "hello",
       "d": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "e": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "f": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "g": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
@@ -284,21 +284,21 @@ Object {
     },
     "g": Object {
       "a": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "b": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "c": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
@@ -306,28 +306,28 @@ Object {
       },
       "clientMutationId": null,
       "d": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "e": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "f": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "g": Object {
-        "cursor": null,
+        "cursor": NOTNULL,
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -114,21 +114,21 @@ Object {
     },
     "b": Object {
       "a": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs5MDAwXV0=",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "b": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9kZXNjIixbOTAwMF1d",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "c": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJpZF9hc2MiLFs5MDAwLDkwMDBdXQ==",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
@@ -136,28 +136,28 @@ Object {
       },
       "clientMutationId": null,
       "d": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJpZF9kZXNjIixbOTAwMCw5MDAwXV0=",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "e": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9hc2MiLFsiam9obm55LmJveS5zbWl0aEBlbWFpbC5jb20iLDkwMDBdXQ=="<Paste>,
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "f": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9kZXNjIixbImpvaG5ueS5ib3kuc21pdGhAZW1haWwuY29tIiw5MDAwXV0=",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
         },
       },
       "g": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs5MDAwXV0=",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
@@ -177,21 +177,21 @@ Object {
     },
     "c": Object {
       "a": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyMF1d",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "b": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9kZXNjIixbMjBdXQ==",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "c": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJpZF9hc2MiLFsyMCwyMF1d",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
@@ -199,28 +199,28 @@ Object {
       },
       "clientMutationId": "hello",
       "d": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJpZF9kZXNjIixbMjAsMjBdXQ==",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "e": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9hc2MiLFsiYmVzdC5wYWxAZW1haWwuY29tIiwyMF1d",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "f": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9kZXNjIixbImJlc3QucGFsQGVtYWlsLmNvbSIsMjBdXQ==",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
         },
       },
       "g": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyMF1d",
         "node": Object {
           "name": "Best Pal",
           "nodeId": "WyJwZW9wbGUiLDIwXQ==",
@@ -284,21 +284,21 @@ Object {
     },
     "g": Object {
       "a": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxOTk4XV0=",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "b": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9kZXNjIixbMTk5OF1d",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "c": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJpZF9hc2MiLFsxOTk4LDE5OThdXQ==",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
@@ -306,28 +306,28 @@ Object {
       },
       "clientMutationId": null,
       "d": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJpZF9kZXNjIixbMTk5OCwxOTk4XV0=",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "e": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9hc2MiLFsiYnVkZC5kZWV5LnRoZS5zZWNvbmRAZW1haWwuY29tIiwxOTk4XV0=",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "f": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9kZXNjIixbImJ1ZGQuZGVleS50aGUuc2Vjb25kQGVtYWlsLmNvbSIsMTk5OF1d",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",
         },
       },
       "g": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxOTk4XV0=",
         "node": Object {
           "name": "Budd Deey",
           "nodeId": "WyJwZW9wbGUiLDE5OThd",

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -143,7 +143,7 @@ Object {
         },
       },
       "e": Object {
-        "cursor": "WyJlbWFpbF9hc2MiLFsiam9obm55LmJveS5zbWl0aEBlbWFpbC5jb20iLDkwMDBdXQ=="<Paste>,
+        "cursor": "WyJlbWFpbF9hc2MiLFsiam9obm55LmJveS5zbWl0aEBlbWFpbC5jb20iLDkwMDBdXQ==",
         "node": Object {
           "name": "John Smith Jr.",
           "nodeId": "WyJwZW9wbGUiLDkwMDBd",
@@ -745,7 +745,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDZd",
       },
       "personEdge": Object {
-        "cursor": "WyJlbWFpbF9kZXNjIixbImdyYXBoaWxlLWJ1aWxkLmlzc3VlLjI3LmV4aXN0c0BleGFtcGxlLmNvbSIsNl1d",
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
         "node": Object {
           "id": 6,
           "nodeId": "WyJwZW9wbGUiLDZd",
@@ -903,7 +903,7 @@ Object {
         "nodeId": "WyJwb3N0cyIsNV0=",
       },
       "postEdge": Object {
-        "cursor": null,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
         "node": Object {
           "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
           "id": 5,

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -559,7 +559,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDFd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
         "node": Object {
           "id": 1,
           "nodeId": "WyJwZW9wbGUiLDFd",
@@ -580,7 +580,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDJd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
         "node": Object {
           "id": 2,
           "nodeId": "WyJwZW9wbGUiLDJd",
@@ -601,7 +601,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDJd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
         "node": Object {
           "id": 2,
           "nodeId": "WyJwZW9wbGUiLDJd",
@@ -622,7 +622,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDNd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
         "node": Object {
           "id": 3,
           "nodeId": "WyJwZW9wbGUiLDNd",
@@ -643,7 +643,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDRd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
         "node": Object {
           "id": 4,
           "nodeId": "WyJwZW9wbGUiLDRd",
@@ -724,7 +724,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDJd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
         "node": Object {
           "id": 2,
           "nodeId": "WyJwZW9wbGUiLDJd",
@@ -745,7 +745,7 @@ Object {
         "nodeId": "WyJwZW9wbGUiLDZd",
       },
       "personEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": "WyJlbWFpbF9kZXNjIixbImdyYXBoaWxlLWJ1aWxkLmlzc3VlLjI3LmV4aXN0c0BleGFtcGxlLmNvbSIsNl1d",
         "node": Object {
           "id": 6,
           "nodeId": "WyJwZW9wbGUiLDZd",
@@ -903,7 +903,7 @@ Object {
         "nodeId": "WyJwb3N0cyIsNV0=",
       },
       "postEdge": Object {
-        "cursor": NOTNULL,
+        "cursor": null,
         "node": Object {
           "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
           "id": 5,

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -160,7 +160,7 @@ type CreateCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
@@ -195,7 +195,7 @@ type CreateEdgeCasePayload {
   # An edge for the type. May be used by Relay 1.
   edgeCaseEdge(
     # The method to use when ordering \`EdgeCase\`.
-    orderBy: EdgeCasesOrderBy = NATURAL
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -224,7 +224,7 @@ type CreatePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -269,7 +269,7 @@ type DeleteCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
   deletedCompoundKeyId: ID
 
@@ -322,7 +322,7 @@ type DeletePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -1107,7 +1107,7 @@ type TableSetMutationPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -1177,7 +1177,7 @@ type UpdateCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
@@ -1237,7 +1237,7 @@ type UpdatePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -1477,7 +1477,7 @@ type CreateTypePayload {
   # An edge for the type. May be used by Relay 1.
   typeEdge(
     # The method to use when ordering \`Type\`.
-    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): TypesEdge
 }
 
@@ -1506,7 +1506,7 @@ type CreateUpdatableViewPayload {
   # An edge for the type. May be used by Relay 1.
   updatableViewEdge(
     # The method to use when ordering \`UpdatableView\`.
-    orderBy: UpdatableViewsOrderBy = NATURAL
+    orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
   ): UpdatableViewsEdge
 }
 
@@ -1590,7 +1590,7 @@ type DeleteTypePayload {
   # An edge for the type. May be used by Relay 1.
   typeEdge(
     # The method to use when ordering \`Type\`.
-    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): TypesEdge
 }
 
@@ -2372,7 +2372,7 @@ type UpdateTypePayload {
   # An edge for the type. May be used by Relay 1.
   typeEdge(
     # The method to use when ordering \`Type\`.
-    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): TypesEdge
 }
 
@@ -2848,7 +2848,7 @@ type CreateCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
@@ -2883,7 +2883,7 @@ type CreateDefaultValuePayload {
   # An edge for the type. May be used by Relay 1.
   defaultValueEdge(
     # The method to use when ordering \`DefaultValue\`.
-    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DefaultValuesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -2912,7 +2912,7 @@ type CreateEdgeCasePayload {
   # An edge for the type. May be used by Relay 1.
   edgeCaseEdge(
     # The method to use when ordering \`EdgeCase\`.
-    orderBy: EdgeCasesOrderBy = NATURAL
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -2944,7 +2944,7 @@ type CreateForeignKeyPayload {
   # An edge for the type. May be used by Relay 1.
   foreignKeyEdge(
     # The method to use when ordering \`ForeignKey\`.
-    orderBy: ForeignKeysOrderBy = NATURAL
+    orderBy: [ForeignKeysOrderBy!] = [NATURAL]
   ): ForeignKeysEdge
 
   # Reads a single \`Person\` that is related to this \`ForeignKey\`.
@@ -2976,7 +2976,7 @@ type CreatePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -3008,7 +3008,7 @@ type CreatePostPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -3040,7 +3040,7 @@ type CreateSimilarTable1Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable1Edge(
     # The method to use when ordering \`SimilarTable1\`.
-    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable1SEdge
 }
 
@@ -3069,7 +3069,7 @@ type CreateSimilarTable2Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable2Edge(
     # The method to use when ordering \`SimilarTable2\`.
-    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable2SEdge
 }
 
@@ -3098,7 +3098,7 @@ type CreateTestviewPayload {
   # An edge for the type. May be used by Relay 1.
   testviewEdge(
     # The method to use when ordering \`Testview\`.
-    orderBy: TestviewsOrderBy = NATURAL
+    orderBy: [TestviewsOrderBy!] = [NATURAL]
   ): TestviewsEdge
 }
 
@@ -3127,7 +3127,7 @@ type CreateTypePayload {
   # An edge for the type. May be used by Relay 1.
   typeEdge(
     # The method to use when ordering \`Type\`.
-    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): TypesEdge
 }
 
@@ -3156,7 +3156,7 @@ type CreateUpdatableViewPayload {
   # An edge for the type. May be used by Relay 1.
   updatableViewEdge(
     # The method to use when ordering \`UpdatableView\`.
-    orderBy: UpdatableViewsOrderBy = NATURAL
+    orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
   ): UpdatableViewsEdge
 }
 
@@ -3185,7 +3185,7 @@ type CreateViewTablePayload {
   # An edge for the type. May be used by Relay 1.
   viewTableEdge(
     # The method to use when ordering \`ViewTable\`.
-    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesEdge
 }
 
@@ -3331,7 +3331,7 @@ type DeleteCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
   deletedCompoundKeyId: ID
 
@@ -3375,7 +3375,7 @@ type DeleteDefaultValuePayload {
   # An edge for the type. May be used by Relay 1.
   defaultValueEdge(
     # The method to use when ordering \`DefaultValue\`.
-    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DefaultValuesEdge
   deletedDefaultValueId: ID
 
@@ -3422,7 +3422,7 @@ type DeletePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -3463,7 +3463,7 @@ type DeletePostPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -3504,7 +3504,7 @@ type DeleteSimilarTable1Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable1Edge(
     # The method to use when ordering \`SimilarTable1\`.
-    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable1SEdge
 }
 
@@ -3542,7 +3542,7 @@ type DeleteSimilarTable2Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable2Edge(
     # The method to use when ordering \`SimilarTable2\`.
-    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable2SEdge
 }
 
@@ -3580,7 +3580,7 @@ type DeleteTypePayload {
   # An edge for the type. May be used by Relay 1.
   typeEdge(
     # The method to use when ordering \`Type\`.
-    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): TypesEdge
 }
 
@@ -3618,7 +3618,7 @@ type DeleteViewTablePayload {
   # An edge for the type. May be used by Relay 1.
   viewTableEdge(
     # The method to use when ordering \`ViewTable\`.
-    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesEdge
 }
 
@@ -4906,7 +4906,7 @@ type PostManyPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
   posts: [Post]
 
@@ -4989,7 +4989,7 @@ type PostWithSuffixPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -5867,7 +5867,7 @@ type TableMutationPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -5891,7 +5891,7 @@ type TableSetMutationPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -6392,7 +6392,7 @@ type UpdateCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
@@ -6441,7 +6441,7 @@ type UpdateDefaultValuePayload {
   # An edge for the type. May be used by Relay 1.
   defaultValueEdge(
     # The method to use when ordering \`DefaultValue\`.
-    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DefaultValuesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -6495,7 +6495,7 @@ type UpdatePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -6541,7 +6541,7 @@ type UpdatePostPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -6587,7 +6587,7 @@ type UpdateSimilarTable1Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable1Edge(
     # The method to use when ordering \`SimilarTable1\`.
-    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable1SEdge
 }
 
@@ -6630,7 +6630,7 @@ type UpdateSimilarTable2Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable2Edge(
     # The method to use when ordering \`SimilarTable2\`.
-    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable2SEdge
 }
 
@@ -6673,7 +6673,7 @@ type UpdateTypePayload {
   # An edge for the type. May be used by Relay 1.
   typeEdge(
     # The method to use when ordering \`Type\`.
-    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): TypesEdge
 }
 
@@ -6716,7 +6716,7 @@ type UpdateViewTablePayload {
   # An edge for the type. May be used by Relay 1.
   viewTableEdge(
     # The method to use when ordering \`ViewTable\`.
-    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesEdge
 }
 
@@ -7606,7 +7606,7 @@ type TableSetMutationPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -7813,7 +7813,7 @@ type CreateCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
@@ -7848,7 +7848,7 @@ type CreateEdgeCasePayload {
   # An edge for the type. May be used by Relay 1.
   edgeCaseEdge(
     # The method to use when ordering \`EdgeCase\`.
-    orderBy: EdgeCasesOrderBy = NATURAL
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -7877,7 +7877,7 @@ type CreatePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -7922,7 +7922,7 @@ type DeleteCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
   deletedCompoundKeyId: ID
 
@@ -7975,7 +7975,7 @@ type DeletePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -8766,7 +8766,7 @@ type TableSetMutationPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -8836,7 +8836,7 @@ type UpdateCompoundKeyPayload {
   # An edge for the type. May be used by Relay 1.
   compoundKeyEdge(
     # The method to use when ordering \`CompoundKey\`.
-    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysEdge
 
   # Reads a single \`Person\` that is related to this \`CompoundKey\`.
@@ -8896,7 +8896,7 @@ type UpdatePersonPayload {
   # An edge for the type. May be used by Relay 1.
   personEdge(
     # The method to use when ordering \`Person\`.
-    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -9067,7 +9067,7 @@ type CreateDefaultValuePayload {
   # An edge for the type. May be used by Relay 1.
   defaultValueEdge(
     # The method to use when ordering \`DefaultValue\`.
-    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DefaultValuesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -9096,7 +9096,7 @@ type CreateForeignKeyPayload {
   # An edge for the type. May be used by Relay 1.
   foreignKeyEdge(
     # The method to use when ordering \`ForeignKey\`.
-    orderBy: ForeignKeysOrderBy = NATURAL
+    orderBy: [ForeignKeysOrderBy!] = [NATURAL]
   ): ForeignKeysEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -9125,7 +9125,7 @@ type CreatePostPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -9157,7 +9157,7 @@ type CreateSimilarTable1Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable1Edge(
     # The method to use when ordering \`SimilarTable1\`.
-    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable1SEdge
 }
 
@@ -9186,7 +9186,7 @@ type CreateSimilarTable2Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable2Edge(
     # The method to use when ordering \`SimilarTable2\`.
-    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable2SEdge
 }
 
@@ -9215,7 +9215,7 @@ type CreateTestviewPayload {
   # An edge for the type. May be used by Relay 1.
   testviewEdge(
     # The method to use when ordering \`Testview\`.
-    orderBy: TestviewsOrderBy = NATURAL
+    orderBy: [TestviewsOrderBy!] = [NATURAL]
   ): TestviewsEdge
 }
 
@@ -9244,7 +9244,7 @@ type CreateViewTablePayload {
   # An edge for the type. May be used by Relay 1.
   viewTableEdge(
     # The method to use when ordering \`ViewTable\`.
-    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesEdge
 }
 
@@ -9350,7 +9350,7 @@ type DeleteDefaultValuePayload {
   # An edge for the type. May be used by Relay 1.
   defaultValueEdge(
     # The method to use when ordering \`DefaultValue\`.
-    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DefaultValuesEdge
   deletedDefaultValueId: ID
 
@@ -9389,7 +9389,7 @@ type DeletePostPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -9430,7 +9430,7 @@ type DeleteSimilarTable1Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable1Edge(
     # The method to use when ordering \`SimilarTable1\`.
-    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable1SEdge
 }
 
@@ -9468,7 +9468,7 @@ type DeleteSimilarTable2Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable2Edge(
     # The method to use when ordering \`SimilarTable2\`.
-    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable2SEdge
 }
 
@@ -9506,7 +9506,7 @@ type DeleteViewTablePayload {
   # An edge for the type. May be used by Relay 1.
   viewTableEdge(
     # The method to use when ordering \`ViewTable\`.
-    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesEdge
 }
 
@@ -9927,7 +9927,7 @@ type PostManyPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
   posts: [Post]
 
@@ -10004,7 +10004,7 @@ type PostWithSuffixPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -10743,7 +10743,7 @@ type UpdateDefaultValuePayload {
   # An edge for the type. May be used by Relay 1.
   defaultValueEdge(
     # The method to use when ordering \`DefaultValue\`.
-    orderBy: DefaultValuesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DefaultValuesEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -10786,7 +10786,7 @@ type UpdatePostPayload {
   # An edge for the type. May be used by Relay 1.
   postEdge(
     # The method to use when ordering \`Post\`.
-    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsEdge
 
   # Our root query field type. Allows us to run any query from our mutation payload.
@@ -10832,7 +10832,7 @@ type UpdateSimilarTable1Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable1Edge(
     # The method to use when ordering \`SimilarTable1\`.
-    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable1SEdge
 }
 
@@ -10875,7 +10875,7 @@ type UpdateSimilarTable2Payload {
   # An edge for the type. May be used by Relay 1.
   similarTable2Edge(
     # The method to use when ordering \`SimilarTable2\`.
-    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
   ): SimilarTable2SEdge
 }
 
@@ -10918,7 +10918,7 @@ type UpdateViewTablePayload {
   # An edge for the type. May be used by Relay 1.
   viewTableEdge(
     # The method to use when ordering \`ViewTable\`.
-    orderBy: ViewTablesOrderBy = PRIMARY_KEY_ASC
+    orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesEdge
 }
 


### PR DESCRIPTION
Fixes https://github.com/postgraphql/postgraphql/issues/664

🔥 BREAKING CHANGE: mutation payloads now support array `orderBy` to match collections. This may cause problems for people using Relay