### PR TITLE
fix(sql): reduce redundancy in select statements

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -523,10 +523,15 @@ class QueryBuilder {
         getContext()
       );
     } else if (type === "select") {
-      this.compiledData[type] = this.data[type].map(([a, b]) => [
-        callIfNecessary(a, getContext()),
-        b,
-      ]);
+      // Assume that duplicate fields must be identical, don't output the same key multiple times
+      const seenFields = [];
+      this.compiledData[type] = this.data[type].reduce((memo, [a, b]) => {
+        if (seenFields.indexOf(b) < 0) {
+          seenFields.push(b);
+          memo.push([callIfNecessary(a, getContext()), b]);
+        }
+        return memo;
+      }, []);
     } else if (type === "orderBy") {
       this.compiledData[type] = this.data[type].map(([a, b]) => [
         callIfNecessary(a, getContext()),


### PR DESCRIPTION
Before:

`select to_json(json_build_array('primary_key_asc'::text, json_build_array(__local_0__."id"))) as "__order_primary_key_asc", to_json(json_build_array(__local_0__."id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_array('primary_key_desc'::text, json_build_array(__local_0__."id"))) as "__order_prima
ry_key_desc", to_json(json_build_array(__local_0__."id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_array('id_asc'::text, json_build_array(__local_0__."id", __local_0__."id"))) as "__order_id_asc", to_json(json_build_array(__local_0__."id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_arra
y('id_desc'::text, json_build_array(__local_0__."id", __local_0__."id"))) as "__order_id_desc", to_json(json_build_array(__local_0__."id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_array('email_asc'::text, json_build_array(__local_0__."email", __local_0__."id"))) as "__order_email_asc", to_json(json_build_array(__local_0__.
"id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_array('email_desc'::text, json_build_array(__local_0__."email", __local_0__."id"))) as "__order_email_desc", to_json(json_build_array(__local_0__."id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_array(__local_0__."id")) as "__identifiers",
 to_json((__local_0__."name")) as "name"`

(Note `__identifiers` is defined multiple times)

After:

`select to_json(json_build_array('primary_key_asc'::text, json_build_array(__local_0__."id"))) as "__order_primary_key_asc", to_json(json_build_array(__local_0__."id")) as "__identifiers", to_json((__local_0__."name")) as "name", to_json(json_build_array('primary_key_desc'::text, json_build_array(__local_0__."id"))) as "__order_prima
ry_key_desc", to_json(json_build_array('id_asc'::text, json_build_array(__local_0__."id", __local_0__."id"))) as "__order_id_asc", to_json(json_build_array('id_desc'::text, json_build_array(__local_0__."id", __local_0__."id"))) as "__order_id_desc", to_json(json_build_array('email_asc'::text, json_build_array(__local_0__."email", __local_0__."id"))) as "__order_
email_asc", to_json(json_build_array('email_desc'::text, json_build_array(__local_0__."email", __local_0__."id"))) as "__order_email_desc"`

(Note `__identifiers` is defined only once)