### PR TITLE
feat(errors): Check inflectors give non-empty string

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -479,9 +479,9 @@ export default (function PgTypesPlugin(
         return reallyEnforceGqlTypeByPgType(type);
       } catch (e) {
         const error = new Error(
-          `Error occurred when processing type '${type.namespaceName}.${
-            type.name
-          }' (type=${type.type}):\n${indent(e.message)}`
+          `Error occurred when processing database type '${
+            type.namespaceName
+          }.${type.name}' (type=${type.type}):\n${indent(e.message)}`
         );
         // $FlowFixMe
         error.originalError = e;


### PR DESCRIPTION
This PR wraps all inflectors with a function that asserts that the result of the inflector is a non-empty string. This should help track down issues like #169 faster by throwing the error at inflection time whilst the schema is being built rather than during the validation phase once the schema has already been built.

Fixes #169 