### PR TITLE
feat: one-to-one relationships

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -284,7 +284,8 @@ export default (function PgBackwardRelationPlugin(
                     return addStartEndCursor(data[alias]);
                   },
                   deprecationReason: isDeprecated
-                    ? `Please use ${singleRelationFieldName} instead`
+                    ? // $FlowFixMe
+                      `Please use ${singleRelationFieldName} instead`
                     : undefined,
                 };
               },

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -7,10 +7,19 @@ import type { Plugin } from "graphile-build";
 
 const debug = debugFactory("graphile-build-pg");
 
+const OMIT = 0;
+const DEPRECATED = 1;
+const ONLY = 2;
+
 export default (function PgBackwardRelationPlugin(
   builder,
-  { pgInflection: inflection }
+  { pgInflection: inflection, pgLegacyRelations }
 ) {
+  const legacyRelationMode =
+    {
+      only: ONLY,
+      deprecated: DEPRECATED,
+    }[pgLegacyRelations] || OMIT;
   builder.hook(
     "GraphQLObjectType:fields",
     (
@@ -59,6 +68,10 @@ export default (function PgBackwardRelationPlugin(
           }
           const foreignTable =
             introspectionResultsByKind.classById[constraint.foreignClassId];
+          const foreignTableTypeName = inflection.tableType(
+            foreignTable.name,
+            foreignTable.namespace.name
+          );
           const gqlForeignTableType = pgGetGqlTypeByTypeId(
             foreignTable.type.id
           );
@@ -92,19 +105,42 @@ export default (function PgBackwardRelationPlugin(
           if (!keys.every(_ => _) || !foreignKeys.every(_ => _)) {
             throw new Error("Could not find key columns!");
           }
+          const singleKey = keys.length === 1 ? keys[0] : null;
+          const isUnique = !!(
+            singleKey &&
+            introspectionResultsByKind.constraint.find(
+              c =>
+                c.classId === singleKey.classId &&
+                c.keyAttributeNums.length === 1 &&
+                c.keyAttributeNums[0] === singleKey.num &&
+                (c.type === "p" || c.type === "u")
+            )
+          );
+
+          const isDeprecated = isUnique && legacyRelationMode === DEPRECATED;
 
           const simpleKeys = keys.map(k => ({
             column: k.name,
             table: k.class.name,
             schema: k.class.namespace.name,
           }));
-          const fieldName = inflection.manyRelationByKeys(
+          const manyRelationFieldName = inflection.manyRelationByKeys(
             simpleKeys,
             table.name,
             table.namespace.name,
             foreignTable.name,
             foreignTable.namespace.name
           );
+          const singleRelationFieldName = isUnique
+            ? inflection.singleRelationByKeys(
+                simpleKeys,
+                table.name,
+                table.namespace.name,
+                foreignTable.name,
+                foreignTable.namespace.name
+              )
+            : null;
+
           const primaryKeyConstraint = introspectionResultsByKind.constraint
             .filter(con => con.classId === table.id)
             .filter(con => con.type === "p")[0];
@@ -114,82 +150,148 @@ export default (function PgBackwardRelationPlugin(
               num => attributes.filter(attr => attr.num === num)[0]
             );
 
-          memo[fieldName] = fieldWithHooks(
-            fieldName,
-            ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
-              addDataGenerator(parsedResolveInfoFragment => {
-                return {
-                  pgQuery: queryBuilder => {
-                    queryBuilder.select(() => {
-                      const resolveData = getDataFromParsedResolveInfoFragment(
-                        parsedResolveInfoFragment,
-                        ConnectionType
-                      );
-                      const tableAlias = sql.identifier(Symbol());
-                      const foreignTableAlias = queryBuilder.getTableAlias();
-                      const query = queryFromResolveData(
-                        sql.identifier(schema.name, table.name),
-                        tableAlias,
-                        resolveData,
-                        {
-                          withPagination: true,
-                          withPaginationAsFields: false,
-                        },
-                        innerQueryBuilder => {
-                          if (primaryKeys) {
-                            innerQueryBuilder.beforeLock("orderBy", () => {
-                              // append order by primary key to the list of orders
-                              if (!innerQueryBuilder.isOrderUnique(false)) {
-                                innerQueryBuilder.data.cursorPrefix = [
-                                  "primary_key_asc",
-                                ];
-                                primaryKeys.forEach(key => {
-                                  innerQueryBuilder.orderBy(
-                                    sql.fragment`${innerQueryBuilder.getTableAlias()}.${sql.identifier(
-                                      key.name
-                                    )}`,
-                                    true
-                                  );
-                                });
-                                innerQueryBuilder.setOrderIsUnique();
-                              }
+          const shouldAddSingleRelation =
+            isUnique && legacyRelationMode !== ONLY;
+
+          const shouldAddManyRelation =
+            !isUnique ||
+            legacyRelationMode === DEPRECATED ||
+            legacyRelationMode === ONLY;
+
+          if (shouldAddSingleRelation) {
+            memo[singleRelationFieldName] = fieldWithHooks(
+              singleRelationFieldName,
+              ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
+                addDataGenerator(parsedResolveInfoFragment => {
+                  return {
+                    pgQuery: queryBuilder => {
+                      queryBuilder.select(() => {
+                        const resolveData = getDataFromParsedResolveInfoFragment(
+                          parsedResolveInfoFragment,
+                          gqlTableType
+                        );
+                        const tableAlias = sql.identifier(Symbol());
+                        const foreignTableAlias = queryBuilder.getTableAlias();
+                        const query = queryFromResolveData(
+                          sql.identifier(schema.name, table.name),
+                          tableAlias,
+                          resolveData,
+                          {
+                            withPagination: false,
+                          },
+                          innerQueryBuilder => {
+                            keys.forEach((key, i) => {
+                              innerQueryBuilder.where(
+                                sql.fragment`${tableAlias}.${sql.identifier(
+                                  key.name
+                                )} = ${foreignTableAlias}.${sql.identifier(
+                                  foreignKeys[i].name
+                                )}`
+                              );
                             });
                           }
-
-                          keys.forEach((key, i) => {
-                            innerQueryBuilder.where(
-                              sql.fragment`${tableAlias}.${sql.identifier(
-                                key.name
-                              )} = ${foreignTableAlias}.${sql.identifier(
-                                foreignKeys[i].name
-                              )}`
-                            );
-                          });
-                        }
-                      );
-                      return sql.fragment`(${query})`;
-                    }, parsedResolveInfoFragment.alias);
+                        );
+                        return sql.fragment`(${query})`;
+                      }, parsedResolveInfoFragment.alias);
+                    },
+                  };
+                });
+                return {
+                  description: `Reads a single \`${tableTypeName}\` that is related to this \`${foreignTableTypeName}\`.`,
+                  type: gqlTableType,
+                  args: {},
+                  resolve: (data, _args, _context, resolveInfo) => {
+                    const alias = getAliasFromResolveInfo(resolveInfo);
+                    return data[alias];
                   },
                 };
-              });
-              const ConnectionType = getTypeByName(
-                inflection.connection(gqlTableType.name)
-              );
-              return {
-                description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
-                type: new GraphQLNonNull(ConnectionType),
-                args: {},
-                resolve: (data, _args, _context, resolveInfo) => {
-                  const alias = getAliasFromResolveInfo(resolveInfo);
-                  return addStartEndCursor(data[alias]);
-                },
-              };
-            },
-            {
-              isPgFieldConnection: true,
-              pgFieldIntrospection: table,
-            }
-          );
+              },
+              {
+                pgFieldIntrospection: table,
+              }
+            );
+          }
+          if (shouldAddManyRelation) {
+            memo[manyRelationFieldName] = fieldWithHooks(
+              manyRelationFieldName,
+              ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
+                addDataGenerator(parsedResolveInfoFragment => {
+                  return {
+                    pgQuery: queryBuilder => {
+                      queryBuilder.select(() => {
+                        const resolveData = getDataFromParsedResolveInfoFragment(
+                          parsedResolveInfoFragment,
+                          ConnectionType
+                        );
+                        const tableAlias = sql.identifier(Symbol());
+                        const foreignTableAlias = queryBuilder.getTableAlias();
+                        const query = queryFromResolveData(
+                          sql.identifier(schema.name, table.name),
+                          tableAlias,
+                          resolveData,
+                          {
+                            withPagination: true,
+                            withPaginationAsFields: false,
+                          },
+                          innerQueryBuilder => {
+                            if (primaryKeys) {
+                              innerQueryBuilder.beforeLock("orderBy", () => {
+                                // append order by primary key to the list of orders
+                                if (!innerQueryBuilder.isOrderUnique(false)) {
+                                  innerQueryBuilder.data.cursorPrefix = [
+                                    "primary_key_asc",
+                                  ];
+                                  primaryKeys.forEach(key => {
+                                    innerQueryBuilder.orderBy(
+                                      sql.fragment`${innerQueryBuilder.getTableAlias()}.${sql.identifier(
+                                        key.name
+                                      )}`,
+                                      true
+                                    );
+                                  });
+                                  innerQueryBuilder.setOrderIsUnique();
+                                }
+                              });
+                            }
+
+                            keys.forEach((key, i) => {
+                              innerQueryBuilder.where(
+                                sql.fragment`${tableAlias}.${sql.identifier(
+                                  key.name
+                                )} = ${foreignTableAlias}.${sql.identifier(
+                                  foreignKeys[i].name
+                                )}`
+                              );
+                            });
+                          }
+                        );
+                        return sql.fragment`(${query})`;
+                      }, parsedResolveInfoFragment.alias);
+                    },
+                  };
+                });
+                const ConnectionType = getTypeByName(
+                  inflection.connection(gqlTableType.name)
+                );
+                return {
+                  description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
+                  type: new GraphQLNonNull(ConnectionType),
+                  args: {},
+                  resolve: (data, _args, _context, resolveInfo) => {
+                    const alias = getAliasFromResolveInfo(resolveInfo);
+                    return addStartEndCursor(data[alias]);
+                  },
+                  deprecationReason: isDeprecated
+                    ? `Please use ${singleRelationFieldName} instead`
+                    : undefined,
+                };
+              },
+              {
+                isPgFieldConnection: true,
+                pgFieldIntrospection: table,
+              }
+            );
+          }
           return memo;
         }, {}),
         `Adding backward relations for ${Self.name}`

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -177,6 +177,8 @@ export default (function PgBackwardRelationPlugin(
                           tableAlias,
                           resolveData,
                           {
+                            asJson: true,
+                            addNullCase: true,
                             withPagination: false,
                           },
                           innerQueryBuilder => {

--- a/packages/postgraphile-core/__tests__/fixtures/queries/one-to-one-backward.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/one-to-one-backward.graphql
@@ -1,0 +1,33 @@
+{
+  allPeople {
+    edges {
+      cursor
+      node {
+        ...PersonDetails
+        leftArm: leftArmByPersonId {
+          nodeId
+          id
+          personId
+          personByPersonId {
+            ...PersonDetails
+          }
+          lengthInMetres
+        }
+        secret: personSecretByPersonId {
+          nodeId
+          personId
+          personByPersonId {
+            ...PersonDetails
+          }
+          secret
+        }
+      }
+    }
+  }
+}
+
+fragment PersonDetails on Person {
+  id
+  name
+  firstName
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1041,6 +1041,153 @@ Object {
 }
 `;
 
+exports[`one-to-one-backward.graphql 1`] = `
+Object {
+  "data": Object {
+    "allPeople": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "firstName": "John",
+            "id": 1,
+            "leftArm": Object {
+              "id": 50,
+              "lengthInMetres": 0.65,
+              "nodeId": "WyJsZWZ0X2FybXMiLDUwXQ==",
+              "personByPersonId": Object {
+                "firstName": "John",
+                "id": 1,
+                "name": "John Smith",
+              },
+              "personId": 1,
+            },
+            "name": "John Smith",
+            "secret": null,
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "firstName": "Sara",
+            "id": 2,
+            "leftArm": Object {
+              "id": 45,
+              "lengthInMetres": 0.7,
+              "nodeId": "WyJsZWZ0X2FybXMiLDQ1XQ==",
+              "personByPersonId": Object {
+                "firstName": "Sara",
+                "id": 2,
+                "name": "Sara Smith",
+              },
+              "personId": 2,
+            },
+            "name": "Sara Smith",
+            "secret": Object {
+              "nodeId": "WyJwZXJzb25fc2VjcmV0cyIsMl0=",
+              "personByPersonId": Object {
+                "firstName": "Sara",
+                "id": 2,
+                "name": "Sara Smith",
+              },
+              "personId": 2,
+              "secret": "Sara Smith is not really my name!",
+            },
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "firstName": "Budd",
+            "id": 3,
+            "leftArm": null,
+            "name": "Budd Deey",
+            "secret": Object {
+              "nodeId": "WyJwZXJzb25fc2VjcmV0cyIsM10=",
+              "personByPersonId": Object {
+                "firstName": "Budd",
+                "id": 3,
+                "name": "Budd Deey",
+              },
+              "personId": 3,
+              "secret": "I once got stuck trying to retrieve something embarassing from between two panes of glass",
+            },
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "firstName": "Kathryn",
+            "id": 4,
+            "leftArm": Object {
+              "id": 42,
+              "lengthInMetres": 0.6,
+              "nodeId": "WyJsZWZ0X2FybXMiLDQyXQ==",
+              "personByPersonId": Object {
+                "firstName": "Kathryn",
+                "id": 4,
+                "name": "Kathryn Ramirez",
+              },
+              "personId": 4,
+            },
+            "name": "Kathryn Ramirez",
+            "secret": null,
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "firstName": "Joe",
+            "id": 5,
+            "leftArm": Object {
+              "id": 47,
+              "lengthInMetres": 0.65,
+              "nodeId": "WyJsZWZ0X2FybXMiLDQ3XQ==",
+              "personByPersonId": Object {
+                "firstName": "Joe",
+                "id": 5,
+                "name": "Joe Tucker",
+              },
+              "personId": 5,
+            },
+            "name": "Joe Tucker",
+            "secret": Object {
+              "nodeId": "WyJwZXJzb25fc2VjcmV0cyIsNV0=",
+              "personByPersonId": Object {
+                "firstName": "Joe",
+                "id": 5,
+                "name": "Joe Tucker",
+              },
+              "personId": 5,
+              "secret": "My only secret is that I have no secrets!",
+            },
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "firstName": "Twenty",
+            "id": 6,
+            "leftArm": null,
+            "name": "Twenty Seventwo",
+            "secret": Object {
+              "nodeId": "WyJwZXJzb25fc2VjcmV0cyIsNl0=",
+              "personByPersonId": Object {
+                "firstName": "Twenty",
+                "id": 6,
+                "name": "Twenty Seventwo",
+              },
+              "personId": 6,
+              "secret": "I don't think the bug I test for will ever return!",
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`posts.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -1381,12 +1381,72 @@ type Person implements Node {
   \\"\\"\\"
   id: ID!
 
+  \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
   leftArmByPersonId: LeftArm
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection! @deprecated(reason: \\"Please use leftArmByPersonId instead\\")
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
 
+  \\"\\"\\"Reads a single \`PersonSecret\` that is related to this \`Person\`.\\"\\"\\"
   personSecretByPersonId: PersonSecret
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection! @deprecated(reason: \\"Please use personSecretByPersonId instead\\")
   rowId: Int!
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
@@ -7490,7 +7550,37 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
+  \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
   leftArmByPersonId: LeftArm
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection! @deprecated(reason: \\"Please use leftArmByPersonId instead\\")
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -7500,7 +7590,37 @@ type Person implements Node {
   \\"\\"\\"
   nodeId: ID!
 
+  \\"\\"\\"Reads a single \`PersonSecret\` that is related to this \`Person\`.\\"\\"\\"
   personSecretByPersonId: PersonSecret
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection! @deprecated(reason: \\"Please use personSecretByPersonId instead\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -11547,7 +11667,37 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
+  \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
   leftArmByPersonId: LeftArm
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection! @deprecated(reason: \\"Please use leftArmByPersonId instead\\")
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -11557,7 +11707,37 @@ type Person implements Node {
   \\"\\"\\"
   nodeId: ID!
 
+  \\"\\"\\"Reads a single \`PersonSecret\` that is related to this \`Person\`.\\"\\"\\"
   personSecretByPersonId: PersonSecret
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection! @deprecated(reason: \\"Please use personSecretByPersonId instead\\")
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
 
@@ -12029,7 +12209,7 @@ input WrappedUrlInput {
 "
 `;
 
-exports[`prints a schema without one-to-one support 1`] = `
+exports[`prints a schema without legacy relations 1`] = `
 "enum AnEnum {
   _ASTERISK_BAR_
   _ASTERISK_BAZ_ASTERISK_
@@ -14264,7 +14444,7 @@ input WrappedUrlInput {
 "
 `;
 
-exports[`prints a schema without parsing tags 1`] = `
+exports[`prints a schema without parsing tags and with legacy relations omitted 1`] = `
 "enum AnEnum {
   _ASTERISK_BAR_
   _ASTERISK_BAZ_ASTERISK_
@@ -15642,6 +15822,7 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
+  \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
   leftArmByPersonId: LeftArm
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -15652,6 +15833,7 @@ type Person implements Node {
   \\"\\"\\"
   nodeId: ID!
 
+  \\"\\"\\"Reads a single \`PersonSecret\` that is related to this \`Person\`.\\"\\"\\"
   personSecretByPersonId: PersonSecret
 
   \\"\\"\\"@deprecated Don’t use me\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -241,6 +241,44 @@ type CreateEdgeCasePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+input CreateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` to be created by this mutation.\\"\\"\\"
+  leftArm: LeftArmInput!
+}
+
+\\"\\"\\"The output of our create \`LeftArm\` mutation.\\"\\"\\"
+type CreateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -269,6 +307,44 @@ type CreatePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`PersonSecret\` mutation.\\"\\"\\"
+input CreatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`PersonSecret\` to be created by this mutation.\\"\\"\\"
+  personSecret: PersonSecretInput!
+}
+
+\\"\\"\\"The output of our create \`PersonSecret\` mutation.\\"\\"\\"
+type CreatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -342,6 +418,67 @@ type DeleteCompoundKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the \`deleteLeftArmByPersonId\` mutation.\\"\\"\\"
+input DeleteLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmByRowId\` mutation.\\"\\"\\"
+input DeleteLeftArmByRowIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  rowId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArm\` mutation.\\"\\"\\"
+input DeleteLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be deleted.
+  \\"\\"\\"
+  id: ID!
+}
+
+\\"\\"\\"The output of our delete \`LeftArm\` mutation.\\"\\"\\"
+type DeleteLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedLeftArmId: ID
+
+  \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the \`deletePersonByEmail\` mutation.\\"\\"\\"
 input DeletePersonByEmailInput {
   \\"\\"\\"
@@ -393,6 +530,57 @@ type DeletePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonSecretByPersonId\` mutation.\\"\\"\\"
+input DeletePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deletePersonSecret\` mutation.\\"\\"\\"
+input DeletePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be deleted.
+  \\"\\"\\"
+  id: ID!
+}
+
+\\"\\"\\"The output of our delete \`PersonSecret\` mutation.\\"\\"\\"
+type DeletePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonSecretId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -655,6 +843,89 @@ type JsonIdentityMutationPayload {
   query: Query
 }
 
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  id: ID!
+  lengthInMetres: Float
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+  rowId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`rowId\` field.\\"\\"\\"
+  rowId: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`LeftArm\`\\"\\"\\"
+input LeftArmInput {
+  lengthInMetres: Float
+  personId: Int!
+  rowId: Int
+}
+
+\\"\\"\\"
+Represents an update to a \`LeftArm\`. Fields that are set will be updated.
+\\"\\"\\"
+input LeftArmPatch {
+  lengthInMetres: Float
+  personId: Int
+  rowId: Int
+}
+
+\\"\\"\\"A connection to a list of \`LeftArm\` values.\\"\\"\\"
+type LeftArmsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`LeftArm\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [LeftArmsEdge!]!
+
+  \\"\\"\\"A list of \`LeftArm\` objects.\\"\\"\\"
+  nodes: [LeftArm]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`LeftArm\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"
 The root mutation type which contains root level fields which mutate data.
 \\"\\"\\"
@@ -675,6 +946,14 @@ type Mutation {
     input: CreateEdgeCaseInput!
   ): CreateEdgeCasePayload
 
+  \\"\\"\\"Creates a single \`LeftArm\`.\\"\\"\\"
+  createLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateLeftArmInput!
+  ): CreateLeftArmPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -682,6 +961,14 @@ type Mutation {
     \\"\\"\\"
     input: CreatePersonInput!
   ): CreatePersonPayload
+
+  \\"\\"\\"Creates a single \`PersonSecret\`.\\"\\"\\"
+  createPersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonSecretInput!
+  ): CreatePersonSecretPayload
 
   \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
   deleteCompoundKey(
@@ -698,6 +985,30 @@ type Mutation {
     \\"\\"\\"
     input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
   ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
+  deleteLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByPersonIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByRowId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByRowIdInput!
+  ): DeleteLeftArmPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -722,6 +1033,22 @@ type Mutation {
     \\"\\"\\"
     input: DeletePersonByRowIdInput!
   ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using its globally unique id.\\"\\"\\"
+  deletePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretInput!
+  ): DeletePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
+  deletePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretByPersonIdInput!
+  ): DeletePersonSecretPayload
   intSetMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -797,6 +1124,30 @@ type Mutation {
     input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
   ): UpdateCompoundKeyPayload
 
+  \\"\\"\\"Updates a single \`LeftArm\` using its globally unique id and a patch.\\"\\"\\"
+  updateLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByPersonIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByRowId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByRowIdInput!
+  ): UpdateLeftArmPayload
+
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
     \\"\\"\\"
@@ -820,6 +1171,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdatePersonByRowIdInput!
   ): UpdatePersonPayload
+
+  \\"\\"\\"
+  Updates a single \`PersonSecret\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updatePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretInput!
+  ): UpdatePersonSecretPayload
+
+  \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
+  updatePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretByPersonIdInput!
+  ): UpdatePersonSecretPayload
 }
 
 \\"\\"\\"All input for the \`noArgsMutation\` mutation.\\"\\"\\"
@@ -1012,8 +1381,66 @@ type Person implements Node {
   \\"\\"\\"
   id: ID!
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection!
+
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection!
   rowId: Int!
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
@@ -1070,6 +1497,82 @@ input PersonPatch {
   name: String
   rowId: Int
   site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  id: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"An input for mutations affecting \`PersonSecret\`\\"\\"\\"
+input PersonSecretInput {
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+Represents an update to a \`PersonSecret\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonSecretPatch {
+  personId: Int
+  secret: String
+}
+
+\\"\\"\\"A connection to a list of \`PersonSecret\` values.\\"\\"\\"
+type PersonSecretsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`PersonSecret\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PersonSecretsEdge!]!
+
+  \\"\\"\\"A list of \`PersonSecret\` objects.\\"\\"\\"
+  nodes: [PersonSecret]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`PersonSecret\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
 }
 
 type Post {
@@ -1141,6 +1644,35 @@ type Query implements Node {
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArms(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -1169,6 +1701,35 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecrets(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -1228,6 +1789,14 @@ type Query implements Node {
   ): IntSetQueryConnection!
   jsonIdentity(json: JSON): JSON
   jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    id: ID!
+  ): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
+  leftArmByRowId(rowId: Int!): LeftArm
   noArgsQuery: Int
 
   \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
@@ -1243,6 +1812,15 @@ type Query implements Node {
   ): Person
   personByEmail(email: Email!): Person
   personByRowId(rowId: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    id: ID!
+  ): PersonSecret
+  personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1
@@ -1427,6 +2005,81 @@ type UpdateCompoundKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the \`updateLeftArmByPersonId\` mutation.\\"\\"\\"
+input UpdateLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArmByRowId\` mutation.\\"\\"\\"
+input UpdateLeftArmByRowIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  rowId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArm\` mutation.\\"\\"\\"
+input UpdateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be updated.
+  \\"\\"\\"
+  id: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+}
+
+\\"\\"\\"The output of our update \`LeftArm\` mutation.\\"\\"\\"
+type UpdateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the \`updatePersonByEmail\` mutation.\\"\\"\\"
 input UpdatePersonByEmailInput {
   \\"\\"\\"
@@ -1492,6 +2145,66 @@ type UpdatePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonSecretByPersonId\` mutation.\\"\\"\\"
+input UpdatePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonSecret\` mutation.\\"\\"\\"
+input UpdatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be updated.
+  \\"\\"\\"
+  id: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"The output of our update \`PersonSecret\` mutation.\\"\\"\\"
+type UpdatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3545,6 +4258,44 @@ type CreateInputPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+input CreateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` to be created by this mutation.\\"\\"\\"
+  leftArm: LeftArmInput!
+}
+
+\\"\\"\\"The output of our create \`LeftArm\` mutation.\\"\\"\\"
+type CreateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -3608,6 +4359,44 @@ type CreatePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`PersonSecret\` mutation.\\"\\"\\"
+input CreatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`PersonSecret\` to be created by this mutation.\\"\\"\\"
+  personSecret: PersonSecretInput!
+}
+
+\\"\\"\\"The output of our create \`PersonSecret\` mutation.\\"\\"\\"
+type CreatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -4246,6 +5035,67 @@ type DeleteInputPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the \`deleteLeftArmById\` mutation.\\"\\"\\"
+input DeleteLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmByPersonId\` mutation.\\"\\"\\"
+input DeleteLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArm\` mutation.\\"\\"\\"
+input DeleteLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`LeftArm\` mutation.\\"\\"\\"
+type DeleteLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedLeftArmId: ID
+
+  \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the \`deletePatchById\` mutation.\\"\\"\\"
 input DeletePatchByIdInput {
   \\"\\"\\"
@@ -4345,6 +5195,57 @@ type DeletePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonSecretByPersonId\` mutation.\\"\\"\\"
+input DeletePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deletePersonSecret\` mutation.\\"\\"\\"
+input DeletePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`PersonSecret\` mutation.\\"\\"\\"
+type DeletePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonSecretId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -5219,6 +6120,90 @@ type JwtToken {
   role: String
 }
 
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  id: Int!
+  lengthInMetres: Float
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`LeftArm\`\\"\\"\\"
+input LeftArmInput {
+  id: Int
+  lengthInMetres: Float
+  personId: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`LeftArm\`. Fields that are set will be updated.
+\\"\\"\\"
+input LeftArmPatch {
+  id: Int
+  lengthInMetres: Float
+  personId: Int
+}
+
+\\"\\"\\"A connection to a list of \`LeftArm\` values.\\"\\"\\"
+type LeftArmsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`LeftArm\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [LeftArmsEdge!]!
+
+  \\"\\"\\"A list of \`LeftArm\` objects.\\"\\"\\"
+  nodes: [LeftArm]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`LeftArm\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"All input for the \`mult1\` mutation.\\"\\"\\"
 input Mult1Input {
   arg0: Int
@@ -5433,6 +6418,14 @@ type Mutation {
     input: CreateInputInput!
   ): CreateInputPayload
 
+  \\"\\"\\"Creates a single \`LeftArm\`.\\"\\"\\"
+  createLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateLeftArmInput!
+  ): CreateLeftArmPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -5448,6 +6441,14 @@ type Mutation {
     \\"\\"\\"
     input: CreatePersonInput!
   ): CreatePersonPayload
+
+  \\"\\"\\"Creates a single \`PersonSecret\`.\\"\\"\\"
+  createPersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonSecretInput!
+  ): CreatePersonSecretPayload
 
   \\"\\"\\"Creates a single \`Post\`.\\"\\"\\"
   createPost(
@@ -5577,6 +6578,30 @@ type Mutation {
     input: DeleteInputByIdInput!
   ): DeleteInputPayload
 
+  \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
+  deleteLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByPersonIdInput!
+  ): DeleteLeftArmPayload
+
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
     \\"\\"\\"
@@ -5616,6 +6641,22 @@ type Mutation {
     \\"\\"\\"
     input: DeletePersonByIdInput!
   ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using its globally unique id.\\"\\"\\"
+  deletePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretInput!
+  ): DeletePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
+  deletePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretByPersonIdInput!
+  ): DeletePersonSecretPayload
 
   \\"\\"\\"Deletes a single \`Post\` using its globally unique id.\\"\\"\\"
   deletePost(
@@ -5909,6 +6950,30 @@ type Mutation {
     input: UpdateInputByIdInput!
   ): UpdateInputPayload
 
+  \\"\\"\\"Updates a single \`LeftArm\` using its globally unique id and a patch.\\"\\"\\"
+  updateLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByPersonIdInput!
+  ): UpdateLeftArmPayload
+
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
     \\"\\"\\"
@@ -5948,6 +7013,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdatePersonByIdInput!
   ): UpdatePersonPayload
+
+  \\"\\"\\"
+  Updates a single \`PersonSecret\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updatePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretInput!
+  ): UpdatePersonSecretPayload
+
+  \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
+  updatePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretByPersonIdInput!
+  ): UpdatePersonSecretPayload
 
   \\"\\"\\"Updates a single \`Post\` using its globally unique id and a patch.\\"\\"\\"
   updatePost(
@@ -6461,6 +7544,35 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection!
+
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
 
@@ -6468,6 +7580,35 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -6552,6 +7693,82 @@ input PersonPatch {
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String
   site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"An input for mutations affecting \`PersonSecret\`\\"\\"\\"
+input PersonSecretInput {
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+Represents an update to a \`PersonSecret\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonSecretPatch {
+  personId: Int
+  secret: String
+}
+
+\\"\\"\\"A connection to a list of \`PersonSecret\` values.\\"\\"\\"
+type PersonSecretsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`PersonSecret\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PersonSecretsEdge!]!
+
+  \\"\\"\\"A list of \`PersonSecret\` objects.\\"\\"\\"
+  nodes: [PersonSecret]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`PersonSecret\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
 }
 
 type Point {
@@ -6902,6 +8119,35 @@ type Query implements Node {
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
   ): InputsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArms(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`NonUpdatableView\`.\\"\\"\\"
   allNonUpdatableViews(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -6988,6 +8234,35 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecrets(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -7415,6 +8690,14 @@ type Query implements Node {
   ): IntSetQueryConnection!
   jsonIdentity(json: JSON): JSON
   jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    nodeId: ID!
+  ): LeftArm
+  leftArmById(id: Int!): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
   noArgsQuery: Int
 
   \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
@@ -7447,6 +8730,15 @@ type Query implements Node {
   ): Person
   personByEmail(email: Email!): Person
   personById(id: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): PersonSecret
+  personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"Reads a single \`Post\` using its globally unique \`ID\`.\\"\\"\\"
   post(
@@ -8821,6 +10113,81 @@ type UpdateInputPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the \`updateLeftArmById\` mutation.\\"\\"\\"
+input UpdateLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+}
+
+\\"\\"\\"All input for the \`updateLeftArmByPersonId\` mutation.\\"\\"\\"
+input UpdateLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArm\` mutation.\\"\\"\\"
+input UpdateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`LeftArm\` mutation.\\"\\"\\"
+type UpdateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the \`updatePatchById\` mutation.\\"\\"\\"
 input UpdatePatchByIdInput {
   \\"\\"\\"
@@ -8943,6 +10310,66 @@ type UpdatePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonSecretByPersonId\` mutation.\\"\\"\\"
+input UpdatePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonSecret\` mutation.\\"\\"\\"
+input UpdatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"The output of our update \`PersonSecret\` mutation.\\"\\"\\"
+type UpdatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -9912,6 +11339,74 @@ type JsonIdentityMutationPayload {
   query: Query
 }
 
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  id: Int!
+  lengthInMetres: Float
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+}
+
+\\"\\"\\"A connection to a list of \`LeftArm\` values.\\"\\"\\"
+type LeftArmsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`LeftArm\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [LeftArmsEdge!]!
+
+  \\"\\"\\"A list of \`LeftArm\` objects.\\"\\"\\"
+  nodes: [LeftArm]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`LeftArm\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"
 The root mutation type which contains root level fields which mutate data.
 \\"\\"\\"
@@ -10160,6 +11655,35 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection!
+
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
 
@@ -10167,6 +11691,35 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection!
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
 
@@ -10194,6 +11747,68 @@ input PersonCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`site\` field.\\"\\"\\"
   site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"A connection to a list of \`PersonSecret\` values.\\"\\"\\"
+type PersonSecretsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`PersonSecret\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PersonSecretsEdge!]!
+
+  \\"\\"\\"A list of \`PersonSecret\` objects.\\"\\"\\"
+  nodes: [PersonSecret]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`PersonSecret\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
 }
 
 type Post {
@@ -10265,6 +11880,35 @@ type Query implements Node {
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArms(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -10293,6 +11937,35 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecrets(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -10347,6 +12020,14 @@ type Query implements Node {
   ): IntSetQueryConnection!
   jsonIdentity(json: JSON): JSON
   jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    nodeId: ID!
+  ): LeftArm
+  leftArmById(id: Int!): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
   noArgsQuery: Int
 
   \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
@@ -10367,6 +12048,15 @@ type Query implements Node {
   ): Person
   personByEmail(email: Email!): Person
   personById(id: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): PersonSecret
+  personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1
@@ -10742,6 +12432,44 @@ type CreateEdgeCasePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+input CreateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` to be created by this mutation.\\"\\"\\"
+  leftArm: LeftArmInput!
+}
+
+\\"\\"\\"The output of our create \`LeftArm\` mutation.\\"\\"\\"
+type CreateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -10770,6 +12498,44 @@ type CreatePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`PersonSecret\` mutation.\\"\\"\\"
+input CreatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`PersonSecret\` to be created by this mutation.\\"\\"\\"
+  personSecret: PersonSecretInput!
+}
+
+\\"\\"\\"The output of our create \`PersonSecret\` mutation.\\"\\"\\"
+type CreatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -10843,6 +12609,67 @@ type DeleteCompoundKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the \`deleteLeftArmById\` mutation.\\"\\"\\"
+input DeleteLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmByPersonId\` mutation.\\"\\"\\"
+input DeleteLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArm\` mutation.\\"\\"\\"
+input DeleteLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`LeftArm\` mutation.\\"\\"\\"
+type DeleteLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedLeftArmId: ID
+
+  \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the \`deletePersonByEmail\` mutation.\\"\\"\\"
 input DeletePersonByEmailInput {
   \\"\\"\\"
@@ -10894,6 +12721,57 @@ type DeletePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonSecretByPersonId\` mutation.\\"\\"\\"
+input DeletePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deletePersonSecret\` mutation.\\"\\"\\"
+input DeletePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`PersonSecret\` mutation.\\"\\"\\"
+type DeletePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonSecretId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -11156,6 +13034,90 @@ type JsonIdentityMutationPayload {
   query: Query
 }
 
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  id: Int!
+  lengthInMetres: Float
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`LeftArm\`\\"\\"\\"
+input LeftArmInput {
+  id: Int
+  lengthInMetres: Float
+  personId: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`LeftArm\`. Fields that are set will be updated.
+\\"\\"\\"
+input LeftArmPatch {
+  id: Int
+  lengthInMetres: Float
+  personId: Int
+}
+
+\\"\\"\\"A connection to a list of \`LeftArm\` values.\\"\\"\\"
+type LeftArmsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`LeftArm\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [LeftArmsEdge!]!
+
+  \\"\\"\\"A list of \`LeftArm\` objects.\\"\\"\\"
+  nodes: [LeftArm]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`LeftArm\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"
 The root mutation type which contains root level fields which mutate data.
 \\"\\"\\"
@@ -11176,6 +13138,14 @@ type Mutation {
     input: CreateEdgeCaseInput!
   ): CreateEdgeCasePayload
 
+  \\"\\"\\"Creates a single \`LeftArm\`.\\"\\"\\"
+  createLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateLeftArmInput!
+  ): CreateLeftArmPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -11183,6 +13153,14 @@ type Mutation {
     \\"\\"\\"
     input: CreatePersonInput!
   ): CreatePersonPayload
+
+  \\"\\"\\"Creates a single \`PersonSecret\`.\\"\\"\\"
+  createPersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonSecretInput!
+  ): CreatePersonSecretPayload
 
   \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
   deleteCompoundKey(
@@ -11199,6 +13177,30 @@ type Mutation {
     \\"\\"\\"
     input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
   ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
+  deleteLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByPersonIdInput!
+  ): DeleteLeftArmPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -11223,6 +13225,22 @@ type Mutation {
     \\"\\"\\"
     input: DeletePersonByIdInput!
   ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using its globally unique id.\\"\\"\\"
+  deletePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretInput!
+  ): DeletePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
+  deletePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretByPersonIdInput!
+  ): DeletePersonSecretPayload
   intSetMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -11298,6 +13316,30 @@ type Mutation {
     input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
   ): UpdateCompoundKeyPayload
 
+  \\"\\"\\"Updates a single \`LeftArm\` using its globally unique id and a patch.\\"\\"\\"
+  updateLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByPersonIdInput!
+  ): UpdateLeftArmPayload
+
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
     \\"\\"\\"
@@ -11321,6 +13363,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdatePersonByIdInput!
   ): UpdatePersonPayload
+
+  \\"\\"\\"
+  Updates a single \`PersonSecret\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updatePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretInput!
+  ): UpdatePersonSecretPayload
+
+  \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
+  updatePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretByPersonIdInput!
+  ): UpdatePersonSecretPayload
 }
 
 \\"\\"\\"All input for the \`noArgsMutation\` mutation.\\"\\"\\"
@@ -11509,6 +13569,35 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection!
+
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
 
@@ -11516,6 +13605,35 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection!
 
   \\"\\"\\"@deprecated Don’t use me\\"\\"\\"
   site: WrappedUrl
@@ -11577,6 +13695,82 @@ input PersonPatch {
 
   \\"\\"\\"@deprecated Don’t use me\\"\\"\\"
   site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"An input for mutations affecting \`PersonSecret\`\\"\\"\\"
+input PersonSecretInput {
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+Represents an update to a \`PersonSecret\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonSecretPatch {
+  personId: Int
+  secret: String
+}
+
+\\"\\"\\"A connection to a list of \`PersonSecret\` values.\\"\\"\\"
+type PersonSecretsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`PersonSecret\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PersonSecretsEdge!]!
+
+  \\"\\"\\"A list of \`PersonSecret\` objects.\\"\\"\\"
+  nodes: [PersonSecret]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`PersonSecret\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
 }
 
 type Post {
@@ -11648,6 +13842,35 @@ type Query implements Node {
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArms(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -11676,6 +13899,35 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecrets(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -11730,6 +13982,14 @@ type Query implements Node {
   ): IntSetQueryConnection!
   jsonIdentity(json: JSON): JSON
   jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    nodeId: ID!
+  ): LeftArm
+  leftArmById(id: Int!): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
   noArgsQuery: Int
 
   \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
@@ -11750,6 +14010,15 @@ type Query implements Node {
   ): Person
   personByEmail(email: Email!): Person
   personById(id: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): PersonSecret
+  personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1
@@ -11934,6 +14203,81 @@ type UpdateCompoundKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the \`updateLeftArmById\` mutation.\\"\\"\\"
+input UpdateLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+}
+
+\\"\\"\\"All input for the \`updateLeftArmByPersonId\` mutation.\\"\\"\\"
+input UpdateLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArm\` mutation.\\"\\"\\"
+input UpdateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`LeftArm\` mutation.\\"\\"\\"
+type UpdateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the \`updatePersonByEmail\` mutation.\\"\\"\\"
 input UpdatePersonByEmailInput {
   \\"\\"\\"
@@ -11999,6 +14343,66 @@ type UpdatePersonPayload {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonSecretByPersonId\` mutation.\\"\\"\\"
+input UpdatePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonSecret\` mutation.\\"\\"\\"
+input UpdatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"The output of our update \`PersonSecret\` mutation.\\"\\"\\"
+type UpdatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -1381,66 +1381,12 @@ type Person implements Node {
   \\"\\"\\"
   id: ID!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
-  leftArmsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: LeftArmCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsConnection!
+  leftArmByPersonId: LeftArm
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
-  personSecretsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: PersonSecretCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection!
+  personSecretByPersonId: PersonSecret
   rowId: Int!
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
@@ -7544,34 +7490,7 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
-  leftArmsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: LeftArmCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsConnection!
+  leftArmByPersonId: LeftArm
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -7581,34 +7500,7 @@ type Person implements Node {
   \\"\\"\\"
   nodeId: ID!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
-  personSecretsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: PersonSecretCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection!
+  personSecretByPersonId: PersonSecret
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -11655,34 +11547,7 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
-  leftArmsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: LeftArmCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsConnection!
+  leftArmByPersonId: LeftArm
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -11692,34 +11557,7 @@ type Person implements Node {
   \\"\\"\\"
   nodeId: ID!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
-  personSecretsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: PersonSecretCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection!
+  personSecretByPersonId: PersonSecret
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
 
@@ -13569,34 +13407,7 @@ type Person implements Node {
   ): PeopleConnection!
   id: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
-  leftArmsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: LeftArmCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsConnection!
+  leftArmByPersonId: LeftArm
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
@@ -13606,34 +13417,7 @@ type Person implements Node {
   \\"\\"\\"
   nodeId: ID!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
-  personSecretsByPersonId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: PersonSecretCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection!
+  personSecretByPersonId: PersonSecret
 
   \\"\\"\\"@deprecated Don’t use me\\"\\"\\"
   site: WrappedUrl

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -12029,6 +12029,2241 @@ input WrappedUrlInput {
 "
 `;
 
+exports[`prints a schema without one-to-one support 1`] = `
+"enum AnEnum {
+  _ASTERISK_BAR_
+  _ASTERISK_BAZ_ASTERISK_
+  _FOO_ASTERISK
+  ASTERISK
+  ASTERISK_ASTERISK
+  ASTERISK_ASTERISK_ASTERISK
+  ASTERISK_BAR
+  ASTERISK_BAR_
+  ASTERISK_BAZ_ASTERISK
+  AWAITING
+  DOLLAR
+  FOO_ASTERISK
+  FOO_ASTERISK_
+  GREATER_THAN_OR_EQUAL
+  LIKE
+  PERCENT
+  PUBLISHED
+  REJECTED
+}
+
+\\"\\"\\"
+A signed eight-byte integer. The upper big integer values are greater then the
+max value for a JavaScript number. Therefore all big integers will be output as
+strings and not numbers.
+\\"\\"\\"
+scalar BigInt
+
+enum Color {
+  BLUE
+  GREEN
+  RED
+}
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`CompoundKey\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input CompoundKeyCondition {
+  \\"\\"\\"Checks for equality with the object’s \`extra\` field.\\"\\"\\"
+  extra: Boolean
+
+  \\"\\"\\"Checks for equality with the object’s \`personId1\` field.\\"\\"\\"
+  personId1: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`personId2\` field.\\"\\"\\"
+  personId2: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`CompoundKey\`\\"\\"\\"
+input CompoundKeyInput {
+  extra: Boolean
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+\\"\\"\\"
+input CompoundKeyPatch {
+  extra: Boolean
+  personId1: Int
+  personId2: Int
+}
+
+\\"\\"\\"A connection to a list of \`CompoundKey\` values.\\"\\"\\"
+type CompoundKeysConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [CompoundKeysEdge!]!
+
+  \\"\\"\\"A list of \`CompoundKey\` objects.\\"\\"\\"
+  nodes: [CompoundKey]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`CompoundKey\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`CompoundKey\` edge in the connection.\\"\\"\\"
+type CompoundKeysEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
+  node: CompoundKey!
+}
+
+\\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"Awesome feature!\\"\\"\\"
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  computedField: Int
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+}
+
+\\"\\"\\"A connection to a list of \`CompoundType\` values.\\"\\"\\"
+type CompoundTypesConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`CompoundType\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [CompoundTypesEdge!]!
+
+  \\"\\"\\"A list of \`CompoundType\` objects.\\"\\"\\"
+  nodes: [CompoundType]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`CompoundType\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`CompoundType\` edge in the connection.\\"\\"\\"
+type CompoundTypesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
+  node: CompoundType!
+}
+
+type Comptype {
+  isOptimised: Boolean
+  schedule: Datetime
+}
+
+\\"\\"\\"All input for the create \`CompoundKey\` mutation.\\"\\"\\"
+input CreateCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` to be created by this mutation.\\"\\"\\"
+  compoundKey: CompoundKeyInput!
+}
+
+\\"\\"\\"The output of our create \`CompoundKey\` mutation.\\"\\"\\"
+type CreateCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`EdgeCase\` mutation.\\"\\"\\"
+input CreateEdgeCaseInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`EdgeCase\` to be created by this mutation.\\"\\"\\"
+  edgeCase: EdgeCaseInput!
+}
+
+\\"\\"\\"The output of our create \`EdgeCase\` mutation.\\"\\"\\"
+type CreateEdgeCasePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
+  edgeCase: EdgeCase
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  edgeCaseEdge(
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+input CreateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` to be created by this mutation.\\"\\"\\"
+  leftArm: LeftArmInput!
+}
+
+\\"\\"\\"The output of our create \`LeftArm\` mutation.\\"\\"\\"
+type CreateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
+input CreatePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` to be created by this mutation.\\"\\"\\"
+  person: PersonInput!
+}
+
+\\"\\"\\"The output of our create \`Person\` mutation.\\"\\"\\"
+type CreatePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`PersonSecret\` mutation.\\"\\"\\"
+input CreatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`PersonSecret\` to be created by this mutation.\\"\\"\\"
+  personSecret: PersonSecretInput!
+}
+
+\\"\\"\\"The output of our create \`PersonSecret\` mutation.\\"\\"\\"
+type CreatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+scalar Cursor
+
+\\"\\"\\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\\"\\"\\"
+scalar Datetime
+
+\\"\\"\\"
+All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+\\"\\"\\"
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the \`deleteCompoundKey\` mutation.\\"\\"\\"
+input DeleteCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`CompoundKey\` mutation.\\"\\"\\"
+type DeleteCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+  deletedCompoundKeyId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmById\` mutation.\\"\\"\\"
+input DeleteLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmByPersonId\` mutation.\\"\\"\\"
+input DeleteLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArm\` mutation.\\"\\"\\"
+input DeleteLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`LeftArm\` mutation.\\"\\"\\"
+type DeleteLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedLeftArmId: ID
+
+  \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonByEmail\` mutation.\\"\\"\\"
+input DeletePersonByEmailInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  email: Email!
+}
+
+\\"\\"\\"All input for the \`deletePersonById\` mutation.\\"\\"\\"
+input DeletePersonByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deletePerson\` mutation.\\"\\"\\"
+input DeletePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`Person\` mutation.\\"\\"\\"
+type DeletePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonId: ID
+
+  \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonSecretByPersonId\` mutation.\\"\\"\\"
+input DeletePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deletePersonSecret\` mutation.\\"\\"\\"
+input DeletePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`PersonSecret\` mutation.\\"\\"\\"
+type DeletePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonSecretId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+type EdgeCase {
+  computed: String
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\\"\\"\\"
+A condition to be used against \`EdgeCase\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input EdgeCaseCondition {
+  \\"\\"\\"Checks for equality with the object’s \`notNullHasDefault\` field.\\"\\"\\"
+  notNullHasDefault: Boolean
+
+  \\"\\"\\"Checks for equality with the object’s \`rowId\` field.\\"\\"\\"
+  rowId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`wontCastEasy\` field.\\"\\"\\"
+  wontCastEasy: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`EdgeCase\`\\"\\"\\"
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\\"\\"\\"A connection to a list of \`EdgeCase\` values.\\"\\"\\"
+type EdgeCasesConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [EdgeCasesEdge!]!
+
+  \\"\\"\\"A list of \`EdgeCase\` objects.\\"\\"\\"
+  nodes: [EdgeCase]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`EdgeCase\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`EdgeCase\` edge in the connection.\\"\\"\\"
+type EdgeCasesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
+  node: EdgeCase!
+}
+
+\\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+enum EnumCaps {
+  _0_BAR
+  BAR_FOO
+  BAZ_QUX
+  FOO_BAR
+}
+
+enum EnumWithEmptyString {
+  _EMPTY_
+  ONE
+  TWO
+}
+
+\\"\\"\\"
+The value at one end of a range. A range can either include this value, or not.
+\\"\\"\\"
+input FloatRangeBoundInput {
+  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  inclusive: Boolean!
+
+  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  value: Float!
+}
+
+\\"\\"\\"A range of \`Float\`.\\"\\"\\"
+input FloatRangeInput {
+  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  end: FloatRangeBoundInput
+
+  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  start: FloatRangeBoundInput
+}
+
+\\"\\"\\"All input for the \`intSetMutation\` mutation.\\"\\"\\"
+input IntSetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+\\"\\"\\"The output of our \`intSetMutation\` mutation.\\"\\"\\"
+type IntSetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integers: [Int]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+type IntSetQueryConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [IntSetQueryEdge!]!
+
+  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  nodes: [Int]!
+}
+
+\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+type IntSetQueryEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  node: Int
+}
+
+\\"\\"\\"
+A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+\\"\\"\\"
+scalar JSON
+
+\\"\\"\\"All input for the \`jsonbIdentityMutation\` mutation.\\"\\"\\"
+input JsonbIdentityMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutation\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonbIdentityMutationPlpgsql\` mutation.\\"\\"\\"
+input JsonbIdentityMutationPlpgsqlInput {
+  _theJson: JSON!
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutationPlpgsql\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPlpgsqlPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonbIdentityMutationPlpgsqlWithDefault\` mutation.\\"\\"\\"
+input JsonbIdentityMutationPlpgsqlWithDefaultInput {
+  _theJson: JSON
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutationPlpgsqlWithDefault\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPlpgsqlWithDefaultPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonIdentityMutation\` mutation.\\"\\"\\"
+input JsonIdentityMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+}
+
+\\"\\"\\"The output of our \`jsonIdentityMutation\` mutation.\\"\\"\\"
+type JsonIdentityMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  id: Int!
+  lengthInMetres: Float
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`LeftArm\`\\"\\"\\"
+input LeftArmInput {
+  id: Int
+  lengthInMetres: Float
+  personId: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`LeftArm\`. Fields that are set will be updated.
+\\"\\"\\"
+input LeftArmPatch {
+  id: Int
+  lengthInMetres: Float
+  personId: Int
+}
+
+\\"\\"\\"A connection to a list of \`LeftArm\` values.\\"\\"\\"
+type LeftArmsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`LeftArm\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [LeftArmsEdge!]!
+
+  \\"\\"\\"A list of \`LeftArm\` objects.\\"\\"\\"
+  nodes: [LeftArm]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`LeftArm\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"
+The root mutation type which contains root level fields which mutate data.
+\\"\\"\\"
+type Mutation {
+  \\"\\"\\"Creates a single \`CompoundKey\`.\\"\\"\\"
+  createCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  \\"\\"\\"Creates a single \`EdgeCase\`.\\"\\"\\"
+  createEdgeCase(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  \\"\\"\\"Creates a single \`LeftArm\`.\\"\\"\\"
+  createLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateLeftArmInput!
+  ): CreateLeftArmPayload
+
+  \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
+  createPerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  \\"\\"\\"Creates a single \`PersonSecret\`.\\"\\"\\"
+  createPersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonSecretInput!
+  ): CreatePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
+  deleteCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`CompoundKey\` using a unique key.\\"\\"\\"
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
+  deleteLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByPersonIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
+  deletePerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using a unique key.\\"\\"\\"
+  deletePersonByEmail(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using a unique key.\\"\\"\\"
+  deletePersonById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonByIdInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using its globally unique id.\\"\\"\\"
+  deletePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretInput!
+  ): DeletePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
+  deletePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretByPersonIdInput!
+  ): DeletePersonSecretPayload
+  intSetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload
+  jsonIdentityMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload
+  jsonbIdentityMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationInput!
+  ): JsonbIdentityMutationPayload
+  jsonbIdentityMutationPlpgsql(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationPlpgsqlInput!
+  ): JsonbIdentityMutationPlpgsqlPayload
+  jsonbIdentityMutationPlpgsqlWithDefault(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationPlpgsqlWithDefaultInput!
+  ): JsonbIdentityMutationPlpgsqlWithDefaultPayload
+  noArgsMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload
+  tableMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TableMutationInput!
+  ): TableMutationPayload
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload
+  typesMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TypesMutationInput!
+  ): TypesMutationPayload
+
+  \\"\\"\\"
+  Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  \\"\\"\\"Updates a single \`CompoundKey\` using a unique key and a patch.\\"\\"\\"
+  updateCompoundKeyByPersonId1AndPersonId2(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using its globally unique id and a patch.\\"\\"\\"
+  updateLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByPersonIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
+  updatePerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"Updates a single \`Person\` using a unique key and a patch.\\"\\"\\"
+  updatePersonByEmail(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"Updates a single \`Person\` using a unique key and a patch.\\"\\"\\"
+  updatePersonById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonByIdInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"
+  Updates a single \`PersonSecret\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updatePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretInput!
+  ): UpdatePersonSecretPayload
+
+  \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
+  updatePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretByPersonIdInput!
+  ): UpdatePersonSecretPayload
+}
+
+\\"\\"\\"All input for the \`noArgsMutation\` mutation.\\"\\"\\"
+input NoArgsMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`noArgsMutation\` mutation.\\"\\"\\"
+type NoArgsMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integer: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+interface Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+scalar NotNullUrl
+
+\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+type PageInfo {
+  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  endCursor: Cursor
+
+  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  hasNextPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  hasPreviousPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  startCursor: Cursor
+}
+
+\\"\\"\\"A connection to a list of \`Person\` values.\\"\\"\\"
+type PeopleConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PeopleEdge!]!
+
+  \\"\\"\\"A list of \`Person\` objects.\\"\\"\\"
+  nodes: [Person]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Person\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Person\` edge in the connection.\\"\\"\\"
+type PeopleEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
+  node: Person!
+}
+
+\\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  ALIASES_ASC
+  ALIASES_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SITE_ASC
+  SITE_DESC
+}
+
+\\"\\"\\"Person test comment\\"\\"\\"
+type Person implements Node {
+  about: String
+  aliases: [String]!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId1(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId2(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection!
+  createdAt: Datetime
+  email: Email!
+  exists(email: Email): Boolean
+  firstName: String
+  firstPost: Post
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  friends(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+  id: Int!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection!
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection!
+
+  \\"\\"\\"@deprecated Don’t use me\\"\\"\\"
+  site: WrappedUrl
+}
+
+\\"\\"\\"
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonCondition {
+  \\"\\"\\"Checks for equality with the object’s \`about\` field.\\"\\"\\"
+  about: String
+
+  \\"\\"\\"Checks for equality with the object’s \`aliases\` field.\\"\\"\\"
+  aliases: [String]
+
+  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  createdAt: Datetime
+
+  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  email: Email
+
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`site\` field.\\"\\"\\"
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"An input for mutations affecting \`Person\`\\"\\"\\"
+input PersonInput {
+  about: String
+  aliases: [String]
+  createdAt: Datetime
+  email: Email!
+  id: Int
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String!
+
+  \\"\\"\\"@deprecated Don’t use me\\"\\"\\"
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"
+Represents an update to a \`Person\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonPatch {
+  about: String
+  aliases: [String]
+  createdAt: Datetime
+  email: Email
+  id: Int
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String
+
+  \\"\\"\\"@deprecated Don’t use me\\"\\"\\"
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"An input for mutations affecting \`PersonSecret\`\\"\\"\\"
+input PersonSecretInput {
+  personId: Int!
+  secret: String
+}
+
+\\"\\"\\"
+Represents an update to a \`PersonSecret\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonSecretPatch {
+  personId: Int
+  secret: String
+}
+
+\\"\\"\\"A connection to a list of \`PersonSecret\` values.\\"\\"\\"
+type PersonSecretsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`PersonSecret\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PersonSecretsEdge!]!
+
+  \\"\\"\\"A list of \`PersonSecret\` objects.\\"\\"\\"
+  nodes: [PersonSecret]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`PersonSecret\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
+}
+
+type Post {
+  authorId: Int
+  body: String
+  comptypes: [Comptype]
+  enums: [AnEnum]
+  headline: String!
+  id: Int!
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query implements Node {
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  allCompoundKeys(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`EdgeCase\`.\\"\\"\\"
+  allEdgeCases(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: EdgeCaseCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArms(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  allPeople(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecrets(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection
+
+  \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
+  compoundKey(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundType\`.\\"\\"\\"
+  compoundTypeSetQuery(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): CompoundTypesConnection!
+  intSetQuery(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection!
+  jsonIdentity(json: JSON): JSON
+  jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    nodeId: ID!
+  ): LeftArm
+  leftArmById(id: Int!): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
+  noArgsQuery: Int
+
+  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  node(
+    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    nodeId: ID!
+  ): Node
+
+  \\"\\"\\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
+  person(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Person\`.\\"\\"\\"
+    nodeId: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): PersonSecret
+  personSecretByPersonId(personId: Int!): PersonSecret
+
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+  tableQuery(id: Int): Post
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetQuery(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+\\"\\"\\"All input for the \`tableMutation\` mutation.\\"\\"\\"
+input TableMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int
+}
+
+\\"\\"\\"The output of our \`tableMutation\` mutation.\\"\\"\\"
+type TableMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  post: Post
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`tableSetMutation\` mutation.\\"\\"\\"
+input TableSetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`tableSetMutation\` mutation.\\"\\"\\"
+type TableSetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  people: [Person]
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`typesMutation\` mutation.\\"\\"\\"
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+\\"\\"\\"The output of our \`typesMutation\` mutation.\\"\\"\\"
+type TypesMutationPayload {
+  boolean: Boolean
+
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+\\"\\"\\"
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \\"\\"\\"
+  compoundKeyPatch: CompoundKeyPatch!
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the \`updateCompoundKey\` mutation.\\"\\"\\"
+input UpdateCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \\"\\"\\"
+  compoundKeyPatch: CompoundKeyPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`CompoundKey\` mutation.\\"\\"\\"
+type UpdateCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateLeftArmById\` mutation.\\"\\"\\"
+input UpdateLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+}
+
+\\"\\"\\"All input for the \`updateLeftArmByPersonId\` mutation.\\"\\"\\"
+input UpdateLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArm\` mutation.\\"\\"\\"
+input UpdateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`LeftArm\` mutation.\\"\\"\\"
+type UpdateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonByEmail\` mutation.\\"\\"\\"
+input UpdatePersonByEmailInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  email: Email!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonById\` mutation.\\"\\"\\"
+input UpdatePersonByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"All input for the \`updatePerson\` mutation.\\"\\"\\"
+input UpdatePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"The output of our update \`Person\` mutation.\\"\\"\\"
+type UpdatePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonSecretByPersonId\` mutation.\\"\\"\\"
+input UpdatePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonSecret\` mutation.\\"\\"\\"
+input UpdatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"The output of our update \`PersonSecret\` mutation.\\"\\"\\"
+type UpdatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+\\"\\"\\"
+scalar UUID
+
+type WrappedUrl {
+  url: NotNullUrl!
+}
+
+\\"\\"\\"An input for mutations affecting \`WrappedUrl\`\\"\\"\\"
+input WrappedUrlInput {
+  url: NotNullUrl!
+}
+"
+`;
+
 exports[`prints a schema without parsing tags 1`] = `
 "enum AnEnum {
   _ASTERISK_BAR_

--- a/packages/postgraphile-core/__tests__/integration/schema.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema.test.js
@@ -44,7 +44,15 @@ const testFixtures = [
     name: "prints a schema without parsing tags",
     createSchema: client =>
       createPostGraphQLSchema(client, "c", {
-        enableTags: false
+        enableTags: false,
+      }),
+  },
+  {
+    name: "prints a schema without one-to-one support",
+    createSchema: client =>
+      createPostGraphQLSchema(client, "c", {
+        legacyRelations: "only",
+        enableTags: false,
       }),
   },
 ];

--- a/packages/postgraphile-core/__tests__/integration/schema.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema.test.js
@@ -41,14 +41,16 @@ const testFixtures = [
       }),
   },
   {
-    name: "prints a schema without parsing tags",
+    name:
+      "prints a schema without parsing tags and with legacy relations omitted",
     createSchema: client =>
       createPostGraphQLSchema(client, "c", {
         enableTags: false,
+        legacyRelations: "omit",
       }),
   },
   {
-    name: "prints a schema without one-to-one support",
+    name: "prints a schema without legacy relations", // will be default in v5
     createSchema: client =>
       createPostGraphQLSchema(client, "c", {
         legacyRelations: "only",

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -8,6 +8,20 @@ insert into c.person (id, name, email, about, created_at) values
 
 alter sequence c.person_id_seq restart with 10;
 
+insert into c.person_secret (person_id, secret) values
+  (2, 'Sara Smith is not really my name!'),
+  (3, 'I once got stuck trying to retrieve something embarassing from between two panes of glass'),
+  (5, 'My only secret is that I have no secrets!'),
+  (6, 'I don''t think the bug I test for will ever return!');
+
+insert into c.left_arm (id, person_id, length_in_metres) values
+  (42, 4, 0.60),
+  (45, 2, 0.70),
+  (47, 5, 0.65),
+  (50, 1, 0.65);
+
+alter sequence c.left_arm_id_seq restart with 100;
+
 insert into a.post (id, author_id, headline) values
   (1, 2, 'No… It’s a thing; it’s like a plan, but with more greatness.'),
   (2, 1, 'I hate yogurt. It’s just stuff with bits in.'),

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -29,6 +29,23 @@ create table c.person (
   created_at timestamp default current_timestamp
 );
 
+-- This is to test that "one-to-one" relationships work on primary keys
+create table c.person_secret (
+  person_id int not null primary key references c.person on delete cascade,
+  secret text
+);
+
+comment on table c.person_secret is 'Tracks the person''s secret';
+
+-- This is to test that "one-to-one" relationships also work on unique keys
+create table c.left_arm (
+  id serial primary key,
+  person_id int not null unique references c.person on delete cascade,
+  length_in_metres float
+);
+
+comment on table c.left_arm is 'Tracks metadata about the left arms of various people';
+
 -- This should not add a query to the schema
 create unique index uniq_person__email_id_3 on c.person (email) where (id = 3);
 

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -44,6 +44,7 @@ type PostGraphQLOptions = {
   readCache?: string,
   writeCache?: string,
   setWriteCacheCallback?: (fn: () => Promise<void>) => void,
+  legacyRelations?: "only" | "deprecated",
 };
 
 type PgConfig = Client | Pool | string;
@@ -84,8 +85,10 @@ const getPostGraphQLBuilder = async (
   schemas,
   options: PostGraphQLOptions = {}
 ) => {
-  const { dynamicJson, classicIds, nodeIdFieldName } = options;
   const {
+    dynamicJson,
+    classicIds,
+    nodeIdFieldName,
     replaceAllPlugins,
     appendPlugins = [],
     prependPlugins = [],
@@ -102,7 +105,18 @@ const getPostGraphQLBuilder = async (
     readCache,
     writeCache,
     setWriteCacheCallback,
+    legacyRelations = "deprecated", // TODO: Change to 'omit' in v5
   } = options;
+
+  if (
+    legacyRelations &&
+    ["only", "deprecated", "omit"].indexOf(legacyRelations) < 0
+  ) {
+    throw new Error(
+      "Invalid configuration for legacy relations: " +
+        JSON.stringify(legacyRelations)
+    );
+  }
   if (replaceAllPlugins) {
     ensureValidPlugins("replaceAllPlugins", replaceAllPlugins);
     if (
@@ -201,6 +215,7 @@ const getPostGraphQLBuilder = async (
         pgDisableDefaultMutations: disableDefaultMutations,
         pgViewUniqueKey: viewUniqueKey,
         pgEnableTags: enableTags,
+        pgLegacyRelations: legacyRelations,
         persistentMemoizeWithKey,
       },
       graphileBuildOptions,


### PR DESCRIPTION
This'll add one-to-one relationships - i.e. where a remote table references the current table using a *unique* column.

~~This will be a breaking change (the last planned one before the release of v4), but~~ I'll be adding a flag to allow you to go enable the old behaviour instead. (Actually this should probably be a dual flag so that you can export the old interface as deprecated along with the new interface which isn't?)

This won't be a breaking change because the default for the flag will be to deprecate the old relations (but still support them).

Fixes postgraphql/postgraphql#432
Fixes postgraphql/postgraphql#283
Fixes postgraphql/postgraphql#123