### PR TITLE
fix(compatibility): v3 compatibility tweaks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-runtime", "transform-es2015-modules-commonjs"],
+  "plugins": ["transform-runtime", "transform-es2015-modules-commonjs", "syntax-object-rest-spread"],
   "presets": [
     ["env", {
       "targets": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-eslint": "8.2.1",
+    "babel-plugin-syntax-object-rest-spread": "6.13.0",
     "babel-preset-env": "^1.6.0",
     "concurrently": "^3.5.0",
     "eslint": "^4.0.0",

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -131,7 +131,7 @@ export default (function PgMutationPayloadEdgePlugin(
                   v => v.name === "PRIMARY_KEY_ASC"
                 ) || TableOrderByType.getValues()[0];
               return {
-                description: "An edge for the type. May be used by Relay 1.",
+                description: `An edge for our \`${tableTypeName}\`. May be used by Relay 1.`,
                 type: TableEdgeType,
                 args: {
                   orderBy: {

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -457,6 +457,7 @@ export default (async function PgMutationUpdateDeletePlugin(
                                 key.class.namespace.name
                               )
                             ] = {
+                              description: key.description,
                               type: new GraphQLNonNull(
                                 pgGetGqlInputTypeByTypeId(key.typeId)
                               ),

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -2,22 +2,24 @@
 import type { Plugin } from "graphile-build";
 const base64 = str => new Buffer(String(str)).toString("base64");
 
-function handleNullRow(row) {
-  if (
-    Object.keys(row)
-      .filter(str => !str.startsWith("__"))
-      .some(key => row[key] !== null)
-  ) {
-    return row;
-  } else {
-    return null;
-  }
-}
-
 export default (function PgTablesPlugin(
   builder,
   { pgInflection: inflection, pgForbidSetofFunctionsToReturnNull = false }
 ) {
+  const handleNullRow = pgForbidSetofFunctionsToReturnNull
+    ? row => row
+    : row => {
+        if (
+          Object.keys(row)
+            .filter(str => !str.startsWith("__"))
+            .some(key => row[key] !== null)
+        ) {
+          return row;
+        } else {
+          return null;
+        }
+      };
+
   builder.hook("init", (_, build) => {
     const {
       getNodeIdForTypeAndIdentifiers,

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -2,6 +2,18 @@
 import type { Plugin } from "graphile-build";
 const base64 = str => new Buffer(String(str)).toString("base64");
 
+function handleNullRow(row) {
+  if (
+    Object.keys(row)
+      .filter(str => !str.startsWith("__"))
+      .some(key => row[key] !== null)
+  ) {
+    return row;
+  } else {
+    return null;
+  }
+}
+
 export default (function PgTablesPlugin(
   builder,
   { pgInflection: inflection, pgForbidSetofFunctionsToReturnNull = false }
@@ -266,7 +278,7 @@ export default (function PgTablesPlugin(
                       TableType
                     ),
                     resolve(data) {
-                      return data;
+                      return handleNullRow(data);
                     },
                   },
                 };
@@ -295,7 +307,7 @@ export default (function PgTablesPlugin(
                     description: `A list of \`${tableTypeName}\` objects.`,
                     type: new GraphQLNonNull(new GraphQLList(TableType)),
                     resolve(data) {
-                      return data.data;
+                      return data.data.map(handleNullRow);
                     },
                   },
                   edges: {

--- a/packages/postgraphile-core/__tests__/fixtures/queries/badlyBehavedFunction.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/badlyBehavedFunction.graphql
@@ -1,0 +1,19 @@
+{
+  badlyBehavedFunction {
+    nodes {
+      ...PersonFragment
+    }
+    edges {
+      cursor
+      node {
+        ...PersonFragment
+      }
+    }
+  }
+}
+
+fragment PersonFragment on Person {
+  nodeId
+  id
+  firstName
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`badlyBehavedFunction.graphql 1`] = `
+Object {
+  "data": Object {
+    "badlyBehavedFunction": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwxXQ==",
+          "node": Object {
+            "firstName": "John",
+            "id": 1,
+            "nodeId": "WyJwZW9wbGUiLDFd",
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwyXQ==",
+          "node": null,
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwzXQ==",
+          "node": Object {
+            "firstName": "Twenty",
+            "id": 6,
+            "nodeId": "WyJwZW9wbGUiLDZd",
+          },
+        },
+      ],
+      "nodes": Array [
+        Object {
+          "firstName": "John",
+          "id": 1,
+          "nodeId": "WyJwZW9wbGUiLDFd",
+        },
+        null,
+        Object {
+          "firstName": "Twenty",
+          "id": 6,
+          "nodeId": "WyJwZW9wbGUiLDZd",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`classic-ids.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -2895,7 +2895,7 @@ Object {
     "a": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJuYXR1cmFsIiwxXQ==",
+          "cursor": "WyJ2aWV3X3VuaXF1ZV9rZXlfYXNjIixbMV1d",
           "node": Object {
             "col1": 11,
             "col2": 21,
@@ -2903,7 +2903,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiwyXQ==",
+          "cursor": "WyJ2aWV3X3VuaXF1ZV9rZXlfYXNjIixbMl1d",
           "node": Object {
             "col1": 12,
             "col2": 22,
@@ -2911,7 +2911,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJuYXR1cmFsIiwzXQ==",
+          "cursor": "WyJ2aWV3X3VuaXF1ZV9rZXlfYXNjIixbM11d",
           "node": Object {
             "col1": 13,
             "col2": 23,
@@ -2923,7 +2923,7 @@ Object {
     "b": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJjb2wxX2Rlc2MiLDNd",
+          "cursor": "WyJjb2wxX2Rlc2MiLFsxMywzXV0=",
           "node": Object {
             "col1": 13,
             "col2": 23,
@@ -2931,7 +2931,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb2wxX2Rlc2MiLDJd",
+          "cursor": "WyJjb2wxX2Rlc2MiLFsxMiwyXV0=",
           "node": Object {
             "col1": 12,
             "col2": 22,
@@ -2939,7 +2939,7 @@ Object {
           },
         },
         Object {
-          "cursor": "WyJjb2wxX2Rlc2MiLDFd",
+          "cursor": "WyJjb2wxX2Rlc2MiLFsxMSwxXV0=",
           "node": Object {
             "col1": 11,
             "col2": 21,

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -1745,6 +1745,27 @@ type Query implements Node {
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunction(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
     \\"\\"\\"
@@ -8584,6 +8605,27 @@ type Query implements Node {
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunction(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
     \\"\\"\\"
@@ -12007,6 +12049,27 @@ type Query implements Node {
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunction(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
     \\"\\"\\"
@@ -13976,6 +14039,27 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunction(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -16169,6 +16253,27 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunction(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -188,7 +188,7 @@ type CreateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -229,7 +229,7 @@ type CreateEdgeCasePayload {
   \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
   edgeCase: EdgeCase
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
   edgeCaseEdge(
     \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
@@ -264,7 +264,7 @@ type CreateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -302,7 +302,7 @@ type CreatePersonPayload {
   \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -340,7 +340,7 @@ type CreatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -399,7 +399,7 @@ type DeleteCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -464,7 +464,7 @@ type DeleteLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -496,6 +496,8 @@ input DeletePersonByRowIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   rowId: Int!
 }
 
@@ -525,7 +527,7 @@ type DeletePersonPayload {
   \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -576,7 +578,7 @@ type DeletePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -1447,6 +1449,8 @@ type Person implements Node {
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection! @deprecated(reason: \\"Please use personSecretByPersonId instead\\")
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   rowId: Int!
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
@@ -1486,6 +1490,8 @@ input PersonInput {
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   rowId: Int
   site: WrappedUrlInput
 }
@@ -1501,6 +1507,8 @@ input PersonPatch {
 
   \\"\\"\\"The person’s name\\"\\"\\"
   name: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   rowId: Int
   site: WrappedUrlInput
 }
@@ -1901,7 +1909,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -1993,7 +2001,7 @@ type UpdateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2071,7 +2079,7 @@ type UpdateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2113,6 +2121,8 @@ input UpdatePersonByRowIdInput {
   An object where the defined keys will be set on the \`Person\` being updated.
   \\"\\"\\"
   personPatch: PersonPatch!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   rowId: Int!
 }
 
@@ -2146,7 +2156,7 @@ type UpdatePersonPayload {
   \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2206,7 +2216,7 @@ type UpdatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2492,7 +2502,7 @@ type CreateTypePayload {
   \\"\\"\\"The \`Type\` that was created by this mutation.\\"\\"\\"
   type: Type
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Type\`. May be used by Relay 1.\\"\\"\\"
   typeEdge(
     \\"\\"\\"The method to use when ordering \`Type\`.\\"\\"\\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2527,7 +2537,7 @@ type CreateUpdatableViewPayload {
   \\"\\"\\"The \`UpdatableView\` that was created by this mutation.\\"\\"\\"
   updatableView: UpdatableView
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`UpdatableView\`. May be used by Relay 1.\\"\\"\\"
   updatableViewEdge(
     \\"\\"\\"The method to use when ordering \`UpdatableView\`.\\"\\"\\"
     orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
@@ -2627,7 +2637,7 @@ type DeleteTypePayload {
   \\"\\"\\"The \`Type\` that was deleted by this mutation.\\"\\"\\"
   type: Type
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Type\`. May be used by Relay 1.\\"\\"\\"
   typeEdge(
     \\"\\"\\"The method to use when ordering \`Type\`.\\"\\"\\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3523,7 +3533,7 @@ type UpdateTypePayload {
   \\"\\"\\"The \`Type\` that was updated by this mutation.\\"\\"\\"
   type: Type
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Type\`. May be used by Relay 1.\\"\\"\\"
   typeEdge(
     \\"\\"\\"The method to use when ordering \`Type\`.\\"\\"\\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4100,7 +4110,7 @@ type CreateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4141,7 +4151,7 @@ type CreateDefaultValuePayload {
   \\"\\"\\"The \`DefaultValue\` that was created by this mutation.\\"\\"\\"
   defaultValue: DefaultValue
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`DefaultValue\`. May be used by Relay 1.\\"\\"\\"
   defaultValueEdge(
     \\"\\"\\"The method to use when ordering \`DefaultValue\`.\\"\\"\\"
     orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4176,7 +4186,7 @@ type CreateEdgeCasePayload {
   \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
   edgeCase: EdgeCase
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
   edgeCaseEdge(
     \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
@@ -4214,7 +4224,7 @@ type CreateForeignKeyPayload {
   \\"\\"\\"The \`ForeignKey\` that was created by this mutation.\\"\\"\\"
   foreignKey: ForeignKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ForeignKey\`. May be used by Relay 1.\\"\\"\\"
   foreignKeyEdge(
     \\"\\"\\"The method to use when ordering \`ForeignKey\`.\\"\\"\\"
     orderBy: [ForeignKeysOrderBy!] = [NATURAL]
@@ -4252,7 +4262,7 @@ type CreateInputPayload {
   \\"\\"\\"The \`Input\` that was created by this mutation.\\"\\"\\"
   input: Input
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Input\`. May be used by Relay 1.\\"\\"\\"
   inputEdge(
     \\"\\"\\"The method to use when ordering \`Input\`.\\"\\"\\"
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4287,7 +4297,7 @@ type CreateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4325,7 +4335,7 @@ type CreatePatchPayload {
   \\"\\"\\"The \`Patch\` that was created by this mutation.\\"\\"\\"
   patch: Patch
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Patch\`. May be used by Relay 1.\\"\\"\\"
   patchEdge(
     \\"\\"\\"The method to use when ordering \`Patch\`.\\"\\"\\"
     orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4360,7 +4370,7 @@ type CreatePersonPayload {
   \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4398,7 +4408,7 @@ type CreatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4436,7 +4446,7 @@ type CreatePostPayload {
   \\"\\"\\"The \`Post\` that was created by this mutation.\\"\\"\\"
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4488,7 +4498,7 @@ type CreateReservedInputRecordPayload {
   \\"\\"\\"The \`ReservedInputRecord\` that was created by this mutation.\\"\\"\\"
   reservedInputRecord: ReservedInputRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedInputRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedInputRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
     orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4523,7 +4533,7 @@ type CreateReservedPatchRecordPayload {
   \\"\\"\\"The \`ReservedPatchRecord\` that was created by this mutation.\\"\\"\\"
   reservedPatchRecord: ReservedPatchRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedPatchRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedPatchRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
     orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4546,7 +4556,7 @@ type CreateReservedPayload {
   \\"\\"\\"The \`Reserved\` that was created by this mutation.\\"\\"\\"
   reserved: Reserved
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Reserved\`. May be used by Relay 1.\\"\\"\\"
   reservedEdge(
     \\"\\"\\"The method to use when ordering \`Reserved\`.\\"\\"\\"
     orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4581,7 +4591,7 @@ type CreateSimilarTable1Payload {
   \\"\\"\\"The \`SimilarTable1\` that was created by this mutation.\\"\\"\\"
   similarTable1: SimilarTable1
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\\"\\"\\"
   similarTable1Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable1\`.\\"\\"\\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4616,7 +4626,7 @@ type CreateSimilarTable2Payload {
   \\"\\"\\"The \`SimilarTable2\` that was created by this mutation.\\"\\"\\"
   similarTable2: SimilarTable2
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\\"\\"\\"
   similarTable2Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable2\`.\\"\\"\\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4651,7 +4661,7 @@ type CreateTestviewPayload {
   \\"\\"\\"The \`Testview\` that was created by this mutation.\\"\\"\\"
   testview: Testview
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Testview\`. May be used by Relay 1.\\"\\"\\"
   testviewEdge(
     \\"\\"\\"The method to use when ordering \`Testview\`.\\"\\"\\"
     orderBy: [TestviewsOrderBy!] = [NATURAL]
@@ -4686,7 +4696,7 @@ type CreateTypePayload {
   \\"\\"\\"The \`Type\` that was created by this mutation.\\"\\"\\"
   type: Type
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Type\`. May be used by Relay 1.\\"\\"\\"
   typeEdge(
     \\"\\"\\"The method to use when ordering \`Type\`.\\"\\"\\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4721,7 +4731,7 @@ type CreateUpdatableViewPayload {
   \\"\\"\\"The \`UpdatableView\` that was created by this mutation.\\"\\"\\"
   updatableView: UpdatableView
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`UpdatableView\`. May be used by Relay 1.\\"\\"\\"
   updatableViewEdge(
     \\"\\"\\"The method to use when ordering \`UpdatableView\`.\\"\\"\\"
     orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
@@ -4756,7 +4766,7 @@ type CreateViewTablePayload {
   \\"\\"\\"The \`ViewTable\` that was created by this mutation.\\"\\"\\"
   viewTable: ViewTable
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ViewTable\`. May be used by Relay 1.\\"\\"\\"
   viewTableEdge(
     \\"\\"\\"The method to use when ordering \`ViewTable\`.\\"\\"\\"
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4926,7 +4936,7 @@ type DeleteCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -4980,7 +4990,7 @@ type DeleteDefaultValuePayload {
   \\"\\"\\"The \`DefaultValue\` that was deleted by this mutation.\\"\\"\\"
   defaultValue: DefaultValue
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`DefaultValue\`. May be used by Relay 1.\\"\\"\\"
   defaultValueEdge(
     \\"\\"\\"The method to use when ordering \`DefaultValue\`.\\"\\"\\"
     orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5029,7 +5039,7 @@ type DeleteInputPayload {
   \\"\\"\\"The \`Input\` that was deleted by this mutation.\\"\\"\\"
   input: Input
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Input\`. May be used by Relay 1.\\"\\"\\"
   inputEdge(
     \\"\\"\\"The method to use when ordering \`Input\`.\\"\\"\\"
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5087,7 +5097,7 @@ type DeleteLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5138,7 +5148,7 @@ type DeletePatchPayload {
   \\"\\"\\"The \`Patch\` that was deleted by this mutation.\\"\\"\\"
   patch: Patch
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Patch\`. May be used by Relay 1.\\"\\"\\"
   patchEdge(
     \\"\\"\\"The method to use when ordering \`Patch\`.\\"\\"\\"
     orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5167,6 +5177,8 @@ input DeletePersonByIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 }
 
@@ -5196,7 +5208,7 @@ type DeletePersonPayload {
   \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5247,7 +5259,7 @@ type DeletePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5298,7 +5310,7 @@ type DeletePostPayload {
   \\"\\"\\"The \`Post\` that was deleted by this mutation.\\"\\"\\"
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5375,7 +5387,7 @@ type DeleteReservedInputRecordPayload {
   \\"\\"\\"The \`ReservedInputRecord\` that was deleted by this mutation.\\"\\"\\"
   reservedInputRecord: ReservedInputRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedInputRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedInputRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
     orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5423,7 +5435,7 @@ type DeleteReservedPatchRecordPayload {
   \\"\\"\\"The \`ReservedPatchRecord\` that was deleted by this mutation.\\"\\"\\"
   reservedPatchRecord: ReservedPatchRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedPatchRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedPatchRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
     orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5447,7 +5459,7 @@ type DeleteReservedPayload {
   \\"\\"\\"The \`Reserved\` that was deleted by this mutation.\\"\\"\\"
   reserved: Reserved
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Reserved\`. May be used by Relay 1.\\"\\"\\"
   reservedEdge(
     \\"\\"\\"The method to use when ordering \`Reserved\`.\\"\\"\\"
     orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5495,7 +5507,7 @@ type DeleteSimilarTable1Payload {
   \\"\\"\\"The \`SimilarTable1\` that was deleted by this mutation.\\"\\"\\"
   similarTable1: SimilarTable1
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\\"\\"\\"
   similarTable1Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable1\`.\\"\\"\\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5543,7 +5555,7 @@ type DeleteSimilarTable2Payload {
   \\"\\"\\"The \`SimilarTable2\` that was deleted by this mutation.\\"\\"\\"
   similarTable2: SimilarTable2
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\\"\\"\\"
   similarTable2Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable2\`.\\"\\"\\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5591,7 +5603,7 @@ type DeleteTypePayload {
   \\"\\"\\"The \`Type\` that was deleted by this mutation.\\"\\"\\"
   type: Type
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Type\`. May be used by Relay 1.\\"\\"\\"
   typeEdge(
     \\"\\"\\"The method to use when ordering \`Type\`.\\"\\"\\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5639,7 +5651,7 @@ type DeleteViewTablePayload {
   \\"\\"\\"The \`ViewTable\` that was deleted by this mutation.\\"\\"\\"
   viewTable: ViewTable
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ViewTable\`. May be used by Relay 1.\\"\\"\\"
   viewTableEdge(
     \\"\\"\\"The method to use when ordering \`ViewTable\`.\\"\\"\\"
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -7548,6 +7560,8 @@ type Person implements Node {
     \\"\\"\\"
     offset: Int
   ): PeopleConnection!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
@@ -7685,6 +7699,8 @@ input PersonInput {
   aliases: [String]
   createdAt: Datetime
   email: Email!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -7700,6 +7716,8 @@ input PersonPatch {
   aliases: [String]
   createdAt: Datetime
   email: Email
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -7867,7 +7885,7 @@ type PostManyPayload {
   \\"\\"\\"Reads a single \`Person\` that is related to this \`Post\`.\\"\\"\\"
   personByAuthorId: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -7960,7 +7978,7 @@ type PostWithSuffixPayload {
   personByAuthorId: Person
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -9420,7 +9438,7 @@ type TableMutationPayload {
   personByAuthorId: Person
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -9450,7 +9468,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -9993,7 +10011,7 @@ type UpdateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10056,7 +10074,7 @@ type UpdateDefaultValuePayload {
   \\"\\"\\"The \`DefaultValue\` that was updated by this mutation.\\"\\"\\"
   defaultValue: DefaultValue
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`DefaultValue\`. May be used by Relay 1.\\"\\"\\"
   defaultValueEdge(
     \\"\\"\\"The method to use when ordering \`DefaultValue\`.\\"\\"\\"
     orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10113,7 +10131,7 @@ type UpdateInputPayload {
   \\"\\"\\"The \`Input\` that was updated by this mutation.\\"\\"\\"
   input: Input
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Input\`. May be used by Relay 1.\\"\\"\\"
   inputEdge(
     \\"\\"\\"The method to use when ordering \`Input\`.\\"\\"\\"
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10185,7 +10203,7 @@ type UpdateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10245,7 +10263,7 @@ type UpdatePatchPayload {
   \\"\\"\\"The \`Patch\` that was updated by this mutation.\\"\\"\\"
   patch: Patch
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Patch\`. May be used by Relay 1.\\"\\"\\"
   patchEdge(
     \\"\\"\\"The method to use when ordering \`Patch\`.\\"\\"\\"
     orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10279,6 +10297,8 @@ input UpdatePersonByIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"
@@ -10317,7 +10337,7 @@ type UpdatePersonPayload {
   \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10377,7 +10397,7 @@ type UpdatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10437,7 +10457,7 @@ type UpdatePostPayload {
   \\"\\"\\"The \`Post\` that was updated by this mutation.\\"\\"\\"
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10533,7 +10553,7 @@ type UpdateReservedInputRecordPayload {
   \\"\\"\\"The \`ReservedInputRecord\` that was updated by this mutation.\\"\\"\\"
   reservedInputRecord: ReservedInputRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedInputRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedInputRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
     orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10590,7 +10610,7 @@ type UpdateReservedPatchRecordPayload {
   \\"\\"\\"The \`ReservedPatchRecord\` that was updated by this mutation.\\"\\"\\"
   reservedPatchRecord: ReservedPatchRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedPatchRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedPatchRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
     orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10613,7 +10633,7 @@ type UpdateReservedPayload {
   \\"\\"\\"The \`Reserved\` that was updated by this mutation.\\"\\"\\"
   reserved: Reserved
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Reserved\`. May be used by Relay 1.\\"\\"\\"
   reservedEdge(
     \\"\\"\\"The method to use when ordering \`Reserved\`.\\"\\"\\"
     orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10670,7 +10690,7 @@ type UpdateSimilarTable1Payload {
   \\"\\"\\"The \`SimilarTable1\` that was updated by this mutation.\\"\\"\\"
   similarTable1: SimilarTable1
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\\"\\"\\"
   similarTable1Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable1\`.\\"\\"\\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10727,7 +10747,7 @@ type UpdateSimilarTable2Payload {
   \\"\\"\\"The \`SimilarTable2\` that was updated by this mutation.\\"\\"\\"
   similarTable2: SimilarTable2
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\\"\\"\\"
   similarTable2Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable2\`.\\"\\"\\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10784,7 +10804,7 @@ type UpdateTypePayload {
   \\"\\"\\"The \`Type\` that was updated by this mutation.\\"\\"\\"
   type: Type
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Type\`. May be used by Relay 1.\\"\\"\\"
   typeEdge(
     \\"\\"\\"The method to use when ordering \`Type\`.\\"\\"\\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -10841,7 +10861,7 @@ type UpdateViewTablePayload {
   \\"\\"\\"The \`ViewTable\` that was updated by this mutation.\\"\\"\\"
   viewTable: ViewTable
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ViewTable\`. May be used by Relay 1.\\"\\"\\"
   viewTableEdge(
     \\"\\"\\"The method to use when ordering \`ViewTable\`.\\"\\"\\"
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -11665,6 +11685,8 @@ type Person implements Node {
     \\"\\"\\"
     offset: Int
   ): PeopleConnection!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
@@ -12149,7 +12171,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12397,7 +12419,7 @@ type CreateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12438,7 +12460,7 @@ type CreateEdgeCasePayload {
   \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
   edgeCase: EdgeCase
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
   edgeCaseEdge(
     \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
@@ -12473,7 +12495,7 @@ type CreateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12511,7 +12533,7 @@ type CreatePersonPayload {
   \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12549,7 +12571,7 @@ type CreatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12608,7 +12630,7 @@ type DeleteCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12673,7 +12695,7 @@ type DeleteLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12705,6 +12727,8 @@ input DeletePersonByIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 }
 
@@ -12734,7 +12758,7 @@ type DeletePersonPayload {
   \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -12785,7 +12809,7 @@ type DeletePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -13585,6 +13609,8 @@ type Person implements Node {
     \\"\\"\\"
     offset: Int
   ): PeopleConnection!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
@@ -13689,6 +13715,8 @@ input PersonInput {
   aliases: [String]
   createdAt: Datetime
   email: Email!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -13706,6 +13734,8 @@ input PersonPatch {
   aliases: [String]
   createdAt: Datetime
   email: Email
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -14111,7 +14141,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14203,7 +14233,7 @@ type UpdateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14281,7 +14311,7 @@ type UpdateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14318,6 +14348,8 @@ input UpdatePersonByIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"
@@ -14356,7 +14388,7 @@ type UpdatePersonPayload {
   \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14416,7 +14448,7 @@ type UpdatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14632,7 +14664,7 @@ type CreateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14673,7 +14705,7 @@ type CreateEdgeCasePayload {
   \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
   edgeCase: EdgeCase
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
   edgeCaseEdge(
     \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
@@ -14708,7 +14740,7 @@ type CreateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14746,7 +14778,7 @@ type CreatePersonPayload {
   \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14784,7 +14816,7 @@ type CreatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14843,7 +14875,7 @@ type DeleteCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14908,7 +14940,7 @@ type DeleteLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -14940,6 +14972,8 @@ input DeletePersonByIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 }
 
@@ -14969,7 +15003,7 @@ type DeletePersonPayload {
   \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -15020,7 +15054,7 @@ type DeletePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -15820,6 +15854,8 @@ type Person implements Node {
     \\"\\"\\"
     offset: Int
   ): PeopleConnection!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
@@ -15872,6 +15908,8 @@ input PersonInput {
   aliases: [String]
   createdAt: Datetime
   email: Email!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -15889,6 +15927,8 @@ input PersonPatch {
   aliases: [String]
   createdAt: Datetime
   email: Email
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int
 
   \\"\\"\\"The person’s name\\"\\"\\"
@@ -16294,7 +16334,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16386,7 +16426,7 @@ type UpdateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
   compoundKeyEdge(
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16464,7 +16504,7 @@ type UpdateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
   leftArmEdge(
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16501,6 +16541,8 @@ input UpdatePersonByIdInput {
   payload verbatim. May be used to track mutations by the client.
   \\"\\"\\"
   clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
   \\"\\"\\"
@@ -16539,7 +16581,7 @@ type UpdatePersonPayload {
   \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
   personEdge(
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16599,7 +16641,7 @@ type UpdatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16825,7 +16867,7 @@ type CreateDefaultValuePayload {
   \\"\\"\\"The \`DefaultValue\` that was created by this mutation.\\"\\"\\"
   defaultValue: DefaultValue
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`DefaultValue\`. May be used by Relay 1.\\"\\"\\"
   defaultValueEdge(
     \\"\\"\\"The method to use when ordering \`DefaultValue\`.\\"\\"\\"
     orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16860,7 +16902,7 @@ type CreateForeignKeyPayload {
   \\"\\"\\"The \`ForeignKey\` that was created by this mutation.\\"\\"\\"
   foreignKey: ForeignKey
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ForeignKey\`. May be used by Relay 1.\\"\\"\\"
   foreignKeyEdge(
     \\"\\"\\"The method to use when ordering \`ForeignKey\`.\\"\\"\\"
     orderBy: [ForeignKeysOrderBy!] = [NATURAL]
@@ -16895,7 +16937,7 @@ type CreateInputPayload {
   \\"\\"\\"The \`Input\` that was created by this mutation.\\"\\"\\"
   input: Input
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Input\`. May be used by Relay 1.\\"\\"\\"
   inputEdge(
     \\"\\"\\"The method to use when ordering \`Input\`.\\"\\"\\"
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16930,7 +16972,7 @@ type CreatePatchPayload {
   \\"\\"\\"The \`Patch\` that was created by this mutation.\\"\\"\\"
   patch: Patch
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Patch\`. May be used by Relay 1.\\"\\"\\"
   patchEdge(
     \\"\\"\\"The method to use when ordering \`Patch\`.\\"\\"\\"
     orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -16965,7 +17007,7 @@ type CreatePostPayload {
   \\"\\"\\"The \`Post\` that was created by this mutation.\\"\\"\\"
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17017,7 +17059,7 @@ type CreateReservedInputRecordPayload {
   \\"\\"\\"The \`ReservedInputRecord\` that was created by this mutation.\\"\\"\\"
   reservedInputRecord: ReservedInputRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedInputRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedInputRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
     orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17052,7 +17094,7 @@ type CreateReservedPatchRecordPayload {
   \\"\\"\\"The \`ReservedPatchRecord\` that was created by this mutation.\\"\\"\\"
   reservedPatchRecord: ReservedPatchRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedPatchRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedPatchRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
     orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17075,7 +17117,7 @@ type CreateReservedPayload {
   \\"\\"\\"The \`Reserved\` that was created by this mutation.\\"\\"\\"
   reserved: Reserved
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Reserved\`. May be used by Relay 1.\\"\\"\\"
   reservedEdge(
     \\"\\"\\"The method to use when ordering \`Reserved\`.\\"\\"\\"
     orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17110,7 +17152,7 @@ type CreateSimilarTable1Payload {
   \\"\\"\\"The \`SimilarTable1\` that was created by this mutation.\\"\\"\\"
   similarTable1: SimilarTable1
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\\"\\"\\"
   similarTable1Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable1\`.\\"\\"\\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17145,7 +17187,7 @@ type CreateSimilarTable2Payload {
   \\"\\"\\"The \`SimilarTable2\` that was created by this mutation.\\"\\"\\"
   similarTable2: SimilarTable2
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\\"\\"\\"
   similarTable2Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable2\`.\\"\\"\\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17180,7 +17222,7 @@ type CreateTestviewPayload {
   \\"\\"\\"The \`Testview\` that was created by this mutation.\\"\\"\\"
   testview: Testview
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Testview\`. May be used by Relay 1.\\"\\"\\"
   testviewEdge(
     \\"\\"\\"The method to use when ordering \`Testview\`.\\"\\"\\"
     orderBy: [TestviewsOrderBy!] = [NATURAL]
@@ -17215,7 +17257,7 @@ type CreateViewTablePayload {
   \\"\\"\\"The \`ViewTable\` that was created by this mutation.\\"\\"\\"
   viewTable: ViewTable
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ViewTable\`. May be used by Relay 1.\\"\\"\\"
   viewTableEdge(
     \\"\\"\\"The method to use when ordering \`ViewTable\`.\\"\\"\\"
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17339,7 +17381,7 @@ type DeleteDefaultValuePayload {
   \\"\\"\\"The \`DefaultValue\` that was deleted by this mutation.\\"\\"\\"
   defaultValue: DefaultValue
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`DefaultValue\`. May be used by Relay 1.\\"\\"\\"
   defaultValueEdge(
     \\"\\"\\"The method to use when ordering \`DefaultValue\`.\\"\\"\\"
     orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17388,7 +17430,7 @@ type DeleteInputPayload {
   \\"\\"\\"The \`Input\` that was deleted by this mutation.\\"\\"\\"
   input: Input
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Input\`. May be used by Relay 1.\\"\\"\\"
   inputEdge(
     \\"\\"\\"The method to use when ordering \`Input\`.\\"\\"\\"
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17436,7 +17478,7 @@ type DeletePatchPayload {
   \\"\\"\\"The \`Patch\` that was deleted by this mutation.\\"\\"\\"
   patch: Patch
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Patch\`. May be used by Relay 1.\\"\\"\\"
   patchEdge(
     \\"\\"\\"The method to use when ordering \`Patch\`.\\"\\"\\"
     orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17484,7 +17526,7 @@ type DeletePostPayload {
   \\"\\"\\"The \`Post\` that was deleted by this mutation.\\"\\"\\"
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17561,7 +17603,7 @@ type DeleteReservedInputRecordPayload {
   \\"\\"\\"The \`ReservedInputRecord\` that was deleted by this mutation.\\"\\"\\"
   reservedInputRecord: ReservedInputRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedInputRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedInputRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
     orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17609,7 +17651,7 @@ type DeleteReservedPatchRecordPayload {
   \\"\\"\\"The \`ReservedPatchRecord\` that was deleted by this mutation.\\"\\"\\"
   reservedPatchRecord: ReservedPatchRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedPatchRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedPatchRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
     orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17633,7 +17675,7 @@ type DeleteReservedPayload {
   \\"\\"\\"The \`Reserved\` that was deleted by this mutation.\\"\\"\\"
   reserved: Reserved
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Reserved\`. May be used by Relay 1.\\"\\"\\"
   reservedEdge(
     \\"\\"\\"The method to use when ordering \`Reserved\`.\\"\\"\\"
     orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17681,7 +17723,7 @@ type DeleteSimilarTable1Payload {
   \\"\\"\\"The \`SimilarTable1\` that was deleted by this mutation.\\"\\"\\"
   similarTable1: SimilarTable1
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\\"\\"\\"
   similarTable1Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable1\`.\\"\\"\\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17729,7 +17771,7 @@ type DeleteSimilarTable2Payload {
   \\"\\"\\"The \`SimilarTable2\` that was deleted by this mutation.\\"\\"\\"
   similarTable2: SimilarTable2
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\\"\\"\\"
   similarTable2Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable2\`.\\"\\"\\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -17777,7 +17819,7 @@ type DeleteViewTablePayload {
   \\"\\"\\"The \`ViewTable\` that was deleted by this mutation.\\"\\"\\"
   viewTable: ViewTable
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ViewTable\`. May be used by Relay 1.\\"\\"\\"
   viewTableEdge(
     \\"\\"\\"The method to use when ordering \`ViewTable\`.\\"\\"\\"
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -18642,7 +18684,7 @@ type PostManyPayload {
   \\"\\"\\"
   clientMutationId: String
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -18729,7 +18771,7 @@ type PostWithSuffixPayload {
   clientMutationId: String
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -19963,7 +20005,7 @@ type UpdateDefaultValuePayload {
   \\"\\"\\"The \`DefaultValue\` that was updated by this mutation.\\"\\"\\"
   defaultValue: DefaultValue
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`DefaultValue\`. May be used by Relay 1.\\"\\"\\"
   defaultValueEdge(
     \\"\\"\\"The method to use when ordering \`DefaultValue\`.\\"\\"\\"
     orderBy: [DefaultValuesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20020,7 +20062,7 @@ type UpdateInputPayload {
   \\"\\"\\"The \`Input\` that was updated by this mutation.\\"\\"\\"
   input: Input
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Input\`. May be used by Relay 1.\\"\\"\\"
   inputEdge(
     \\"\\"\\"The method to use when ordering \`Input\`.\\"\\"\\"
     orderBy: [InputsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20077,7 +20119,7 @@ type UpdatePatchPayload {
   \\"\\"\\"The \`Patch\` that was updated by this mutation.\\"\\"\\"
   patch: Patch
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Patch\`. May be used by Relay 1.\\"\\"\\"
   patchEdge(
     \\"\\"\\"The method to use when ordering \`Patch\`.\\"\\"\\"
     orderBy: [PatchesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20134,7 +20176,7 @@ type UpdatePostPayload {
   \\"\\"\\"The \`Post\` that was updated by this mutation.\\"\\"\\"
   post: Post
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Post\`. May be used by Relay 1.\\"\\"\\"
   postEdge(
     \\"\\"\\"The method to use when ordering \`Post\`.\\"\\"\\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20230,7 +20272,7 @@ type UpdateReservedInputRecordPayload {
   \\"\\"\\"The \`ReservedInputRecord\` that was updated by this mutation.\\"\\"\\"
   reservedInputRecord: ReservedInputRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedInputRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedInputRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
     orderBy: [ReservedInputRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20287,7 +20329,7 @@ type UpdateReservedPatchRecordPayload {
   \\"\\"\\"The \`ReservedPatchRecord\` that was updated by this mutation.\\"\\"\\"
   reservedPatchRecord: ReservedPatchRecord
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ReservedPatchRecord\`. May be used by Relay 1.\\"\\"\\"
   reservedPatchRecordEdge(
     \\"\\"\\"The method to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
     orderBy: [ReservedPatchRecordsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20310,7 +20352,7 @@ type UpdateReservedPayload {
   \\"\\"\\"The \`Reserved\` that was updated by this mutation.\\"\\"\\"
   reserved: Reserved
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`Reserved\`. May be used by Relay 1.\\"\\"\\"
   reservedEdge(
     \\"\\"\\"The method to use when ordering \`Reserved\`.\\"\\"\\"
     orderBy: [ReservedsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20367,7 +20409,7 @@ type UpdateSimilarTable1Payload {
   \\"\\"\\"The \`SimilarTable1\` that was updated by this mutation.\\"\\"\\"
   similarTable1: SimilarTable1
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\\"\\"\\"
   similarTable1Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable1\`.\\"\\"\\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20424,7 +20466,7 @@ type UpdateSimilarTable2Payload {
   \\"\\"\\"The \`SimilarTable2\` that was updated by this mutation.\\"\\"\\"
   similarTable2: SimilarTable2
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\\"\\"\\"
   similarTable2Edge(
     \\"\\"\\"The method to use when ordering \`SimilarTable2\`.\\"\\"\\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -20481,7 +20523,7 @@ type UpdateViewTablePayload {
   \\"\\"\\"The \`ViewTable\` that was updated by this mutation.\\"\\"\\"
   viewTable: ViewTable
 
-  \\"\\"\\"An edge for the type. May be used by Relay 1.\\"\\"\\"
+  \\"\\"\\"An edge for our \`ViewTable\`. May be used by Relay 1.\\"\\"\\"
   viewTableEdge(
     \\"\\"\\"The method to use when ordering \`ViewTable\`.\\"\\"\\"
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -106,7 +106,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey
+  node: CompoundKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -157,7 +157,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType
+  node: CompoundType!
 }
 
 type Comptype {
@@ -642,7 +642,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase
+  node: EdgeCase!
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -726,7 +726,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
@@ -912,7 +912,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm
+  node: LeftArm!
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -1265,7 +1265,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person
+  node: Person!
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -1575,7 +1575,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret
+  node: PersonSecret!
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -3357,7 +3357,7 @@ type TypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Type\` at the end of the edge.\\"\\"\\"
-  node: Type
+  node: Type!
 }
 
 \\"\\"\\"Methods to use when ordering \`Type\`.\\"\\"\\"
@@ -3488,7 +3488,7 @@ type UpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`UpdatableView\` at the end of the edge.\\"\\"\\"
-  node: UpdatableView
+  node: UpdatableView!
 }
 
 \\"\\"\\"Methods to use when ordering \`UpdatableView\`.\\"\\"\\"
@@ -4007,7 +4007,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey
+  node: CompoundKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -4094,7 +4094,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType
+  node: CompoundType!
 }
 
 type Comptype {
@@ -4905,7 +4905,7 @@ type DefaultValuesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`DefaultValue\` at the end of the edge.\\"\\"\\"
-  node: DefaultValue
+  node: DefaultValue!
 }
 
 \\"\\"\\"Methods to use when ordering \`DefaultValue\`.\\"\\"\\"
@@ -5731,7 +5731,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase
+  node: EdgeCase!
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -5837,7 +5837,7 @@ type ForeignKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ForeignKey\` at the end of the edge.\\"\\"\\"
-  node: ForeignKey
+  node: ForeignKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`ForeignKey\`.\\"\\"\\"
@@ -5931,7 +5931,7 @@ type InputsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Input\` at the end of the edge.\\"\\"\\"
-  node: Input
+  node: Input!
 }
 
 \\"\\"\\"Methods to use when ordering \`Input\`.\\"\\"\\"
@@ -6032,7 +6032,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
@@ -6227,7 +6227,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm
+  node: LeftArm!
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -7297,7 +7297,7 @@ type NonUpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`NonUpdatableView\` at the end of the edge.\\"\\"\\"
-  node: NonUpdatableView
+  node: NonUpdatableView!
 }
 
 \\"\\"\\"Methods to use when ordering \`NonUpdatableView\`.\\"\\"\\"
@@ -7393,7 +7393,7 @@ type PatchesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Patch\` at the end of the edge.\\"\\"\\"
-  node: Patch
+  node: Patch!
 }
 
 \\"\\"\\"Methods to use when ordering \`Patch\`.\\"\\"\\"
@@ -7440,7 +7440,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person
+  node: Person!
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -7808,7 +7808,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret
+  node: PersonSecret!
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -7954,7 +7954,7 @@ type PostsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Post\` at the end of the edge.\\"\\"\\"
-  node: Post
+  node: Post!
 }
 
 \\"\\"\\"Methods to use when ordering \`Post\`.\\"\\"\\"
@@ -9008,7 +9008,7 @@ type ReservedInputRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedInputRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedInputRecord
+  node: ReservedInputRecord!
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
@@ -9085,7 +9085,7 @@ type ReservedPatchRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedPatchRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedPatchRecord
+  node: ReservedPatchRecord!
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
@@ -9120,7 +9120,7 @@ type ReservedsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Reserved\` at the end of the edge.\\"\\"\\"
-  node: Reserved
+  node: Reserved!
 }
 
 \\"\\"\\"Methods to use when ordering \`Reserved\`.\\"\\"\\"
@@ -9226,7 +9226,7 @@ type SimilarTable1SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable1\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable1
+  node: SimilarTable1!
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable1\`.\\"\\"\\"
@@ -9315,7 +9315,7 @@ type SimilarTable2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable2\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable2
+  node: SimilarTable2!
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable2\`.\\"\\"\\"
@@ -9341,7 +9341,7 @@ type StaticBigIntegerConnection {
   edges: [StaticBigIntegerEdge!]!
 
   \\"\\"\\"A list of \`BigInt\` objects.\\"\\"\\"
-  nodes: [BigInt]!
+  nodes: [BigInt!]!
 }
 
 \\"\\"\\"A \`BigInt\` edge in the connection.\\"\\"\\"
@@ -9384,7 +9384,7 @@ type TablefuncCrosstab2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab2\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab2
+  node: TablefuncCrosstab2!
 }
 
 type TablefuncCrosstab3 {
@@ -9419,7 +9419,7 @@ type TablefuncCrosstab3SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab3\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab3
+  node: TablefuncCrosstab3!
 }
 
 type TablefuncCrosstab4 {
@@ -9455,7 +9455,7 @@ type TablefuncCrosstab4SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab4\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab4
+  node: TablefuncCrosstab4!
 }
 
 \\"\\"\\"All input for the \`tableMutation\` mutation.\\"\\"\\"
@@ -9573,7 +9573,7 @@ type TestviewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Testview\` at the end of the edge.\\"\\"\\"
-  node: Testview
+  node: Testview!
 }
 
 \\"\\"\\"Methods to use when ordering \`Testview\`.\\"\\"\\"
@@ -9826,7 +9826,7 @@ type TypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Type\` at the end of the edge.\\"\\"\\"
-  node: Type
+  node: Type!
 }
 
 \\"\\"\\"All input for the \`typesMutation\` mutation.\\"\\"\\"
@@ -9989,7 +9989,7 @@ type UpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`UpdatableView\` at the end of the edge.\\"\\"\\"
-  node: UpdatableView
+  node: UpdatableView!
 }
 
 \\"\\"\\"Methods to use when ordering \`UpdatableView\`.\\"\\"\\"
@@ -10980,7 +10980,7 @@ type ViewTablesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ViewTable\` at the end of the edge.\\"\\"\\"
-  node: ViewTable
+  node: ViewTable!
 }
 
 \\"\\"\\"Methods to use when ordering \`ViewTable\`.\\"\\"\\"
@@ -11097,7 +11097,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey
+  node: CompoundKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -11148,7 +11148,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType
+  node: CompoundType!
 }
 
 type Comptype {
@@ -11210,7 +11210,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase
+  node: EdgeCase!
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -11294,7 +11294,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
@@ -11465,7 +11465,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm
+  node: LeftArm!
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -11615,7 +11615,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person
+  node: Person!
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -11879,7 +11879,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret
+  node: PersonSecret!
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -12400,7 +12400,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey
+  node: CompoundKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -12451,7 +12451,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType
+  node: CompoundType!
 }
 
 type Comptype {
@@ -12936,7 +12936,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase
+  node: EdgeCase!
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -13020,7 +13020,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
@@ -13207,7 +13207,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm
+  node: LeftArm!
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -13560,7 +13560,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person
+  node: Person!
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -13870,7 +13870,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret
+  node: PersonSecret!
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -14666,7 +14666,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey
+  node: CompoundKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -14717,7 +14717,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType
+  node: CompoundType!
 }
 
 type Comptype {
@@ -15202,7 +15202,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase
+  node: EdgeCase!
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -15286,7 +15286,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
@@ -15473,7 +15473,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm
+  node: LeftArm!
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -15826,7 +15826,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person
+  node: Person!
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -16084,7 +16084,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret
+  node: PersonSecret!
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -17437,7 +17437,7 @@ type DefaultValuesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`DefaultValue\` at the end of the edge.\\"\\"\\"
-  node: DefaultValue
+  node: DefaultValue!
 }
 
 \\"\\"\\"Methods to use when ordering \`DefaultValue\`.\\"\\"\\"
@@ -17982,7 +17982,7 @@ type ForeignKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ForeignKey\` at the end of the edge.\\"\\"\\"
-  node: ForeignKey
+  node: ForeignKey!
 }
 
 \\"\\"\\"Methods to use when ordering \`ForeignKey\`.\\"\\"\\"
@@ -18049,7 +18049,7 @@ type InputsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Input\` at the end of the edge.\\"\\"\\"
-  node: Input
+  node: Input!
 }
 
 \\"\\"\\"Methods to use when ordering \`Input\`.\\"\\"\\"
@@ -18608,7 +18608,7 @@ type NonUpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`NonUpdatableView\` at the end of the edge.\\"\\"\\"
-  node: NonUpdatableView
+  node: NonUpdatableView!
 }
 
 \\"\\"\\"Methods to use when ordering \`NonUpdatableView\`.\\"\\"\\"
@@ -18702,7 +18702,7 @@ type PatchesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Patch\` at the end of the edge.\\"\\"\\"
-  node: Patch
+  node: Patch!
 }
 
 \\"\\"\\"Methods to use when ordering \`Patch\`.\\"\\"\\"
@@ -18836,7 +18836,7 @@ type PostsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Post\` at the end of the edge.\\"\\"\\"
-  node: Post
+  node: Post!
 }
 
 \\"\\"\\"Methods to use when ordering \`Post\`.\\"\\"\\"
@@ -19550,7 +19550,7 @@ type ReservedInputRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedInputRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedInputRecord
+  node: ReservedInputRecord!
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
@@ -19627,7 +19627,7 @@ type ReservedPatchRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedPatchRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedPatchRecord
+  node: ReservedPatchRecord!
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
@@ -19662,7 +19662,7 @@ type ReservedsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Reserved\` at the end of the edge.\\"\\"\\"
-  node: Reserved
+  node: Reserved!
 }
 
 \\"\\"\\"Methods to use when ordering \`Reserved\`.\\"\\"\\"
@@ -19768,7 +19768,7 @@ type SimilarTable1SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable1\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable1
+  node: SimilarTable1!
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable1\`.\\"\\"\\"
@@ -19857,7 +19857,7 @@ type SimilarTable2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable2\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable2
+  node: SimilarTable2!
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable2\`.\\"\\"\\"
@@ -19883,7 +19883,7 @@ type StaticBigIntegerConnection {
   edges: [StaticBigIntegerEdge!]!
 
   \\"\\"\\"A list of \`BigInt\` objects.\\"\\"\\"
-  nodes: [BigInt]!
+  nodes: [BigInt!]!
 }
 
 \\"\\"\\"A \`BigInt\` edge in the connection.\\"\\"\\"
@@ -19926,7 +19926,7 @@ type TablefuncCrosstab2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab2\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab2
+  node: TablefuncCrosstab2!
 }
 
 type TablefuncCrosstab3 {
@@ -19961,7 +19961,7 @@ type TablefuncCrosstab3SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab3\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab3
+  node: TablefuncCrosstab3!
 }
 
 type TablefuncCrosstab4 {
@@ -19997,7 +19997,7 @@ type TablefuncCrosstab4SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab4\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab4
+  node: TablefuncCrosstab4!
 }
 
 type Testview {
@@ -20051,7 +20051,7 @@ type TestviewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Testview\` at the end of the edge.\\"\\"\\"
-  node: Testview
+  node: Testview!
 }
 
 \\"\\"\\"Methods to use when ordering \`Testview\`.\\"\\"\\"
@@ -20700,7 +20700,7 @@ type ViewTablesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ViewTable\` at the end of the edge.\\"\\"\\"
-  node: ViewTable
+  node: ViewTable!
 }
 
 \\"\\"\\"Methods to use when ordering \`ViewTable\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -106,7 +106,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -157,7 +157,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType!
+  node: CompoundType
 }
 
 type Comptype {
@@ -642,7 +642,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -912,7 +912,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm!
+  node: LeftArm
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -1265,7 +1265,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person!
+  node: Person
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -1575,7 +1575,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret!
+  node: PersonSecret
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -3336,7 +3336,7 @@ type TypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Type\` at the end of the edge.\\"\\"\\"
-  node: Type!
+  node: Type
 }
 
 \\"\\"\\"Methods to use when ordering \`Type\`.\\"\\"\\"
@@ -3467,7 +3467,7 @@ type UpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`UpdatableView\` at the end of the edge.\\"\\"\\"
-  node: UpdatableView!
+  node: UpdatableView
 }
 
 \\"\\"\\"Methods to use when ordering \`UpdatableView\`.\\"\\"\\"
@@ -3986,7 +3986,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -4073,7 +4073,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType!
+  node: CompoundType
 }
 
 type Comptype {
@@ -4884,7 +4884,7 @@ type DefaultValuesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`DefaultValue\` at the end of the edge.\\"\\"\\"
-  node: DefaultValue!
+  node: DefaultValue
 }
 
 \\"\\"\\"Methods to use when ordering \`DefaultValue\`.\\"\\"\\"
@@ -5710,7 +5710,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -5816,7 +5816,7 @@ type ForeignKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ForeignKey\` at the end of the edge.\\"\\"\\"
-  node: ForeignKey!
+  node: ForeignKey
 }
 
 \\"\\"\\"Methods to use when ordering \`ForeignKey\`.\\"\\"\\"
@@ -5910,7 +5910,7 @@ type InputsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Input\` at the end of the edge.\\"\\"\\"
-  node: Input!
+  node: Input
 }
 
 \\"\\"\\"Methods to use when ordering \`Input\`.\\"\\"\\"
@@ -6206,7 +6206,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm!
+  node: LeftArm
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -7276,7 +7276,7 @@ type NonUpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`NonUpdatableView\` at the end of the edge.\\"\\"\\"
-  node: NonUpdatableView!
+  node: NonUpdatableView
 }
 
 \\"\\"\\"Methods to use when ordering \`NonUpdatableView\`.\\"\\"\\"
@@ -7372,7 +7372,7 @@ type PatchesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Patch\` at the end of the edge.\\"\\"\\"
-  node: Patch!
+  node: Patch
 }
 
 \\"\\"\\"Methods to use when ordering \`Patch\`.\\"\\"\\"
@@ -7419,7 +7419,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person!
+  node: Person
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -7787,7 +7787,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret!
+  node: PersonSecret
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -7933,7 +7933,7 @@ type PostsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Post\` at the end of the edge.\\"\\"\\"
-  node: Post!
+  node: Post
 }
 
 \\"\\"\\"Methods to use when ordering \`Post\`.\\"\\"\\"
@@ -8966,7 +8966,7 @@ type ReservedInputRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedInputRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedInputRecord!
+  node: ReservedInputRecord
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
@@ -9043,7 +9043,7 @@ type ReservedPatchRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedPatchRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedPatchRecord!
+  node: ReservedPatchRecord
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
@@ -9078,7 +9078,7 @@ type ReservedsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Reserved\` at the end of the edge.\\"\\"\\"
-  node: Reserved!
+  node: Reserved
 }
 
 \\"\\"\\"Methods to use when ordering \`Reserved\`.\\"\\"\\"
@@ -9184,7 +9184,7 @@ type SimilarTable1SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable1\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable1!
+  node: SimilarTable1
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable1\`.\\"\\"\\"
@@ -9273,7 +9273,7 @@ type SimilarTable2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable2\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable2!
+  node: SimilarTable2
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable2\`.\\"\\"\\"
@@ -9342,7 +9342,7 @@ type TablefuncCrosstab2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab2\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab2!
+  node: TablefuncCrosstab2
 }
 
 type TablefuncCrosstab3 {
@@ -9377,7 +9377,7 @@ type TablefuncCrosstab3SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab3\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab3!
+  node: TablefuncCrosstab3
 }
 
 type TablefuncCrosstab4 {
@@ -9413,7 +9413,7 @@ type TablefuncCrosstab4SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab4\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab4!
+  node: TablefuncCrosstab4
 }
 
 \\"\\"\\"All input for the \`tableMutation\` mutation.\\"\\"\\"
@@ -9531,7 +9531,7 @@ type TestviewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Testview\` at the end of the edge.\\"\\"\\"
-  node: Testview!
+  node: Testview
 }
 
 \\"\\"\\"Methods to use when ordering \`Testview\`.\\"\\"\\"
@@ -9784,7 +9784,7 @@ type TypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Type\` at the end of the edge.\\"\\"\\"
-  node: Type!
+  node: Type
 }
 
 \\"\\"\\"All input for the \`typesMutation\` mutation.\\"\\"\\"
@@ -9947,7 +9947,7 @@ type UpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`UpdatableView\` at the end of the edge.\\"\\"\\"
-  node: UpdatableView!
+  node: UpdatableView
 }
 
 \\"\\"\\"Methods to use when ordering \`UpdatableView\`.\\"\\"\\"
@@ -10938,7 +10938,7 @@ type ViewTablesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ViewTable\` at the end of the edge.\\"\\"\\"
-  node: ViewTable!
+  node: ViewTable
 }
 
 \\"\\"\\"Methods to use when ordering \`ViewTable\`.\\"\\"\\"
@@ -11055,7 +11055,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -11106,7 +11106,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType!
+  node: CompoundType
 }
 
 type Comptype {
@@ -11168,7 +11168,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -11423,7 +11423,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm!
+  node: LeftArm
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -11573,7 +11573,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person!
+  node: Person
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -11837,7 +11837,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret!
+  node: PersonSecret
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -12337,7 +12337,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -12388,7 +12388,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType!
+  node: CompoundType
 }
 
 type Comptype {
@@ -12873,7 +12873,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -13144,7 +13144,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm!
+  node: LeftArm
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -13497,7 +13497,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person!
+  node: Person
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -13807,7 +13807,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret!
+  node: PersonSecret
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -14582,7 +14582,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
@@ -14633,7 +14633,7 @@ type CompoundTypesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
-  node: CompoundType!
+  node: CompoundType
 }
 
 type Comptype {
@@ -15118,7 +15118,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -15389,7 +15389,7 @@ type LeftArmsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm!
+  node: LeftArm
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -15742,7 +15742,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person!
+  node: Person
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -16000,7 +16000,7 @@ type PersonSecretsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret!
+  node: PersonSecret
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -17332,7 +17332,7 @@ type DefaultValuesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`DefaultValue\` at the end of the edge.\\"\\"\\"
-  node: DefaultValue!
+  node: DefaultValue
 }
 
 \\"\\"\\"Methods to use when ordering \`DefaultValue\`.\\"\\"\\"
@@ -17877,7 +17877,7 @@ type ForeignKeysEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ForeignKey\` at the end of the edge.\\"\\"\\"
-  node: ForeignKey!
+  node: ForeignKey
 }
 
 \\"\\"\\"Methods to use when ordering \`ForeignKey\`.\\"\\"\\"
@@ -17944,7 +17944,7 @@ type InputsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Input\` at the end of the edge.\\"\\"\\"
-  node: Input!
+  node: Input
 }
 
 \\"\\"\\"Methods to use when ordering \`Input\`.\\"\\"\\"
@@ -18503,7 +18503,7 @@ type NonUpdatableViewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`NonUpdatableView\` at the end of the edge.\\"\\"\\"
-  node: NonUpdatableView!
+  node: NonUpdatableView
 }
 
 \\"\\"\\"Methods to use when ordering \`NonUpdatableView\`.\\"\\"\\"
@@ -18597,7 +18597,7 @@ type PatchesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Patch\` at the end of the edge.\\"\\"\\"
-  node: Patch!
+  node: Patch
 }
 
 \\"\\"\\"Methods to use when ordering \`Patch\`.\\"\\"\\"
@@ -18731,7 +18731,7 @@ type PostsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Post\` at the end of the edge.\\"\\"\\"
-  node: Post!
+  node: Post
 }
 
 \\"\\"\\"Methods to use when ordering \`Post\`.\\"\\"\\"
@@ -19445,7 +19445,7 @@ type ReservedInputRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedInputRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedInputRecord!
+  node: ReservedInputRecord
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedInputRecord\`.\\"\\"\\"
@@ -19522,7 +19522,7 @@ type ReservedPatchRecordsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ReservedPatchRecord\` at the end of the edge.\\"\\"\\"
-  node: ReservedPatchRecord!
+  node: ReservedPatchRecord
 }
 
 \\"\\"\\"Methods to use when ordering \`ReservedPatchRecord\`.\\"\\"\\"
@@ -19557,7 +19557,7 @@ type ReservedsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Reserved\` at the end of the edge.\\"\\"\\"
-  node: Reserved!
+  node: Reserved
 }
 
 \\"\\"\\"Methods to use when ordering \`Reserved\`.\\"\\"\\"
@@ -19663,7 +19663,7 @@ type SimilarTable1SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable1\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable1!
+  node: SimilarTable1
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable1\`.\\"\\"\\"
@@ -19752,7 +19752,7 @@ type SimilarTable2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`SimilarTable2\` at the end of the edge.\\"\\"\\"
-  node: SimilarTable2!
+  node: SimilarTable2
 }
 
 \\"\\"\\"Methods to use when ordering \`SimilarTable2\`.\\"\\"\\"
@@ -19821,7 +19821,7 @@ type TablefuncCrosstab2SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab2\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab2!
+  node: TablefuncCrosstab2
 }
 
 type TablefuncCrosstab3 {
@@ -19856,7 +19856,7 @@ type TablefuncCrosstab3SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab3\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab3!
+  node: TablefuncCrosstab3
 }
 
 type TablefuncCrosstab4 {
@@ -19892,7 +19892,7 @@ type TablefuncCrosstab4SEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`TablefuncCrosstab4\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab4!
+  node: TablefuncCrosstab4
 }
 
 type Testview {
@@ -19946,7 +19946,7 @@ type TestviewsEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`Testview\` at the end of the edge.\\"\\"\\"
-  node: Testview!
+  node: Testview
 }
 
 \\"\\"\\"Methods to use when ordering \`Testview\`.\\"\\"\\"
@@ -20595,7 +20595,7 @@ type ViewTablesEdge {
   cursor: Cursor
 
   \\"\\"\\"The \`ViewTable\` at the end of the edge.\\"\\"\\"
-  node: ViewTable!
+  node: ViewTable
 }
 
 \\"\\"\\"Methods to use when ordering \`ViewTable\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -28,7 +28,13 @@ beforeAll(() => {
     // Different fixtures need different schemas with different configurations.
     // Make all of the different schemas with different configurations that we
     // need and wait for them to be created in parallel.
-    const [normal, classicIds, dynamicJson, viewUniqueKey] = await Promise.all([
+    const [
+      normal,
+      classicIds,
+      dynamicJson,
+      pgColumnFilter,
+      viewUniqueKey,
+    ] = await Promise.all([
       createPostGraphQLSchema(pgClient, ["a", "b", "c"]),
       createPostGraphQLSchema(pgClient, ["a", "b", "c"], { classicIds: true }),
       createPostGraphQLSchema(pgClient, ["a", "b", "c"], { dynamicJson: true }),
@@ -37,6 +43,7 @@ beforeAll(() => {
       }),
       createPostGraphQLSchema(pgClient, ["a", "b", "c"], {
         viewUniqueKey: "testviewid",
+        badlyBehavedFunctions: true,
       }),
     ]);
     debug(printSchema(normal));
@@ -44,6 +51,7 @@ beforeAll(() => {
       normal,
       classicIds,
       dynamicJson,
+      pgColumnFilter,
       viewUniqueKey,
     };
   });
@@ -75,6 +83,7 @@ beforeAll(() => {
             "classic-ids.graphql": gqlSchemas.classicIds,
             "dynamic-json.graphql": gqlSchemas.dynamicJson,
             "view.graphql": gqlSchemas.viewUniqueKey,
+            "badlyBehavedFunction.graphql": gqlSchemas.viewUniqueKey,
           };
           const gqlSchema = schemas[fileName]
             ? schemas[fileName]

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -50,6 +50,7 @@ comment on table c.left_arm is 'Tracks metadata about the left arms of various p
 create unique index uniq_person__email_id_3 on c.person (email) where (id = 3);
 
 comment on table c.person is 'Person test comment';
+comment on column c.person.id is 'The primary unique identifier for the person';
 comment on column c.person.name is 'The person’s name';
 comment on column c.person.site is '@deprecated Don’t use me';
 

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -356,3 +356,11 @@ create table a."reservedPatchs" (
   id serial primary key
 );
 comment on table a."reservedPatchs" is '`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table';
+
+create function c.badly_behaved_function() returns setof c.person as $$
+begin
+  return query select * from c.person order by id asc limit 1;
+  return next null;
+  return query select * from c.person order by id desc limit 1;
+end;
+$$ language plpgsql stable;

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -45,7 +45,7 @@ type PostGraphQLOptions = {
   writeCache?: string,
   setWriteCacheCallback?: (fn: () => Promise<void>) => void,
   legacyRelations?: "only" | "deprecated",
-  wellBehavedFunctions?: boolean,
+  badlyBehavedFunctions?: boolean,
 };
 
 type PgConfig = Client | Pool | string;
@@ -107,7 +107,7 @@ const getPostGraphQLBuilder = async (
     writeCache,
     setWriteCacheCallback,
     legacyRelations = "deprecated", // TODO: Change to 'omit' in v5
-    wellBehavedFunctions = false,
+    badlyBehavedFunctions = false,
   } = options;
 
   if (
@@ -219,7 +219,7 @@ const getPostGraphQLBuilder = async (
         pgEnableTags: enableTags,
         pgLegacyRelations: legacyRelations,
         persistentMemoizeWithKey,
-        pgForbidSetofFunctionsToReturnNull: wellBehavedFunctions,
+        pgForbidSetofFunctionsToReturnNull: !badlyBehavedFunctions,
       },
       graphileBuildOptions,
       graphqlBuildOptions // DEPRECATED!

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -45,6 +45,7 @@ type PostGraphQLOptions = {
   writeCache?: string,
   setWriteCacheCallback?: (fn: () => Promise<void>) => void,
   legacyRelations?: "only" | "deprecated",
+  wellBehavedFunctions?: boolean,
 };
 
 type PgConfig = Client | Pool | string;
@@ -106,6 +107,7 @@ const getPostGraphQLBuilder = async (
     writeCache,
     setWriteCacheCallback,
     legacyRelations = "deprecated", // TODO: Change to 'omit' in v5
+    wellBehavedFunctions = false,
   } = options;
 
   if (
@@ -217,6 +219,7 @@ const getPostGraphQLBuilder = async (
         pgEnableTags: enableTags,
         pgLegacyRelations: legacyRelations,
         persistentMemoizeWithKey,
+        pgForbidSetofFunctionsToReturnNull: wellBehavedFunctions,
       },
       graphileBuildOptions,
       graphqlBuildOptions // DEPRECATED!

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,6 +557,10 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
 
+babel-plugin-syntax-object-rest-spread@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"


### PR DESCRIPTION
Add object rest/spread support to babel 🎉 

Tweak/add some comments.

Add `pgForbidSetofFunctionsToReturnNull` / `--no-badly-behaved-functions` option (default: ON ✅ ) - this is a breaking change **if** you return nulls in the middle of `setof` functions (why would you do that?!! 😖 ) - e.g.

```sql
create function c.badly_behaved_function() returns setof c.person as $$
begin
  return query select * from c.person order by id asc limit 1;
  return next null; -- < Returning null in the middle of a function is BAD, mmmmkay?
  return query select * from c.person order by id desc limit 1;
end;
$$ language plpgsql stable;
```

This makes a load of stuff non-null so turning this option off (with `--badly-behaved-functions`) is a breaking change - do it early if you need it!