### PR TITLE
perf(sql): upgrade pg-sql2

### DIFF
--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -43,7 +43,7 @@
     "lodash": ">=4 <5",
     "lru-cache": "4.1.1",
     "pg-range-parser": "^1.0.0",
-    "pg-sql2": "^1.0.0-beta.3",
+    "pg-sql2": "1.0.0-beta.7",
     "pluralize": "^5.0.0",
     "postgres-interval": "1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3894,9 +3894,9 @@ pg-range-parser@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pg-range-parser/-/pg-range-parser-1.0.0.tgz#561e8c4c3dee98a1caa8288c5c7e4300861819bb"
 
-pg-sql2@^1.0.0-beta.3:
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-1.0.0-beta.3.tgz#0bf0f7072c6428e2971e4a25fda71f7eeef8c2f2"
+pg-sql2@1.0.0-beta.7:
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-1.0.0-beta.7.tgz#cf6674f5101af54c8903555c10d013369eb59a10"
   dependencies:
     debug ">=2 <3"
 


### PR DESCRIPTION
Squeezes out a little additional performance through micro-optimisations to pg-sql2

(I can't believe I spent 2 hours on this instead of sleeping... Oh well, fetching no data [from a fairly simple query](https://github.com/graphile/postgraphile_changes/blob/fff2ef4cf8eacfe1ca29a40363bb665a36efebbd/graphql/PopularThreads.graphql) is now about 60% faster... Just think of all the electrons I'm no longer inconveniencing!)