### PR TITLE
fix(sql): still introspect when standard_conforming_strings is off

### DIFF
--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -64,7 +64,7 @@ with
       -- Do not expose trigger functions (type trigger has oid 2279)
       pro.prorettype <> 2279 and
       -- We don't want functions that will clash with GraphQL (treat them as private)
-      pro.proname not like '\_\_%' and
+      pro.proname not like E'\\_\\_%' and
       -- We also don’t want procedures that have been defined in our namespace
       -- twice. This leads to duplicate fields in the API which throws an
       -- error. In the future we may support this case. For now though, it is
@@ -107,7 +107,7 @@ with
     where
       rel.relpersistence in ('p') and
       -- We don't want classes that will clash with GraphQL (treat them as private)
-      rel.relname not like '\_\_%' and
+      rel.relname not like E'\\_\\_%' and
       rel.relkind in ('r', 'v', 'm', 'c', 'f')
     order by
       rel.relnamespace, rel.relname
@@ -130,7 +130,7 @@ with
       att.attrelid in (select "id" from class) and
       att.attnum > 0 and
       -- We don't want attributes that will clash with GraphQL (treat them as private)
-      att.attname not like '\_\_%' and
+      att.attname not like E'\\_\\_%' and
       not att.attisdropped
     order by
       att.attrelid, att.attnum


### PR DESCRIPTION
Since PostgreSQL 9.1 `standard_conforming_strings` has defaulted to `on`; however someone raised an issue in the gitter that PostGraphile wasn't successfully introspecting their database, but no errors were output. PostGraphQL v3 worked fine, so I could simply do a diff of the introspection queries. When running the introspection query the following errors were raised:

```
WARNING:  nonstandard use of escape in a string literal
LINE 61:       pro.proname not like '\_\_%' and
                                    ^
HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
WARNING:  nonstandard use of escape in a string literal
LINE 104:       rel.relname not like '\_\_%' and
                                     ^
HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
WARNING:  nonstandard use of escape in a string literal
LINE 127:       att.attname not like '\_\_%' and
                                     ^
HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
```

This lead me to figure out that `standard_conforming_strings` must be set to off for this user; so all tables, functions, etc that had at least 2 characters in their names were being excluded - hence the empty schema. 😅 

This PR switches to using solid escaped strings to ensure that these backslashes are not swallowed. It's not as pretty but it's more compatible 😁 