### PR TITLE
fix: gracefully handle stale pg_catalog.pg_description

### DIFF
--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -102,7 +102,7 @@ with
       (pg_catalog.pg_relation_is_updatable(rel.oid, true)::bit(8) & B'00000100') = B'00000100' as "isDeletable"
     from
       pg_catalog.pg_class as rel
-      left join pg_catalog.pg_description as dsc on dsc.objoid = rel.oid and dsc.objsubid = 0
+      left join pg_catalog.pg_description as dsc on dsc.objoid = rel.oid and dsc.objsubid = 0 and dsc.classoid = (select oid from pg_catalog.pg_class where relname = 'pg_class')
       left join pg_catalog.pg_namespace as nsp on nsp.oid = rel.relnamespace
     where
       rel.relpersistence in ('p') and


### PR DESCRIPTION
After upgrading a database using `pg_upgrade`, it's possible for stale entries in `pg_description` to exist. These refer to an old `pg_class` system catalog. These need to be filtered out by only including descriptions related to the current `pg_class` system catalog.

---

This is a fix I'm using after upgrading my Postgres 9.6 to Postgres 10.3 RDS instance via AWS (which uses pg_upgrade). It seems that pg_upgrade left behind a stale record in pg_description, which caused this error:

```
Error: Type 'NotesOrderBy' has already been registered! 
    at Object.newWithHooks (/app/node_modules/graphile-build/src/makeNewBuild.js:650:17) 
    at introspectionResultsByKind.class.filter.filter.forEach.table (/app/node_modules/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js:28:11) 
    at Array.forEach (<anonymous>) 
    at PgConnectionArgOrderBy.builder.hook (/app/node_modules/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js:22:10) 
    at SchemaBuilder.applyHooks (/app/node_modules/graphile-build/src/SchemaBuilder.js:292:20) 
    at SchemaBuilder.createBuild (/app/node_modules/graphile-build/src/SchemaBuilder.js:337:10) 
    at SchemaBuilder.buildSchema (/app/node_modules/graphile-build/src/SchemaBuilder.js:343:26) 
    at Object.exports.createPostGraphQLSchema (/app/node_modules/postgraphile-core/src/index.js:235:26) 
    at <anonymous> 
    at process._tickCallback (internal/process/next_tick.js:182:7) 
```

I have a `note` table, and what was happening is that the introspection query was returning two tuples for that table (because there were two items in `pg_catalog.pg_description` associated with that table). This patch narrows the join between `pg_catalog.pg_class` and `pg_catalog.pg_description` to honor the current `pg_class` oid.

This was a fairly serious bug for me, as it meant by node server would not start after upgrading to Postgres 10.3. Fortunately I did this on a staging environment first.