### PR TITLE
feat(collections): add "simple collections"

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.0-beta.7"
+  "version": "4.0.0-beta.7.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.0-beta.7.1"
+  "version": "4.0.0-beta.7.2"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-prettier": "^2.1.2",
+    "eslint_d": "5.3.1",
     "flow-copy-source": "^1.2.0",
     "jest": "^20.0.4",
     "lerna": "^2.0.0",

--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphile-build-pg",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.7.1",
   "description": "Build a GraphQL schema by reflection over a PostgreSQL schema. Easy to customize since it's built with plugins on graphile-build",
   "main": "node8plus/index.js",
   "scripts": {
@@ -36,7 +36,7 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "debug": ">=2 <3",
-    "graphile-build": "4.0.0-beta.7",
+    "graphile-build": "4.0.0-beta.7.1",
     "graphql-iso-date": "^3.2.0",
     "jsonwebtoken": "^8.1.1",
     "lodash": ">=4 <5",

--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphile-build-pg",
-  "version": "4.0.0-beta.7.1",
+  "version": "4.0.0-beta.7.2",
   "description": "Build a GraphQL schema by reflection over a PostgreSQL schema. Easy to customize since it's built with plugins on graphile-build",
   "main": "node8plus/index.js",
   "scripts": {
@@ -36,7 +36,7 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "debug": ">=2 <3",
-    "graphile-build": "4.0.0-beta.7.1",
+    "graphile-build": "4.0.0-beta.7.2",
     "graphql-iso-date": "^3.2.0",
     "jsonwebtoken": "^8.1.1",
     "lodash": ">=4 <5",

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -14,8 +14,11 @@ const ONLY = 2;
 
 export default (function PgBackwardRelationPlugin(
   builder,
-  { pgLegacyRelations }
+  { pgLegacyRelations, pgSimpleCollections }
 ) {
+  const hasConnections = pgSimpleCollections !== "only";
+  const hasSimpleCollections =
+    pgSimpleCollections === "only" || pgSimpleCollections === "both";
   const legacyRelationMode =
     {
       only: ONLY,
@@ -322,8 +325,12 @@ export default (function PgBackwardRelationPlugin(
               );
             }
           }
-          makeFields(true);
-          makeFields(false);
+          if (hasConnections) {
+            makeFields(true);
+          }
+          if (hasSimpleCollections) {
+            makeFields(false);
+          }
           return memo;
         }, {}),
         `Adding backward relations for ${Self.name}`

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -32,7 +32,7 @@ export default (function PgBackwardRelationPlugin(
         pgIntrospectionResultsByKind: introspectionResultsByKind,
         pgSql: sql,
         getAliasFromResolveInfo,
-        graphql: { GraphQLNonNull },
+        graphql: { GraphQLNonNull, GraphQLList },
         inflection,
       },
       {
@@ -124,12 +124,6 @@ export default (function PgBackwardRelationPlugin(
 
           const isDeprecated = isUnique && legacyRelationMode === DEPRECATED;
 
-          const manyRelationFieldName = inflection.manyRelationByKeys(
-            keys,
-            table,
-            foreignTable,
-            constraint
-          );
           const singleRelationFieldName = isUnique
             ? inflection.singleRelationByKeys(
                 keys,
@@ -211,89 +205,124 @@ export default (function PgBackwardRelationPlugin(
               }
             );
           }
-          if (shouldAddManyRelation && !omit(table, "many")) {
-            memo[manyRelationFieldName] = fieldWithHooks(
-              manyRelationFieldName,
-              ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
-                addDataGenerator(parsedResolveInfoFragment => {
-                  return {
-                    pgQuery: queryBuilder => {
-                      queryBuilder.select(() => {
-                        const resolveData = getDataFromParsedResolveInfoFragment(
-                          parsedResolveInfoFragment,
-                          ConnectionType
-                        );
-                        const tableAlias = sql.identifier(Symbol());
-                        const foreignTableAlias = queryBuilder.getTableAlias();
-                        const query = queryFromResolveData(
-                          sql.identifier(schema.name, table.name),
-                          tableAlias,
-                          resolveData,
-                          {
-                            withPagination: true,
-                            withPaginationAsFields: false,
-                          },
-                          innerQueryBuilder => {
-                            if (primaryKeys) {
-                              innerQueryBuilder.beforeLock("orderBy", () => {
-                                // append order by primary key to the list of orders
-                                if (!innerQueryBuilder.isOrderUnique(false)) {
-                                  innerQueryBuilder.data.cursorPrefix = [
-                                    "primary_key_asc",
-                                  ];
-                                  primaryKeys.forEach(key => {
-                                    innerQueryBuilder.orderBy(
-                                      sql.fragment`${innerQueryBuilder.getTableAlias()}.${sql.identifier(
-                                        key.name
-                                      )}`,
-                                      true
-                                    );
-                                  });
-                                  innerQueryBuilder.setOrderIsUnique();
-                                }
+          function makeFields(isConnection) {
+            if (isUnique && !isConnection) {
+              // Don't need this, use the singular instead
+              return;
+            }
+            if (shouldAddManyRelation && !omit(table, "many")) {
+              const manyRelationFieldName = isConnection
+                ? inflection.manyRelationByKeys(
+                    keys,
+                    table,
+                    foreignTable,
+                    constraint
+                  )
+                : inflection.manyRelationByKeysSimple(
+                    keys,
+                    table,
+                    foreignTable,
+                    constraint
+                  );
+
+              memo[manyRelationFieldName] = fieldWithHooks(
+                manyRelationFieldName,
+                ({
+                  getDataFromParsedResolveInfoFragment,
+                  addDataGenerator,
+                }) => {
+                  addDataGenerator(parsedResolveInfoFragment => {
+                    return {
+                      pgQuery: queryBuilder => {
+                        queryBuilder.select(() => {
+                          const resolveData = getDataFromParsedResolveInfoFragment(
+                            parsedResolveInfoFragment,
+                            ConnectionType
+                          );
+                          const tableAlias = sql.identifier(Symbol());
+                          const foreignTableAlias = queryBuilder.getTableAlias();
+                          const query = queryFromResolveData(
+                            sql.identifier(schema.name, table.name),
+                            tableAlias,
+                            resolveData,
+                            {
+                              withPagination: isConnection,
+                              withPaginationAsFields: false,
+                            },
+                            innerQueryBuilder => {
+                              if (primaryKeys) {
+                                innerQueryBuilder.beforeLock("orderBy", () => {
+                                  // append order by primary key to the list of orders
+                                  if (!innerQueryBuilder.isOrderUnique(false)) {
+                                    innerQueryBuilder.data.cursorPrefix = [
+                                      "primary_key_asc",
+                                    ];
+                                    primaryKeys.forEach(key => {
+                                      innerQueryBuilder.orderBy(
+                                        sql.fragment`${innerQueryBuilder.getTableAlias()}.${sql.identifier(
+                                          key.name
+                                        )}`,
+                                        true
+                                      );
+                                    });
+                                    innerQueryBuilder.setOrderIsUnique();
+                                  }
+                                });
+                              }
+
+                              keys.forEach((key, i) => {
+                                innerQueryBuilder.where(
+                                  sql.fragment`${tableAlias}.${sql.identifier(
+                                    key.name
+                                  )} = ${foreignTableAlias}.${sql.identifier(
+                                    foreignKeys[i].name
+                                  )}`
+                                );
                               });
                             }
-
-                            keys.forEach((key, i) => {
-                              innerQueryBuilder.where(
-                                sql.fragment`${tableAlias}.${sql.identifier(
-                                  key.name
-                                )} = ${foreignTableAlias}.${sql.identifier(
-                                  foreignKeys[i].name
-                                )}`
-                              );
-                            });
-                          }
-                        );
-                        return sql.fragment`(${query})`;
-                      }, parsedResolveInfoFragment.alias);
+                          );
+                          return sql.fragment`(${query})`;
+                        }, parsedResolveInfoFragment.alias);
+                      },
+                    };
+                  });
+                  const ConnectionType = getTypeByName(
+                    inflection.connection(gqlTableType.name)
+                  );
+                  const TableType = pgGetGqlTypeByTypeId(table.type.id);
+                  return {
+                    description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
+                    type: isConnection
+                      ? new GraphQLNonNull(ConnectionType)
+                      : new GraphQLNonNull(
+                          new GraphQLList(new GraphQLNonNull(TableType))
+                        ),
+                    args: {},
+                    resolve: (data, _args, _context, resolveInfo) => {
+                      const alias = getAliasFromResolveInfo(resolveInfo);
+                      if (isConnection) {
+                        return addStartEndCursor(data[alias]);
+                      } else {
+                        return data[alias];
+                      }
                     },
+                    deprecationReason: isDeprecated
+                      ? // $FlowFixMe
+                        `Please use ${singleRelationFieldName} instead`
+                      : undefined,
                   };
-                });
-                const ConnectionType = getTypeByName(
-                  inflection.connection(gqlTableType.name)
-                );
-                return {
-                  description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
-                  type: new GraphQLNonNull(ConnectionType),
-                  args: {},
-                  resolve: (data, _args, _context, resolveInfo) => {
-                    const alias = getAliasFromResolveInfo(resolveInfo);
-                    return addStartEndCursor(data[alias]);
-                  },
-                  deprecationReason: isDeprecated
-                    ? // $FlowFixMe
-                      `Please use ${singleRelationFieldName} instead`
-                    : undefined,
-                };
-              },
-              {
-                isPgFieldConnection: true,
-                isPgBackwardRelationField: true,
-                pgFieldIntrospection: table,
-              }
-            );
+                },
+                {
+                  isPgFieldConnection: isConnection,
+                  isPgFieldSimpleCollection: !isConnection,
+                  isPgBackwardRelationField: true,
+                  pgFieldIntrospection: table,
+                }
+              );
+            }
           }
+          makeFields(true);
+          makeFields(false);
           return memo;
         }, {}),
         `Adding backward relations for ${Self.name}`

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -237,7 +237,7 @@ export default (function PgBackwardRelationPlugin(
                         queryBuilder.select(() => {
                           const resolveData = getDataFromParsedResolveInfoFragment(
                             parsedResolveInfoFragment,
-                            ConnectionType
+                            isConnection ? ConnectionType : TableType
                           );
                           const tableAlias = sql.identifier(Symbol());
                           const foreignTableAlias = queryBuilder.getTableAlias();
@@ -248,6 +248,7 @@ export default (function PgBackwardRelationPlugin(
                             {
                               withPagination: isConnection,
                               withPaginationAsFields: false,
+                              asJsonAggregate: !isConnection,
                             },
                             innerQueryBuilder => {
                               if (primaryKeys) {

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -269,21 +269,6 @@ export default (function PgBasicsPlugin(
               .join("-and-")}`
           );
         },
-        singleRelationByKeysSimple(
-          detailedKeys: Keys,
-          table: PgClass,
-          _foreignTable: PgClass,
-          constraint: PgConstraint
-        ) {
-          if (constraint.tags.fieldName) {
-            return constraint.tags.fieldName;
-          }
-          return this.camelCase(
-            `${this._singularizedTableName(table)}-by-${detailedKeys
-              .map(key => this.column(key))
-              .join("-and-")}-simple`
-          );
-        },
         manyRelationByKeys(
           detailedKeys: Keys,
           table: PgClass,
@@ -311,7 +296,9 @@ export default (function PgBasicsPlugin(
           return this.camelCase(
             `${this.pluralize(
               this._singularizedTableName(table)
-            )}-by-${detailedKeys.map(key => this.column(key)).join("-and-")}-simple`
+            )}-by-${detailedKeys
+              .map(key => this.column(key))
+              .join("-and-")}-simple`
           );
         },
         rowByUniqueKeys(

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -235,6 +235,9 @@ export default (function PgBasicsPlugin(
         functionQueryName(proc: PgProc) {
           return this.camelCase(this._functionName(proc));
         },
+        functionQueryNameList(proc: PgProc) {
+          return this.camelCase(`${this._functionName(proc)}-list`);
+        },
         functionPayloadType(proc: PgProc) {
           return this.upperCamelCase(`${this._functionName(proc)}-payload`);
         },

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -226,7 +226,7 @@ export default (function PgBasicsPlugin(
         },
         allRowsSimple(table: PgClass) {
           return this.camelCase(
-            `all-${this.pluralize(this._singularizedTableName(table))}-simple`
+            `all-${this.pluralize(this._singularizedTableName(table))}-list`
           );
         },
         functionMutationName(proc: PgProc) {
@@ -298,7 +298,7 @@ export default (function PgBasicsPlugin(
               this._singularizedTableName(table)
             )}-by-${detailedKeys
               .map(key => this.column(key))
-              .join("-and-")}-simple`
+              .join("-and-")}-list`
           );
         },
         rowByUniqueKeys(

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -257,6 +257,15 @@ export default (function PgBasicsPlugin(
         ) {
           return proc.tags.fieldName || this.camelCase(pseudoColumnName);
         },
+        computedColumnList(
+          pseudoColumnName: string,
+          proc: PgProc,
+          _table: PgClass
+        ) {
+          return proc.tags.fieldName
+            ? proc.tags.fieldName + "List"
+            : this.camelCase(`${pseudoColumnName}-list`);
+        },
         singleRelationByKeys(
           detailedKeys: Keys,
           table: PgClass,

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -224,6 +224,11 @@ export default (function PgBasicsPlugin(
             `all-${this.pluralize(this._singularizedTableName(table))}`
           );
         },
+        allRowsSimple(table: PgClass) {
+          return this.camelCase(
+            `all-${this.pluralize(this._singularizedTableName(table))}-simple`
+          );
+        },
         functionMutationName(proc: PgProc) {
           return this.camelCase(this._functionName(proc));
         },
@@ -264,6 +269,21 @@ export default (function PgBasicsPlugin(
               .join("-and-")}`
           );
         },
+        singleRelationByKeysSimple(
+          detailedKeys: Keys,
+          table: PgClass,
+          _foreignTable: PgClass,
+          constraint: PgConstraint
+        ) {
+          if (constraint.tags.fieldName) {
+            return constraint.tags.fieldName;
+          }
+          return this.camelCase(
+            `${this._singularizedTableName(table)}-by-${detailedKeys
+              .map(key => this.column(key))
+              .join("-and-")}-simple`
+          );
+        },
         manyRelationByKeys(
           detailedKeys: Keys,
           table: PgClass,
@@ -277,6 +297,21 @@ export default (function PgBasicsPlugin(
             `${this.pluralize(
               this._singularizedTableName(table)
             )}-by-${detailedKeys.map(key => this.column(key)).join("-and-")}`
+          );
+        },
+        manyRelationByKeysSimple(
+          detailedKeys: Keys,
+          table: PgClass,
+          _foreignTable: PgClass,
+          constraint: PgConstraint
+        ) {
+          if (constraint.tags.foreignFieldName) {
+            return constraint.tags.foreignFieldName;
+          }
+          return this.camelCase(
+            `${this.pluralize(
+              this._singularizedTableName(table)
+            )}-by-${detailedKeys.map(key => this.column(key)).join("-and-")}-simple`
           );
         },
         rowByUniqueKeys(

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -68,13 +68,19 @@ export default (function PgConnectionArgCondition(builder) {
         inflection,
       } = build;
       const {
-        scope: { isPgFieldConnection, pgFieldIntrospection: table },
+        scope: {
+          isPgFieldConnection,
+          isPgFieldSimpleCollection,
+          pgFieldIntrospection: table,
+        },
         addArgDataGenerator,
         Self,
         field,
       } = context;
+      const shouldAddCondition =
+        isPgFieldConnection || isPgFieldSimpleCollection;
       if (
-        !isPgFieldConnection ||
+        !shouldAddCondition ||
         !table ||
         table.kind !== "class" ||
         !table.namespace ||

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -87,31 +87,32 @@ export default (function PgConnectionArgCondition(builder) {
         inflection.conditionType(TableType.name)
       );
 
+      const relevantAttributes = introspectionResultsByKind.attribute
+        .filter(attr => attr.classId === table.id)
+        .filter(attr => pgColumnFilter(attr, build, context))
+        .filter(attr => !omit(attr, "filter"));
+
       addArgDataGenerator(function connectionCondition({ condition }) {
         return {
           pgQuery: queryBuilder => {
             if (condition != null) {
-              introspectionResultsByKind.attribute
-                .filter(attr => attr.classId === table.id)
-                .filter(attr => pgColumnFilter(attr, build, context))
-                .filter(attr => !omit(attr, "filter"))
-                .forEach(attr => {
-                  const fieldName = inflection.column(attr);
-                  const val = condition[fieldName];
-                  if (val != null) {
-                    queryBuilder.where(
-                      sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-                        attr.name
-                      )} = ${gql2pg(val, attr.type)}`
-                    );
-                  } else if (val === null) {
-                    queryBuilder.where(
-                      sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-                        attr.name
-                      )} IS NULL`
-                    );
-                  }
-                });
+              relevantAttributes.forEach(attr => {
+                const fieldName = inflection.column(attr);
+                const val = condition[fieldName];
+                if (val != null) {
+                  queryBuilder.where(
+                    sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
+                      attr.name
+                    )} = ${gql2pg(val, attr.type)}`
+                  );
+                } else if (val === null) {
+                  queryBuilder.where(
+                    sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
+                      attr.name
+                    )} IS NULL`
+                  );
+                }
+              });
             }
           },
         };

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
@@ -10,14 +10,18 @@ export default (function PgConnectionArgs(builder) {
       args,
       { extend, getTypeByName, graphql: { GraphQLInt } },
       {
-        scope: { isPgFieldConnection, pgFieldIntrospection: source },
+        scope: {
+          isPgFieldConnection,
+          isPgFieldSimpleCollection,
+          pgFieldIntrospection: source,
+        },
         addArgDataGenerator,
         field,
         Self,
       }
     ) => {
       if (
-        !isPgFieldConnection ||
+        !(isPgFieldConnection || isPgFieldSimpleCollection) ||
         !source ||
         (source.kind !== "class" && source.kind !== "procedure")
       ) {
@@ -34,28 +38,32 @@ export default (function PgConnectionArgs(builder) {
       }) {
         return {
           pgQuery: queryBuilder => {
-            if (after != null) {
-              addCursorConstraint(after, true);
-            }
-            if (before != null) {
-              addCursorConstraint(before, false);
-            }
             if (first != null) {
               queryBuilder.first(first);
             }
             if (offset != null) {
               queryBuilder.offset(offset);
             }
-            if (last != null) {
-              if (first != null) {
-                throw new Error("We don't support setting both first and last");
+            if (isPgFieldConnection) {
+              if (after != null) {
+                addCursorConstraint(after, true);
               }
-              if (offset != null) {
-                throw new Error(
-                  "We don't support setting both offset and last"
-                );
+              if (before != null) {
+                addCursorConstraint(before, false);
               }
-              queryBuilder.last(last);
+              if (last != null) {
+                if (first != null) {
+                  throw new Error(
+                    "We don't support setting both first and last"
+                  );
+                }
+                if (offset != null) {
+                  throw new Error(
+                    "We don't support setting both offset and last"
+                  );
+                }
+                queryBuilder.last(last);
+              }
             }
 
             function addCursorConstraint(cursor, isAfter) {
@@ -73,29 +81,42 @@ export default (function PgConnectionArgs(builder) {
             description: "Only read the first `n` values of the set.",
             type: GraphQLInt,
           },
-          last: {
-            description: "Only read the last `n` values of the set.",
-            type: GraphQLInt,
-          },
+          ...(isPgFieldConnection
+            ? {
+                last: {
+                  description: "Only read the last `n` values of the set.",
+                  type: GraphQLInt,
+                },
+              }
+            : null),
           offset: {
-            description:
-              "Skip the first `n` values from our `after` cursor, an alternative to cursor based pagination. May not be used with `last`.",
+            description: isPgFieldConnection
+              ? "Skip the first `n` values from our `after` cursor, an alternative to cursor based pagination. May not be used with `last`."
+              : "Skip the first `n` values.",
             type: GraphQLInt,
           },
-          before: {
-            description:
-              "Read all values in the set before (above) this cursor.",
-            type: Cursor,
-          },
-          after: {
-            description:
-              "Read all values in the set after (below) this cursor.",
-            type: Cursor,
-          },
+          ...(isPgFieldConnection
+            ? {
+                before: {
+                  description:
+                    "Read all values in the set before (above) this cursor.",
+                  type: Cursor,
+                },
+                after: {
+                  description:
+                    "Read all values in the set after (below) this cursor.",
+                  type: Cursor,
+                },
+              }
+            : null),
         },
-        `Adding connection pagination args to field '${field.name}' of '${
-          Self.name
-        }'`
+        isPgFieldConnection
+          ? `Adding connection pagination args to field '${field.name}' of '${
+              Self.name
+            }'`
+          : `Adding simple collection args to field '${field.name}' of '${
+              Self.name
+            }'`
       );
     }
   );

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -78,18 +78,27 @@ export default (function PgConnectionArgOrderBy(builder) {
       const TableOrderByType = getTypeByName(
         inflection.orderByType(tableTypeName)
       );
+      const cursorPrefixFromOrderBy = orderBy => {
+        if (orderBy) {
+          let cursorPrefixes = [];
+          for (const item of orderBy) {
+            if (item.alias) {
+              cursorPrefixes.push(sql.literal(item.alias));
+            }
+          }
+          if (cursorPrefixes.length > 0) {
+            return cursorPrefixes;
+          }
+        }
+        return null;
+      };
 
       addArgDataGenerator(function connectionOrderBy({ orderBy: rawOrderBy }) {
         const orderBy = rawOrderBy
           ? Array.isArray(rawOrderBy) ? rawOrderBy : [rawOrderBy]
           : null;
         return {
-          pgCursorPrefix:
-            orderBy && orderBy.some(item => item.alias)
-              ? orderBy
-                  .filter(item => item.alias)
-                  .map(item => sql.literal(item.alias))
-              : null,
+          pgCursorPrefix: cursorPrefixFromOrderBy(orderBy),
           pgQuery: queryBuilder => {
             if (orderBy != null) {
               orderBy.forEach(item => {

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -57,14 +57,19 @@ export default (function PgConnectionArgOrderBy(builder) {
         inflection,
       },
       {
-        scope: { isPgFieldConnection, pgFieldIntrospection: table },
+        scope: {
+          isPgFieldConnection,
+          isPgFieldSimpleCollection,
+          pgFieldIntrospection: table,
+        },
         addArgDataGenerator,
         Self,
         field,
       }
     ) => {
+      const shouldAddOrderBy = isPgFieldConnection || isPgFieldSimpleCollection;
       if (
-        !isPgFieldConnection ||
+        !shouldAddOrderBy ||
         !table ||
         table.kind !== "class" ||
         !table.namespace ||

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -2,6 +2,23 @@
 import type { Plugin } from "graphile-build";
 const base64 = str => new Buffer(String(str)).toString("base64");
 
+const hasNonNullKey = row => {
+  if (
+    Array.isArray(row.__identifiers) &&
+    row.__identifiers.every(i => i != null)
+  ) {
+    return true;
+  }
+  for (const k in row) {
+    if (row.hasOwnProperty(k)) {
+      if ((k[0] !== "_" || k[1] !== "_") && row[k] !== null) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
 export default (function PgTablesPlugin(
   builder,
   { pgForbidSetofFunctionsToReturnNull = false }
@@ -9,13 +26,7 @@ export default (function PgTablesPlugin(
   const handleNullRow = pgForbidSetofFunctionsToReturnNull
     ? row => row
     : row => {
-        if (
-          Object.keys(row)
-            .filter(str => !str.startsWith("__"))
-            .some(key => row[key] !== null) ||
-          (Array.isArray(row.__identifiers) &&
-            row.__identifiers.every(i => i != null))
-        ) {
+        if (hasNonNullKey(row)) {
           return row;
         } else {
           return null;

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -250,11 +250,15 @@ export default function makeProcField(
           functionAlias,
           resolveData,
           {
-            withPagination: !isMutation && proc.returnsSet,
-            withPaginationAsFields: !isMutation && proc.returnsSet && !computed,
-            asJson: !proc.returnsSet && computed && !returnFirstValueAsValue,
+            withPagination: !forceList && !isMutation && proc.returnsSet,
+            withPaginationAsFields:
+              !forceList && !isMutation && proc.returnsSet && !computed,
+            asJson:
+              computed &&
+              (forceList || (!proc.returnsSet && !returnFirstValueAsValue)),
             asJsonAggregate:
-              !proc.returnsSet && computed && rawReturnType.isPgArray,
+              computed &&
+              (forceList || (!proc.returnsSet && rawReturnType.isPgArray)),
             addNullCase:
               !proc.returnsSet && !rawReturnType.isPgArray && isTableLike,
           },
@@ -433,7 +437,7 @@ export default function makeProcField(
                   return pg2gql(value, returnType);
                 }
               } else {
-                if (proc.returnsSet && !isMutation) {
+                if (proc.returnsSet && !isMutation && !forceList) {
                   return addStartEndCursor({
                     ...value,
                     data: value.data ? value.data.map(scalarAwarePg2gql) : null,

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -425,13 +425,13 @@ export default function makeProcField(
               const alias = getAliasFromResolveInfo(resolveInfo);
               const value = data[alias];
               if (returnFirstValueAsValue) {
-                if (proc.returnsSet) {
+                if (proc.returnsSet && !forceList) {
                   // EITHER `isMutation` is true, or `ConnectionType` does not
                   // exist - either way, we're not returning a connection.
                   return value.data
                     .map(firstValue)
                     .map(v => pg2gql(v, returnType));
-                } else if (rawReturnType.isPgArray) {
+                } else if (proc.returnsSet || rawReturnType.isPgArray) {
                   return value.map(firstValue).map(v => pg2gql(v, returnType));
                 } else {
                   return pg2gql(value, returnType);
@@ -512,7 +512,7 @@ export default function makeProcField(
               const [row] = rows;
               const result = (() => {
                 if (returnFirstValueAsValue) {
-                  if (proc.returnsSet && !isMutation) {
+                  if (proc.returnsSet && !isMutation && !forceList) {
                     // EITHER `isMutation` is true, or `ConnectionType` does
                     // not exist - either way, we're not returning a
                     // connection.
@@ -525,7 +525,7 @@ export default function makeProcField(
                     return pg2gql(firstValue(row), returnType);
                   }
                 } else {
-                  if (proc.returnsSet && !isMutation) {
+                  if (proc.returnsSet && !isMutation && !forceList) {
                     // Connection
                     return addStartEndCursor({
                       ...row,

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -127,8 +127,11 @@ export default function makeProcField(
     (TableType && isCompositeType(TableType)) || false;
   if (isTableLike) {
     if (proc.returnsSet) {
-      if (isMutation || forceList) {
+      if (isMutation) {
         type = new GraphQLList(TableType);
+      } else if (forceList) {
+        type = new GraphQLList(TableType);
+        fieldScope.isPgFieldSimpleCollection = true;
       } else {
         const ConnectionType = getTypeByName(
           inflection.connection(TableType.name)
@@ -158,10 +161,14 @@ export default function makeProcField(
     if (proc.returnsSet) {
       const connectionTypeName = inflection.scalarFunctionConnection(proc);
       const ConnectionType = getTypeByName(connectionTypeName);
-      if (isMutation || forceList || !ConnectionType) {
+      if (isMutation) {
         // Cannot return a connection because it would have to run the mutation again
         type = new GraphQLList(Type);
         returnFirstValueAsValue = true;
+      } else if (forceList || !ConnectionType) {
+        type = new GraphQLList(Type);
+        returnFirstValueAsValue = true;
+        fieldScope.isPgFieldSimpleCollection = true;
       } else {
         type = new GraphQLNonNull(ConnectionType);
         fieldScope.isPgFieldConnection = true;

--- a/packages/graphile-build-pg/src/queryFromResolveData.js
+++ b/packages/graphile-build-pg/src/queryFromResolveData.js
@@ -5,6 +5,8 @@ import type { SQL } from "pg-sql2";
 import type { DataForType } from "graphile-build";
 import isSafeInteger from "lodash/isSafeInteger";
 
+const identity = _ => _ !== null && _ !== undefined;
+
 export default (
   from: SQL,
   fromAlias: ?SQL,
@@ -34,7 +36,7 @@ export default (
     (calculateHasPreviousPage && calculateHasPreviousPage.length > 0) ||
     false;
   const rawCursorPrefix =
-    reallyRawCursorPrefix && reallyRawCursorPrefix.filter(_ => _);
+    reallyRawCursorPrefix && reallyRawCursorPrefix.filter(identity);
 
   const queryBuilder = new QueryBuilder();
   queryBuilder.from(from, fromAlias ? fromAlias : undefined);

--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphile-build",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.7.1",
   "description": "Build a GraphQL schema from plugins",
   "main": "node8plus/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/graphile/graphile-build#readme",
   "dependencies": {
     "debug": ">=2 <3",
-    "graphql-parse-resolve-info": "4.0.0-beta.7",
+    "graphql-parse-resolve-info": "4.0.0-beta.7.1",
     "lodash": ">=4 <5",
     "pluralize": "7.0.0"
   },

--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphile-build",
-  "version": "4.0.0-beta.7.1",
+  "version": "4.0.0-beta.7.2",
   "description": "Build a GraphQL schema from plugins",
   "main": "node8plus/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/graphile/graphile-build#readme",
   "dependencies": {
     "debug": ">=2 <3",
-    "graphql-parse-resolve-info": "4.0.0-beta.7.1",
+    "graphql-parse-resolve-info": "4.0.0-beta.7.2",
     "lodash": ">=4 <5",
     "pluralize": "7.0.0"
   },

--- a/packages/graphile/package.json
+++ b/packages/graphile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphile",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.7.1",
   "scripts": {
     "watch": "sleep 1000000000",
     "test": "true",

--- a/packages/graphile/package.json
+++ b/packages/graphile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphile",
-  "version": "4.0.0-beta.7.1",
+  "version": "4.0.0-beta.7.2",
   "scripts": {
     "watch": "sleep 1000000000",
     "test": "true",

--- a/packages/graphql-parse-resolve-info/package.json
+++ b/packages/graphql-parse-resolve-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parse-resolve-info",
-  "version": "4.0.0-beta.7.1",
+  "version": "4.0.0-beta.7.2",
   "description": "Parse GraphQLResolveInfo (the 4th argument of resolve) into a simple tree",
   "main": "node8plus/index.js",
   "scripts": {

--- a/packages/graphql-parse-resolve-info/package.json
+++ b/packages/graphql-parse-resolve-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parse-resolve-info",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.7.1",
   "description": "Parse GraphQLResolveInfo (the 4th argument of resolve) into a simple tree",
   "main": "node8plus/index.js",
   "scripts": {

--- a/packages/graphql-parse-resolve-info/src/index.js
+++ b/packages/graphql-parse-resolve-info/src/index.js
@@ -78,18 +78,16 @@ export function getAliasFromResolveInfo(
   resolveInfo: GraphQLResolveInfo
 ): string {
   const asts = resolveInfo.fieldNodes || resolveInfo.fieldASTs;
-  const alias = asts.reduce(function(alias, val) {
-    if (!alias) {
-      if (val.kind === "Field") {
-        alias = val.alias ? val.alias.value : val.name && val.name.value;
+  for (let i = 0, l = asts.length; i < l; i++) {
+    const val = asts[i];
+    if (val.kind === "Field") {
+      const alias = val.alias ? val.alias.value : val.name && val.name.value;
+      if (alias) {
+        return alias;
       }
     }
-    return alias;
-  }, null);
-  if (!alias) {
-    throw new Error("Could not determine alias?!");
   }
-  return alias;
+  throw new Error("Could not determine alias?!");
 }
 
 export function parseResolveInfo(

--- a/packages/postgraphile-core/__tests__/fixtures/queries/simple-collections.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/simple-collections.graphql
@@ -1,0 +1,25 @@
+query {
+  a: allPeopleList { ...personFragment }
+  b: allPeopleList(first: 2) { ...personFragment }
+	c: allPeopleList(orderBy: NAME_ASC) { ...personFragment }
+  d: allPeopleList(orderBy: NAME_DESC) { ...personFragment }
+  e: allPostsList(condition: { authorId: 2 }) { ...postFragment }
+	f: allPostsList(first: 2, condition: { authorId: 2 }) { ...postFragment }
+  g: allPeopleList(first: 3, offset: 1) { ...personFragment }
+  h: allPeopleList(first: 0) { ...personFragment }
+  i: allPeopleList(orderBy: PRIMARY_KEY_ASC) { ...personFragment }
+  j: allPeopleList(condition: { about: null }) { ...personFragment }
+  k: allPostsList(orderBy: [AUTHOR_ID_DESC, HEADLINE_DESC], first: 3) { ...postFragment }
+
+}
+
+fragment personFragment on Person {
+  id
+  name
+  email
+}
+
+fragment postFragment on Post {
+  headline
+  authorId
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/simple-procedure-computed-fields.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/simple-procedure-computed-fields.graphql
@@ -15,4 +15,68 @@
       }
     }
   }
+  allPeople {
+    nodes {
+      ...PersonFrag
+    }
+  }
+  allPeopleList {
+    ...PersonFrag
+  }
+}
+
+fragment PersonFrag on Person {
+  id
+  name
+  postsByAuthorId(last: 2) {
+    nodes {
+      ...PostFrag
+    }
+  }
+  postsByAuthorIdList(first: 2) {
+    ...PostFrag
+  }
+  roundOnePost: postsByAuthorId(condition: {headline: "Large bet on myself in round one."}) {
+    nodes {
+      ...PostFrag
+    }
+  }
+  roundOnePostList: postsByAuthorIdList(condition: {headline: "Large bet on myself in round one."}) {
+    ...PostFrag
+  }
+  compoundKeysByPersonId1 {
+    nodes {
+      ...PersonIdFrag
+    }
+  }
+  compoundKeysByPersonId2 {
+    nodes {
+      ...PersonIdFrag
+    }
+  }
+    compoundKeysByPersonId1List {
+      ...PersonIdFrag
+  }
+  compoundKeysByPersonId2List {
+      ...PersonIdFrag
+    }
+}
+
+fragment PostFrag on Post {
+  headline
+  headlineTrimmed
+  authorId
+  computedIntervalSet(first:1){
+    nodes{
+      seconds
+    }
+  }
+  computedIntervalSetList(first:1){
+    seconds
+  }
+}
+
+fragment PersonIdFrag on CompoundKey {
+  personId1
+  personId2
 }

--- a/packages/postgraphile-core/__tests__/fixtures/queries/simple-procedure-computed-fields.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/simple-procedure-computed-fields.graphql
@@ -1,0 +1,18 @@
+{
+  allPeopleList {
+    name
+    firstName
+    friends {
+      nodes {
+        name
+        firstName
+        friends(first: 1) {
+          nodes {
+            name
+            firstName
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/simple-procedure-query.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/simple-procedure-query.graphql
@@ -1,0 +1,39 @@
+{
+  compoundTypeSetQueryList(first: 5) {
+    a
+    b
+    c
+    d
+    e
+    f
+    f
+    g {
+      hours
+      minutes
+      seconds
+    }
+  }
+  tableSetQueryList {
+    name
+  }
+  tableSetQueryWithOffset6: tableSetQueryList(first: 2, offset: 2) {
+    name
+  }
+  intSetQueryList(x: 5, z: 6)
+  staticBigIntegerList
+  queryIntervalSetList {
+    seconds
+    minutes
+    hours
+    days
+    months
+    years
+  }
+  allPostsList(first: 1) {
+    id
+    computedIntervalSetList {
+      seconds
+      minutes
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/simple-relations-head-tail.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/simple-relations-head-tail.graphql
@@ -1,0 +1,26 @@
+query {
+  allPeopleList {
+    id
+    name
+    postsByAuthorIdList(first: 2) {
+      headline
+      authorId
+    }
+    roundOnePost: postsByAuthorIdList(condition: {headline: "Large bet on myself in round one."}) {
+      headline
+      authorId
+    }
+    compoundKeysByPersonId1List {
+      personId1
+      personId2
+    }
+    compoundKeysByPersonId2List {
+      personId1
+      personId2
+    }
+  }
+  allCompoundKeysList {
+    personId1
+    personId2
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/simple-relations-tail-head.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/simple-relations-tail-head.graphql
@@ -1,0 +1,29 @@
+query{
+  allCompoundKeysList {
+    personId1
+    personId2
+    extra
+    personByPersonId1 {
+      name
+      email
+    }
+    personByPersonId2 {
+      name
+      email
+    }
+  }
+  allForeignKeysList {
+    personId
+    compoundKey1
+    compoundKey2
+    personByPersonId {
+      name
+      email
+    }
+    compoundKeyByCompoundKey1AndCompoundKey2 {
+      personId1
+      personId2
+      extra
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -4674,8 +4674,554 @@ Object {
 exports[`simple-procedure-computed-fields.graphql 1`] = `
 Object {
   "data": Object {
+    "allPeople": Object {
+      "nodes": Array [
+        Object {
+          "compoundKeysByPersonId1": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 1,
+                "personId2": 2,
+              },
+            ],
+          },
+          "compoundKeysByPersonId1List": Array [
+            Object {
+              "personId1": 1,
+              "personId2": 2,
+            },
+          ],
+          "compoundKeysByPersonId2": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 2,
+                "personId2": 1,
+              },
+            ],
+          },
+          "compoundKeysByPersonId2List": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 1,
+            },
+          ],
+          "id": 1,
+          "name": "John Smith",
+          "postsByAuthorId": Object {
+            "nodes": Array [
+              Object {
+                "authorId": 1,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "You hit me with a cricket bat.",
+                "headlineTrimmed": "You hit m…",
+              },
+              Object {
+                "authorId": 1,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "Large bet on myself in round one.",
+                "headlineTrimmed": "Large bet…",
+              },
+            ],
+          },
+          "postsByAuthorIdList": Array [
+            Object {
+              "authorId": 1,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "I hate yogurt. It’s just stuff with bits in.",
+              "headlineTrimmed": "I hate yo…",
+            },
+            Object {
+              "authorId": 1,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Is that a cooking show?",
+              "headlineTrimmed": "Is that a…",
+            },
+          ],
+          "roundOnePost": Object {
+            "nodes": Array [
+              Object {
+                "authorId": 1,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "Large bet on myself in round one.",
+                "headlineTrimmed": "Large bet…",
+              },
+            ],
+          },
+          "roundOnePostList": Array [
+            Object {
+              "authorId": 1,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Large bet on myself in round one.",
+              "headlineTrimmed": "Large bet…",
+            },
+          ],
+        },
+        Object {
+          "compoundKeysByPersonId1": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 2,
+                "personId2": 1,
+              },
+              Object {
+                "personId1": 2,
+                "personId2": 3,
+              },
+              Object {
+                "personId1": 2,
+                "personId2": 5,
+              },
+            ],
+          },
+          "compoundKeysByPersonId1List": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 1,
+            },
+            Object {
+              "personId1": 2,
+              "personId2": 3,
+            },
+            Object {
+              "personId1": 2,
+              "personId2": 5,
+            },
+          ],
+          "compoundKeysByPersonId2": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 1,
+                "personId2": 2,
+              },
+            ],
+          },
+          "compoundKeysByPersonId2List": Array [
+            Object {
+              "personId1": 1,
+              "personId2": 2,
+            },
+          ],
+          "id": 2,
+          "name": "Sara Smith",
+          "postsByAuthorId": Object {
+            "nodes": Array [
+              Object {
+                "authorId": 2,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+                "headlineTrimmed": "It’s a fe…",
+              },
+              Object {
+                "authorId": 2,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "What’s with you kids? Every other day it’s food, food, food.",
+                "headlineTrimmed": "What’s wi…",
+              },
+            ],
+          },
+          "postsByAuthorIdList": Array [
+            Object {
+              "authorId": 2,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+              "headlineTrimmed": "No… It’s …",
+            },
+            Object {
+              "authorId": 2,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+              "headlineTrimmed": "It’s a fe…",
+            },
+          ],
+          "roundOnePost": Object {
+            "nodes": Array [],
+          },
+          "roundOnePostList": Array [],
+        },
+        Object {
+          "compoundKeysByPersonId1": Object {
+            "nodes": Array [],
+          },
+          "compoundKeysByPersonId1List": Array [],
+          "compoundKeysByPersonId2": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 2,
+                "personId2": 3,
+              },
+              Object {
+                "personId1": 4,
+                "personId2": 3,
+              },
+            ],
+          },
+          "compoundKeysByPersonId2List": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 3,
+            },
+            Object {
+              "personId1": 4,
+              "personId2": 3,
+            },
+          ],
+          "id": 3,
+          "name": "Budd Deey",
+          "postsByAuthorId": Object {
+            "nodes": Array [
+              Object {
+                "authorId": 3,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "You know how I sometimes have really brilliant ideas?",
+                "headlineTrimmed": "You know …",
+              },
+              Object {
+                "authorId": 3,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "They’re not aliens, they’re Earth…liens!",
+                "headlineTrimmed": "They’re n…",
+              },
+            ],
+          },
+          "postsByAuthorIdList": Array [
+            Object {
+              "authorId": 3,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Stop talking, brain thinking. Hush.",
+              "headlineTrimmed": "Stop talk…",
+            },
+            Object {
+              "authorId": 3,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "You know how I sometimes have really brilliant ideas?",
+              "headlineTrimmed": "You know …",
+            },
+          ],
+          "roundOnePost": Object {
+            "nodes": Array [],
+          },
+          "roundOnePostList": Array [],
+        },
+        Object {
+          "compoundKeysByPersonId1": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 4,
+                "personId2": 3,
+              },
+              Object {
+                "personId1": 4,
+                "personId2": 4,
+              },
+            ],
+          },
+          "compoundKeysByPersonId1List": Array [
+            Object {
+              "personId1": 4,
+              "personId2": 3,
+            },
+            Object {
+              "personId1": 4,
+              "personId2": 4,
+            },
+          ],
+          "compoundKeysByPersonId2": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 4,
+                "personId2": 4,
+              },
+            ],
+          },
+          "compoundKeysByPersonId2List": Array [
+            Object {
+              "personId1": 4,
+              "personId2": 4,
+            },
+          ],
+          "id": 4,
+          "name": "Kathryn Ramirez",
+          "postsByAuthorId": Object {
+            "nodes": Array [],
+          },
+          "postsByAuthorIdList": Array [],
+          "roundOnePost": Object {
+            "nodes": Array [],
+          },
+          "roundOnePostList": Array [],
+        },
+        Object {
+          "compoundKeysByPersonId1": Object {
+            "nodes": Array [],
+          },
+          "compoundKeysByPersonId1List": Array [],
+          "compoundKeysByPersonId2": Object {
+            "nodes": Array [
+              Object {
+                "personId1": 2,
+                "personId2": 5,
+              },
+            ],
+          },
+          "compoundKeysByPersonId2List": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 5,
+            },
+          ],
+          "id": 5,
+          "name": "Joe Tucker",
+          "postsByAuthorId": Object {
+            "nodes": Array [
+              Object {
+                "authorId": 5,
+                "computedIntervalSet": Object {
+                  "nodes": Array [
+                    Object {
+                      "seconds": 12,
+                    },
+                  ],
+                },
+                "computedIntervalSetList": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+                "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
+                "headlineTrimmed": "Please, D…",
+              },
+            ],
+          },
+          "postsByAuthorIdList": Array [
+            Object {
+              "authorId": 5,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
+              "headlineTrimmed": "Please, D…",
+            },
+          ],
+          "roundOnePost": Object {
+            "nodes": Array [],
+          },
+          "roundOnePostList": Array [],
+        },
+        Object {
+          "compoundKeysByPersonId1": Object {
+            "nodes": Array [],
+          },
+          "compoundKeysByPersonId1List": Array [],
+          "compoundKeysByPersonId2": Object {
+            "nodes": Array [],
+          },
+          "compoundKeysByPersonId2List": Array [],
+          "id": 6,
+          "name": "Twenty Seventwo",
+          "postsByAuthorId": Object {
+            "nodes": Array [],
+          },
+          "postsByAuthorIdList": Array [],
+          "roundOnePost": Object {
+            "nodes": Array [],
+          },
+          "roundOnePostList": Array [],
+        },
+      ],
+    },
     "allPeopleList": Array [
       Object {
+        "compoundKeysByPersonId1": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 1,
+              "personId2": 2,
+            },
+          ],
+        },
+        "compoundKeysByPersonId1List": Array [
+          Object {
+            "personId1": 1,
+            "personId2": 2,
+          },
+        ],
+        "compoundKeysByPersonId2": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 1,
+            },
+          ],
+        },
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 1,
+          },
+        ],
         "firstName": "John",
         "friends": Object {
           "nodes": Array [
@@ -4705,9 +5251,168 @@ Object {
             },
           ],
         },
+        "id": 1,
         "name": "John Smith",
+        "postsByAuthorId": Object {
+          "nodes": Array [
+            Object {
+              "authorId": 1,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "You hit me with a cricket bat.",
+              "headlineTrimmed": "You hit m…",
+            },
+            Object {
+              "authorId": 1,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Large bet on myself in round one.",
+              "headlineTrimmed": "Large bet…",
+            },
+          ],
+        },
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 1,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "I hate yogurt. It’s just stuff with bits in.",
+            "headlineTrimmed": "I hate yo…",
+          },
+          Object {
+            "authorId": 1,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "Is that a cooking show?",
+            "headlineTrimmed": "Is that a…",
+          },
+        ],
+        "roundOnePost": Object {
+          "nodes": Array [
+            Object {
+              "authorId": 1,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Large bet on myself in round one.",
+              "headlineTrimmed": "Large bet…",
+            },
+          ],
+        },
+        "roundOnePostList": Array [
+          Object {
+            "authorId": 1,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "Large bet on myself in round one.",
+            "headlineTrimmed": "Large bet…",
+          },
+        ],
       },
       Object {
+        "compoundKeysByPersonId1": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 1,
+            },
+            Object {
+              "personId1": 2,
+              "personId2": 3,
+            },
+            Object {
+              "personId1": 2,
+              "personId2": 5,
+            },
+          ],
+        },
+        "compoundKeysByPersonId1List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 1,
+          },
+          Object {
+            "personId1": 2,
+            "personId2": 3,
+          },
+          Object {
+            "personId1": 2,
+            "personId2": 5,
+          },
+        ],
+        "compoundKeysByPersonId2": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 1,
+              "personId2": 2,
+            },
+          ],
+        },
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 1,
+            "personId2": 2,
+          },
+        ],
         "firstName": "Sara",
         "friends": Object {
           "nodes": Array [
@@ -4737,9 +5442,114 @@ Object {
             },
           ],
         },
+        "id": 2,
         "name": "Sara Smith",
+        "postsByAuthorId": Object {
+          "nodes": Array [
+            Object {
+              "authorId": 2,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+              "headlineTrimmed": "It’s a fe…",
+            },
+            Object {
+              "authorId": 2,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "What’s with you kids? Every other day it’s food, food, food.",
+              "headlineTrimmed": "What’s wi…",
+            },
+          ],
+        },
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 2,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+            "headlineTrimmed": "No… It’s …",
+          },
+          Object {
+            "authorId": 2,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+            "headlineTrimmed": "It’s a fe…",
+          },
+        ],
+        "roundOnePost": Object {
+          "nodes": Array [],
+        },
+        "roundOnePostList": Array [],
       },
       Object {
+        "compoundKeysByPersonId1": Object {
+          "nodes": Array [],
+        },
+        "compoundKeysByPersonId1List": Array [],
+        "compoundKeysByPersonId2": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 3,
+            },
+            Object {
+              "personId1": 4,
+              "personId2": 3,
+            },
+          ],
+        },
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 3,
+          },
+          Object {
+            "personId1": 4,
+            "personId2": 3,
+          },
+        ],
         "firstName": "Budd",
         "friends": Object {
           "nodes": Array [
@@ -4769,9 +5579,124 @@ Object {
             },
           ],
         },
+        "id": 3,
         "name": "Budd Deey",
+        "postsByAuthorId": Object {
+          "nodes": Array [
+            Object {
+              "authorId": 3,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "You know how I sometimes have really brilliant ideas?",
+              "headlineTrimmed": "You know …",
+            },
+            Object {
+              "authorId": 3,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "They’re not aliens, they’re Earth…liens!",
+              "headlineTrimmed": "They’re n…",
+            },
+          ],
+        },
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 3,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "Stop talking, brain thinking. Hush.",
+            "headlineTrimmed": "Stop talk…",
+          },
+          Object {
+            "authorId": 3,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "You know how I sometimes have really brilliant ideas?",
+            "headlineTrimmed": "You know …",
+          },
+        ],
+        "roundOnePost": Object {
+          "nodes": Array [],
+        },
+        "roundOnePostList": Array [],
       },
       Object {
+        "compoundKeysByPersonId1": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 4,
+              "personId2": 3,
+            },
+            Object {
+              "personId1": 4,
+              "personId2": 4,
+            },
+          ],
+        },
+        "compoundKeysByPersonId1List": Array [
+          Object {
+            "personId1": 4,
+            "personId2": 3,
+          },
+          Object {
+            "personId1": 4,
+            "personId2": 4,
+          },
+        ],
+        "compoundKeysByPersonId2": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 4,
+              "personId2": 4,
+            },
+          ],
+        },
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 4,
+            "personId2": 4,
+          },
+        ],
         "firstName": "Kathryn",
         "friends": Object {
           "nodes": Array [
@@ -4796,9 +5721,36 @@ Object {
             },
           ],
         },
+        "id": 4,
         "name": "Kathryn Ramirez",
+        "postsByAuthorId": Object {
+          "nodes": Array [],
+        },
+        "postsByAuthorIdList": Array [],
+        "roundOnePost": Object {
+          "nodes": Array [],
+        },
+        "roundOnePostList": Array [],
       },
       Object {
+        "compoundKeysByPersonId1": Object {
+          "nodes": Array [],
+        },
+        "compoundKeysByPersonId1List": Array [],
+        "compoundKeysByPersonId2": Object {
+          "nodes": Array [
+            Object {
+              "personId1": 2,
+              "personId2": 5,
+            },
+          ],
+        },
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 5,
+          },
+        ],
         "firstName": "Joe",
         "friends": Object {
           "nodes": Array [
@@ -4811,14 +5763,76 @@ Object {
             },
           ],
         },
+        "id": 5,
         "name": "Joe Tucker",
+        "postsByAuthorId": Object {
+          "nodes": Array [
+            Object {
+              "authorId": 5,
+              "computedIntervalSet": Object {
+                "nodes": Array [
+                  Object {
+                    "seconds": 12,
+                  },
+                ],
+              },
+              "computedIntervalSetList": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+              "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
+              "headlineTrimmed": "Please, D…",
+            },
+          ],
+        },
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 5,
+            "computedIntervalSet": Object {
+              "nodes": Array [
+                Object {
+                  "seconds": 12,
+                },
+              ],
+            },
+            "computedIntervalSetList": Array [
+              Object {
+                "seconds": 12,
+              },
+            ],
+            "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
+            "headlineTrimmed": "Please, D…",
+          },
+        ],
+        "roundOnePost": Object {
+          "nodes": Array [],
+        },
+        "roundOnePostList": Array [],
       },
       Object {
+        "compoundKeysByPersonId1": Object {
+          "nodes": Array [],
+        },
+        "compoundKeysByPersonId1List": Array [],
+        "compoundKeysByPersonId2": Object {
+          "nodes": Array [],
+        },
+        "compoundKeysByPersonId2List": Array [],
         "firstName": "Twenty",
         "friends": Object {
           "nodes": Array [],
         },
+        "id": 6,
         "name": "Twenty Seventwo",
+        "postsByAuthorId": Object {
+          "nodes": Array [],
+        },
+        "postsByAuthorIdList": Array [],
+        "roundOnePost": Object {
+          "nodes": Array [],
+        },
+        "roundOnePostList": Array [],
       },
     ],
   },

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -4441,6 +4441,808 @@ Object {
 }
 `;
 
+exports[`simple-collections.graphql 1`] = `
+Object {
+  "data": Object {
+    "a": Array [
+      Object {
+        "email": "john.smith@email.com",
+        "id": 1,
+        "name": "John Smith",
+      },
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+      Object {
+        "email": "budd.deey@email.com",
+        "id": 3,
+        "name": "Budd Deey",
+      },
+      Object {
+        "email": "kathryn.ramirez@email.com",
+        "id": 4,
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "email": "joe.tucker@email.com",
+        "id": 5,
+        "name": "Joe Tucker",
+      },
+      Object {
+        "email": "graphile-build.issue.27.exists@example.com",
+        "id": 6,
+        "name": "Twenty Seventwo",
+      },
+    ],
+    "b": Array [
+      Object {
+        "email": "john.smith@email.com",
+        "id": 1,
+        "name": "John Smith",
+      },
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+    ],
+    "c": Array [
+      Object {
+        "email": "budd.deey@email.com",
+        "id": 3,
+        "name": "Budd Deey",
+      },
+      Object {
+        "email": "joe.tucker@email.com",
+        "id": 5,
+        "name": "Joe Tucker",
+      },
+      Object {
+        "email": "john.smith@email.com",
+        "id": 1,
+        "name": "John Smith",
+      },
+      Object {
+        "email": "kathryn.ramirez@email.com",
+        "id": 4,
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+      Object {
+        "email": "graphile-build.issue.27.exists@example.com",
+        "id": 6,
+        "name": "Twenty Seventwo",
+      },
+    ],
+    "d": Array [
+      Object {
+        "email": "graphile-build.issue.27.exists@example.com",
+        "id": 6,
+        "name": "Twenty Seventwo",
+      },
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+      Object {
+        "email": "kathryn.ramirez@email.com",
+        "id": 4,
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "email": "john.smith@email.com",
+        "id": 1,
+        "name": "John Smith",
+      },
+      Object {
+        "email": "joe.tucker@email.com",
+        "id": 5,
+        "name": "Joe Tucker",
+      },
+      Object {
+        "email": "budd.deey@email.com",
+        "id": 3,
+        "name": "Budd Deey",
+      },
+    ],
+    "e": Array [
+      Object {
+        "authorId": 2,
+        "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+      },
+      Object {
+        "authorId": 2,
+        "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+      },
+      Object {
+        "authorId": 2,
+        "headline": "What’s with you kids? Every other day it’s food, food, food.",
+      },
+    ],
+    "f": Array [
+      Object {
+        "authorId": 2,
+        "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+      },
+      Object {
+        "authorId": 2,
+        "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+      },
+    ],
+    "g": Array [
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+      Object {
+        "email": "budd.deey@email.com",
+        "id": 3,
+        "name": "Budd Deey",
+      },
+      Object {
+        "email": "kathryn.ramirez@email.com",
+        "id": 4,
+        "name": "Kathryn Ramirez",
+      },
+    ],
+    "h": Array [],
+    "i": Array [
+      Object {
+        "email": "john.smith@email.com",
+        "id": 1,
+        "name": "John Smith",
+      },
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+      Object {
+        "email": "budd.deey@email.com",
+        "id": 3,
+        "name": "Budd Deey",
+      },
+      Object {
+        "email": "kathryn.ramirez@email.com",
+        "id": 4,
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "email": "joe.tucker@email.com",
+        "id": 5,
+        "name": "Joe Tucker",
+      },
+      Object {
+        "email": "graphile-build.issue.27.exists@example.com",
+        "id": 6,
+        "name": "Twenty Seventwo",
+      },
+    ],
+    "j": Array [
+      Object {
+        "email": "john.smith@email.com",
+        "id": 1,
+        "name": "John Smith",
+      },
+      Object {
+        "email": "sara.smith@email.com",
+        "id": 2,
+        "name": "Sara Smith",
+      },
+      Object {
+        "email": "kathryn.ramirez@email.com",
+        "id": 4,
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "email": "joe.tucker@email.com",
+        "id": 5,
+        "name": "Joe Tucker",
+      },
+      Object {
+        "email": "graphile-build.issue.27.exists@example.com",
+        "id": 6,
+        "name": "Twenty Seventwo",
+      },
+    ],
+    "k": Array [
+      Object {
+        "authorId": 5,
+        "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
+      },
+      Object {
+        "authorId": 3,
+        "headline": "You know how I sometimes have really brilliant ideas?",
+      },
+      Object {
+        "authorId": 3,
+        "headline": "They’re not aliens, they’re Earth…liens!",
+      },
+    ],
+  },
+}
+`;
+
+exports[`simple-procedure-computed-fields.graphql 1`] = `
+Object {
+  "data": Object {
+    "allPeopleList": Array [
+      Object {
+        "firstName": "John",
+        "friends": Object {
+          "nodes": Array [
+            Object {
+              "firstName": "Sara",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Budd",
+                    "name": "Budd Deey",
+                  },
+                ],
+              },
+              "name": "Sara Smith",
+            },
+            Object {
+              "firstName": "Budd",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Kathryn",
+                    "name": "Kathryn Ramirez",
+                  },
+                ],
+              },
+              "name": "Budd Deey",
+            },
+          ],
+        },
+        "name": "John Smith",
+      },
+      Object {
+        "firstName": "Sara",
+        "friends": Object {
+          "nodes": Array [
+            Object {
+              "firstName": "Budd",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Kathryn",
+                    "name": "Kathryn Ramirez",
+                  },
+                ],
+              },
+              "name": "Budd Deey",
+            },
+            Object {
+              "firstName": "Kathryn",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Joe",
+                    "name": "Joe Tucker",
+                  },
+                ],
+              },
+              "name": "Kathryn Ramirez",
+            },
+          ],
+        },
+        "name": "Sara Smith",
+      },
+      Object {
+        "firstName": "Budd",
+        "friends": Object {
+          "nodes": Array [
+            Object {
+              "firstName": "Kathryn",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Joe",
+                    "name": "Joe Tucker",
+                  },
+                ],
+              },
+              "name": "Kathryn Ramirez",
+            },
+            Object {
+              "firstName": "Joe",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Twenty",
+                    "name": "Twenty Seventwo",
+                  },
+                ],
+              },
+              "name": "Joe Tucker",
+            },
+          ],
+        },
+        "name": "Budd Deey",
+      },
+      Object {
+        "firstName": "Kathryn",
+        "friends": Object {
+          "nodes": Array [
+            Object {
+              "firstName": "Joe",
+              "friends": Object {
+                "nodes": Array [
+                  Object {
+                    "firstName": "Twenty",
+                    "name": "Twenty Seventwo",
+                  },
+                ],
+              },
+              "name": "Joe Tucker",
+            },
+            Object {
+              "firstName": "Twenty",
+              "friends": Object {
+                "nodes": Array [],
+              },
+              "name": "Twenty Seventwo",
+            },
+          ],
+        },
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "firstName": "Joe",
+        "friends": Object {
+          "nodes": Array [
+            Object {
+              "firstName": "Twenty",
+              "friends": Object {
+                "nodes": Array [],
+              },
+              "name": "Twenty Seventwo",
+            },
+          ],
+        },
+        "name": "Joe Tucker",
+      },
+      Object {
+        "firstName": "Twenty",
+        "friends": Object {
+          "nodes": Array [],
+        },
+        "name": "Twenty Seventwo",
+      },
+    ],
+  },
+}
+`;
+
+exports[`simple-procedure-query.graphql 1`] = `
+Object {
+  "data": Object {
+    "allPostsList": Array [
+      Object {
+        "computedIntervalSetList": Array [
+          Object {
+            "minutes": null,
+            "seconds": 12,
+          },
+          Object {
+            "minutes": null,
+            "seconds": null,
+          },
+          Object {
+            "minutes": 36,
+            "seconds": 7,
+          },
+        ],
+        "id": 1,
+      },
+    ],
+    "compoundTypeSetQueryList": Array [
+      Object {
+        "a": 1,
+        "b": "2",
+        "c": "BLUE",
+        "d": null,
+        "e": "_0_BAR",
+        "f": "_EMPTY_",
+        "g": Object {
+          "hours": null,
+          "minutes": null,
+          "seconds": 18,
+        },
+      },
+    ],
+    "intSetQueryList": Array [
+      1,
+      2,
+      3,
+      4,
+      5,
+      null,
+      6,
+    ],
+    "queryIntervalSetList": Array [
+      Object {
+        "days": null,
+        "hours": null,
+        "minutes": null,
+        "months": null,
+        "seconds": 12,
+        "years": null,
+      },
+      Object {
+        "days": null,
+        "hours": 3,
+        "minutes": null,
+        "months": null,
+        "seconds": null,
+        "years": null,
+      },
+      Object {
+        "days": null,
+        "hours": 9,
+        "minutes": 36,
+        "months": null,
+        "seconds": 7,
+        "years": null,
+      },
+    ],
+    "staticBigIntegerList": Array [
+      "30894622507013190",
+      "30894622507013191",
+      "30894622507013192",
+      "30894622507013193",
+      "30894622507013194",
+      "30894622507013195",
+      "30894622507013196",
+      "30894622507013197",
+      "30894622507013198",
+      "30894622507013199",
+      "30894622507013200",
+    ],
+    "tableSetQueryList": Array [
+      Object {
+        "name": "John Smith",
+      },
+      Object {
+        "name": "Sara Smith",
+      },
+      Object {
+        "name": "Budd Deey",
+      },
+      Object {
+        "name": "Kathryn Ramirez",
+      },
+      Object {
+        "name": "Joe Tucker",
+      },
+      Object {
+        "name": "Twenty Seventwo",
+      },
+    ],
+    "tableSetQueryWithOffset6": Array [
+      Object {
+        "name": "Budd Deey",
+      },
+      Object {
+        "name": "Kathryn Ramirez",
+      },
+    ],
+  },
+}
+`;
+
+exports[`simple-relations-head-tail.graphql 1`] = `
+Object {
+  "data": Object {
+    "allCompoundKeysList": Array [
+      Object {
+        "personId1": 1,
+        "personId2": 2,
+      },
+      Object {
+        "personId1": 2,
+        "personId2": 1,
+      },
+      Object {
+        "personId1": 2,
+        "personId2": 3,
+      },
+      Object {
+        "personId1": 2,
+        "personId2": 5,
+      },
+      Object {
+        "personId1": 4,
+        "personId2": 3,
+      },
+      Object {
+        "personId1": 4,
+        "personId2": 4,
+      },
+    ],
+    "allPeopleList": Array [
+      Object {
+        "compoundKeysByPersonId1List": Array [
+          Object {
+            "personId1": 1,
+            "personId2": 2,
+          },
+        ],
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 1,
+          },
+        ],
+        "id": 1,
+        "name": "John Smith",
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 1,
+            "headline": "I hate yogurt. It’s just stuff with bits in.",
+          },
+          Object {
+            "authorId": 1,
+            "headline": "Is that a cooking show?",
+          },
+        ],
+        "roundOnePost": Array [
+          Object {
+            "authorId": 1,
+            "headline": "Large bet on myself in round one.",
+          },
+        ],
+      },
+      Object {
+        "compoundKeysByPersonId1List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 1,
+          },
+          Object {
+            "personId1": 2,
+            "personId2": 3,
+          },
+          Object {
+            "personId1": 2,
+            "personId2": 5,
+          },
+        ],
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 1,
+            "personId2": 2,
+          },
+        ],
+        "id": 2,
+        "name": "Sara Smith",
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 2,
+            "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+          },
+          Object {
+            "authorId": 2,
+            "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+          },
+        ],
+        "roundOnePost": Array [],
+      },
+      Object {
+        "compoundKeysByPersonId1List": Array [],
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 3,
+          },
+          Object {
+            "personId1": 4,
+            "personId2": 3,
+          },
+        ],
+        "id": 3,
+        "name": "Budd Deey",
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 3,
+            "headline": "Stop talking, brain thinking. Hush.",
+          },
+          Object {
+            "authorId": 3,
+            "headline": "You know how I sometimes have really brilliant ideas?",
+          },
+        ],
+        "roundOnePost": Array [],
+      },
+      Object {
+        "compoundKeysByPersonId1List": Array [
+          Object {
+            "personId1": 4,
+            "personId2": 3,
+          },
+          Object {
+            "personId1": 4,
+            "personId2": 4,
+          },
+        ],
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 4,
+            "personId2": 4,
+          },
+        ],
+        "id": 4,
+        "name": "Kathryn Ramirez",
+        "postsByAuthorIdList": Array [],
+        "roundOnePost": Array [],
+      },
+      Object {
+        "compoundKeysByPersonId1List": Array [],
+        "compoundKeysByPersonId2List": Array [
+          Object {
+            "personId1": 2,
+            "personId2": 5,
+          },
+        ],
+        "id": 5,
+        "name": "Joe Tucker",
+        "postsByAuthorIdList": Array [
+          Object {
+            "authorId": 5,
+            "headline": "Please, Don-Bot… look into your hard drive, and open your mercy file!",
+          },
+        ],
+        "roundOnePost": Array [],
+      },
+      Object {
+        "compoundKeysByPersonId1List": Array [],
+        "compoundKeysByPersonId2List": Array [],
+        "id": 6,
+        "name": "Twenty Seventwo",
+        "postsByAuthorIdList": Array [],
+        "roundOnePost": Array [],
+      },
+    ],
+  },
+}
+`;
+
+exports[`simple-relations-tail-head.graphql 1`] = `
+Object {
+  "data": Object {
+    "allCompoundKeysList": Array [
+      Object {
+        "extra": null,
+        "personByPersonId1": Object {
+          "email": "john.smith@email.com",
+          "name": "John Smith",
+        },
+        "personByPersonId2": Object {
+          "email": "sara.smith@email.com",
+          "name": "Sara Smith",
+        },
+        "personId1": 1,
+        "personId2": 2,
+      },
+      Object {
+        "extra": false,
+        "personByPersonId1": Object {
+          "email": "sara.smith@email.com",
+          "name": "Sara Smith",
+        },
+        "personByPersonId2": Object {
+          "email": "john.smith@email.com",
+          "name": "John Smith",
+        },
+        "personId1": 2,
+        "personId2": 1,
+      },
+      Object {
+        "extra": null,
+        "personByPersonId1": Object {
+          "email": "sara.smith@email.com",
+          "name": "Sara Smith",
+        },
+        "personByPersonId2": Object {
+          "email": "budd.deey@email.com",
+          "name": "Budd Deey",
+        },
+        "personId1": 2,
+        "personId2": 3,
+      },
+      Object {
+        "extra": true,
+        "personByPersonId1": Object {
+          "email": "sara.smith@email.com",
+          "name": "Sara Smith",
+        },
+        "personByPersonId2": Object {
+          "email": "joe.tucker@email.com",
+          "name": "Joe Tucker",
+        },
+        "personId1": 2,
+        "personId2": 5,
+      },
+      Object {
+        "extra": true,
+        "personByPersonId1": Object {
+          "email": "kathryn.ramirez@email.com",
+          "name": "Kathryn Ramirez",
+        },
+        "personByPersonId2": Object {
+          "email": "budd.deey@email.com",
+          "name": "Budd Deey",
+        },
+        "personId1": 4,
+        "personId2": 3,
+      },
+      Object {
+        "extra": false,
+        "personByPersonId1": Object {
+          "email": "kathryn.ramirez@email.com",
+          "name": "Kathryn Ramirez",
+        },
+        "personByPersonId2": Object {
+          "email": "kathryn.ramirez@email.com",
+          "name": "Kathryn Ramirez",
+        },
+        "personId1": 4,
+        "personId2": 4,
+      },
+    ],
+    "allForeignKeysList": Array [
+      Object {
+        "compoundKey1": 2,
+        "compoundKey2": 1,
+        "compoundKeyByCompoundKey1AndCompoundKey2": Object {
+          "extra": false,
+          "personId1": 2,
+          "personId2": 1,
+        },
+        "personByPersonId": Object {
+          "email": "joe.tucker@email.com",
+          "name": "Joe Tucker",
+        },
+        "personId": 5,
+      },
+      Object {
+        "compoundKey1": 4,
+        "compoundKey2": 4,
+        "compoundKeyByCompoundKey1AndCompoundKey2": Object {
+          "extra": false,
+          "personId1": 4,
+          "personId2": 4,
+        },
+        "personByPersonId": null,
+        "personId": null,
+      },
+      Object {
+        "compoundKey1": 2,
+        "compoundKey2": 1,
+        "compoundKeyByCompoundKey1AndCompoundKey2": Object {
+          "extra": false,
+          "personId1": 2,
+          "personId2": 1,
+        },
+        "personByPersonId": null,
+        "personId": null,
+      },
+    ],
+  },
+}
+`;
+
 exports[`types.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -41,6 +41,7 @@ beforeAll(() => {
       pgColumnFilter,
       viewUniqueKey,
       dSchema,
+      simpleCollections,
     ] = await Promise.all([
       createPostGraphileSchema(pgClient, ["a", "b", "c"]),
       createPostGraphileSchema(pgClient, ["a", "b", "c"], { classicIds: true }),
@@ -57,6 +58,8 @@ beforeAll(() => {
         setofFunctionsContainNulls: true,
       }),
       createPostGraphileSchema(pgClient, ["d"], {}),
+      createPostGraphileSchema(pgClient, ["a", "b", "c"], { simpleCollections: "both" }),
+
     ]);
     debug(printSchema(normal));
     return {
@@ -66,6 +69,7 @@ beforeAll(() => {
       pgColumnFilter,
       viewUniqueKey,
       dSchema,
+      simpleCollections,
     };
   });
 
@@ -99,6 +103,11 @@ beforeAll(() => {
               gqlSchemas.dynamicJson,
             "view.graphql": gqlSchemas.viewUniqueKey,
             "badlyBehavedFunction.graphql": gqlSchemas.viewUniqueKey,
+            "simple-collections.graphql": gqlSchemas.simpleCollections,
+            "simple-relations-head-tail.graphql": gqlSchemas.simpleCollections,
+            "simple-relations-tail-head.graphql": gqlSchemas.simpleCollections,
+            "simple-procedure-computed-fields.graphql": gqlSchemas.simpleCollections,
+            "simple-procedure-query.graphql": gqlSchemas.simpleCollections,
           };
           const gqlSchema = schemas[fileName]
             ? schemas[fileName]

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -1820,7 +1820,7 @@ type Person implements Node {
   ): CompoundKeysConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
-  compoundKeysByPersonId1Simple(
+  compoundKeysByPersonId1List(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -1866,7 +1866,7 @@ type Person implements Node {
   ): CompoundKeysConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
-  compoundKeysByPersonId2Simple(
+  compoundKeysByPersonId2List(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2166,7 +2166,7 @@ type Query implements Node {
   ): CompoundKeysConnection
 
   \\"\\"\\"Reads a set of \`CompoundKey\`.\\"\\"\\"
-  allCompoundKeysSimple(
+  allCompoundKeysList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2212,7 +2212,7 @@ type Query implements Node {
   ): EdgeCasesConnection
 
   \\"\\"\\"Reads a set of \`EdgeCase\`.\\"\\"\\"
-  allEdgeCasesSimple(
+  allEdgeCasesList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2258,7 +2258,7 @@ type Query implements Node {
   ): Issue756SConnection
 
   \\"\\"\\"Reads a set of \`Issue756\`.\\"\\"\\"
-  allIssue756SSimple(
+  allIssue756SList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2304,7 +2304,7 @@ type Query implements Node {
   ): LeftArmsConnection
 
   \\"\\"\\"Reads a set of \`LeftArm\`.\\"\\"\\"
-  allLeftArmsSimple(
+  allLeftArmsList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2350,7 +2350,7 @@ type Query implements Node {
   ): MyTablesConnection
 
   \\"\\"\\"Reads a set of \`MyTable\`.\\"\\"\\"
-  allMyTablesSimple(
+  allMyTablesList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2396,7 +2396,7 @@ type Query implements Node {
   ): PeopleConnection
 
   \\"\\"\\"Reads a set of \`Person\`.\\"\\"\\"
-  allPeopleSimple(
+  allPeopleList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"
@@ -2442,7 +2442,7 @@ type Query implements Node {
   ): PersonSecretsConnection
 
   \\"\\"\\"Reads a set of \`PersonSecret\`.\\"\\"\\"
-  allPersonSecretsSimple(
+  allPersonSecretsList(
     \\"\\"\\"
     A condition to be used in determining which values should be returned by the collection.
     \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -1820,6 +1820,23 @@ type Person implements Node {
   ): CompoundKeysConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId1Simple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!]
+  ): [CompoundKey!]!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
   compoundKeysByPersonId2(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
     after: Cursor
@@ -1847,6 +1864,23 @@ type Person implements Node {
     \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId2Simple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!]
+  ): [CompoundKey!]!
   createdAt: Datetime
   email: Email!
   exists(email: Email): Boolean
@@ -2131,6 +2165,23 @@ type Query implements Node {
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
   ): CompoundKeysConnection
 
+  \\"\\"\\"Reads a set of \`CompoundKey\`.\\"\\"\\"
+  allCompoundKeysSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!]
+  ): [CompoundKey!]
+
   \\"\\"\\"Reads and enables pagination through a set of \`EdgeCase\`.\\"\\"\\"
   allEdgeCases(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -2159,6 +2210,23 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
   ): EdgeCasesConnection
+
+  \\"\\"\\"Reads a set of \`EdgeCase\`.\\"\\"\\"
+  allEdgeCasesSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: EdgeCaseCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!]
+  ): [EdgeCase!]
 
   \\"\\"\\"Reads and enables pagination through a set of \`Issue756\`.\\"\\"\\"
   allIssue756S(
@@ -2189,6 +2257,23 @@ type Query implements Node {
     orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
   ): Issue756SConnection
 
+  \\"\\"\\"Reads a set of \`Issue756\`.\\"\\"\\"
+  allIssue756SSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: Issue756Condition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!]
+  ): [Issue756!]
+
   \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
   allLeftArms(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -2217,6 +2302,23 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
     orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
   ): LeftArmsConnection
+
+  \\"\\"\\"Reads a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArmsSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!]
+  ): [LeftArm!]
 
   \\"\\"\\"Reads and enables pagination through a set of \`MyTable\`.\\"\\"\\"
   allMyTables(
@@ -2247,6 +2349,23 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesConnection
 
+  \\"\\"\\"Reads a set of \`MyTable\`.\\"\\"\\"
+  allMyTablesSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: MyTableCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!]
+  ): [MyTable!]
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -2276,6 +2395,23 @@ type Query implements Node {
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): PeopleConnection
 
+  \\"\\"\\"Reads a set of \`Person\`.\\"\\"\\"
+  allPeopleSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!]
+  ): [Person!]
+
   \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
   allPersonSecrets(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -2304,6 +2440,23 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
+
+  \\"\\"\\"Reads a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecretsSimple(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!]
+  ): [PersonSecret!]
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   badlyBehavedFunction(

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -1908,6 +1908,9 @@ type Person implements Node {
     offset: Int
   ): PeopleConnection!
 
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  friendsList: [Person]
+
   \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
 
@@ -2479,6 +2482,9 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection!
 
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunctionList: [Person]
+
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
     \\"\\"\\"
@@ -2508,6 +2514,9 @@ type Query implements Node {
     \\"\\"\\"
     offset: Int
   ): CompoundTypesConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundType\`.\\"\\"\\"
+  compoundTypeSetQueryList: [CompoundType]
   intSetQuery(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
     after: Cursor
@@ -2530,6 +2539,7 @@ type Query implements Node {
     y: Int
     z: Int
   ): IntSetQueryConnection!
+  intSetQueryList(x: Int, y: Int, z: Int): [Int]
 
   \\"\\"\\"Reads a single \`Issue756\` using its globally unique \`ID\`.\\"\\"\\"
   issue756(
@@ -2611,6 +2621,9 @@ type Query implements Node {
     \\"\\"\\"
     offset: Int
   ): PeopleConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetQueryList: [Person]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -1,0 +1,2954 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints a schema with simple collections 1`] = `
+"enum AnEnum {
+  _ASTERISK_BAR_
+  _ASTERISK_BAZ_ASTERISK_
+  _FOO_ASTERISK
+  ASTERISK
+  ASTERISK_ASTERISK
+  ASTERISK_ASTERISK_ASTERISK
+  ASTERISK_BAR
+  ASTERISK_BAR_
+  ASTERISK_BAZ_ASTERISK
+  AWAITING
+  DOLLAR
+  FOO_ASTERISK
+  FOO_ASTERISK_
+  GREATER_THAN_OR_EQUAL
+  LIKE
+  PERCENT
+  PUBLISHED
+  REJECTED
+}
+
+\\"\\"\\"
+A signed eight-byte integer. The upper big integer values are greater then the
+max value for a JavaScript number. Therefore all big integers will be output as
+strings and not numbers.
+\\"\\"\\"
+scalar BigInt
+
+enum Color {
+  BLUE
+  GREEN
+  RED
+}
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`CompoundKey\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input CompoundKeyCondition {
+  \\"\\"\\"Checks for equality with the object’s \`extra\` field.\\"\\"\\"
+  extra: Boolean
+
+  \\"\\"\\"Checks for equality with the object’s \`personId1\` field.\\"\\"\\"
+  personId1: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`personId2\` field.\\"\\"\\"
+  personId2: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`CompoundKey\`\\"\\"\\"
+input CompoundKeyInput {
+  extra: Boolean
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+\\"\\"\\"
+input CompoundKeyPatch {
+  extra: Boolean
+  personId1: Int
+  personId2: Int
+}
+
+\\"\\"\\"A connection to a list of \`CompoundKey\` values.\\"\\"\\"
+type CompoundKeysConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [CompoundKeysEdge!]!
+
+  \\"\\"\\"A list of \`CompoundKey\` objects.\\"\\"\\"
+  nodes: [CompoundKey!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`CompoundKey\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`CompoundKey\` edge in the connection.\\"\\"\\"
+type CompoundKeysEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
+  node: CompoundKey!
+}
+
+\\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"Awesome feature!\\"\\"\\"
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  computedField: Int
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: Interval
+}
+
+\\"\\"\\"A connection to a list of \`CompoundType\` values.\\"\\"\\"
+type CompoundTypesConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`CompoundType\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [CompoundTypesEdge!]!
+
+  \\"\\"\\"A list of \`CompoundType\` objects.\\"\\"\\"
+  nodes: [CompoundType!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`CompoundType\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`CompoundType\` edge in the connection.\\"\\"\\"
+type CompoundTypesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`CompoundType\` at the end of the edge.\\"\\"\\"
+  node: CompoundType!
+}
+
+type Comptype {
+  isOptimised: Boolean
+  schedule: Datetime
+}
+
+\\"\\"\\"All input for the create \`CompoundKey\` mutation.\\"\\"\\"
+input CreateCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` to be created by this mutation.\\"\\"\\"
+  compoundKey: CompoundKeyInput!
+}
+
+\\"\\"\\"The output of our create \`CompoundKey\` mutation.\\"\\"\\"
+type CreateCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`EdgeCase\` mutation.\\"\\"\\"
+input CreateEdgeCaseInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`EdgeCase\` to be created by this mutation.\\"\\"\\"
+  edgeCase: EdgeCaseInput!
+}
+
+\\"\\"\\"The output of our create \`EdgeCase\` mutation.\\"\\"\\"
+type CreateEdgeCasePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
+  edgeCase: EdgeCase
+
+  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
+  edgeCaseEdge(
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`Issue756\` mutation.\\"\\"\\"
+input CreateIssue756Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Issue756\` to be created by this mutation.\\"\\"\\"
+  issue756: Issue756Input!
+}
+
+\\"\\"\\"The output of our create \`Issue756\` mutation.\\"\\"\\"
+type CreateIssue756Payload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Issue756\` that was created by this mutation.\\"\\"\\"
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+input CreateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` to be created by this mutation.\\"\\"\\"
+  leftArm: LeftArmInput!
+}
+
+\\"\\"\\"The output of our create \`LeftArm\` mutation.\\"\\"\\"
+type CreateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`MyTable\` mutation.\\"\\"\\"
+input CreateMyTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`MyTable\` to be created by this mutation.\\"\\"\\"
+  myTable: MyTableInput!
+}
+
+\\"\\"\\"The output of our create \`MyTable\` mutation.\\"\\"\\"
+type CreateMyTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`MyTable\` that was created by this mutation.\\"\\"\\"
+  myTable: MyTable
+
+  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
+  myTableEdge(
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
+input CreatePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` to be created by this mutation.\\"\\"\\"
+  person: PersonInput!
+}
+
+\\"\\"\\"The output of our create \`Person\` mutation.\\"\\"\\"
+type CreatePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`PersonSecret\` mutation.\\"\\"\\"
+input CreatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`PersonSecret\` to be created by this mutation.\\"\\"\\"
+  personSecret: PersonSecretInput!
+}
+
+\\"\\"\\"The output of our create \`PersonSecret\` mutation.\\"\\"\\"
+type CreatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+scalar Cursor
+
+\\"\\"\\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\\"\\"\\"
+scalar Datetime
+
+\\"\\"\\"
+All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+\\"\\"\\"
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the \`deleteCompoundKey\` mutation.\\"\\"\\"
+input DeleteCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`CompoundKey\` mutation.\\"\\"\\"
+type DeleteCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+  deletedCompoundKeyId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteIssue756ById\` mutation.\\"\\"\\"
+input DeleteIssue756ByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteIssue756\` mutation.\\"\\"\\"
+input DeleteIssue756Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Issue756\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`Issue756\` mutation.\\"\\"\\"
+type DeleteIssue756Payload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedIssue756Id: ID
+
+  \\"\\"\\"The \`Issue756\` that was deleted by this mutation.\\"\\"\\"
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmById\` mutation.\\"\\"\\"
+input DeleteLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmByPersonId\` mutation.\\"\\"\\"
+input DeleteLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArm\` mutation.\\"\\"\\"
+input DeleteLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`LeftArm\` mutation.\\"\\"\\"
+type DeleteLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedLeftArmId: ID
+
+  \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteMyTableById\` mutation.\\"\\"\\"
+input DeleteMyTableByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteMyTable\` mutation.\\"\\"\\"
+input DeleteMyTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`MyTable\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`MyTable\` mutation.\\"\\"\\"
+type DeleteMyTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedMyTableId: ID
+
+  \\"\\"\\"The \`MyTable\` that was deleted by this mutation.\\"\\"\\"
+  myTable: MyTable
+
+  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
+  myTableEdge(
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonByEmail\` mutation.\\"\\"\\"
+input DeletePersonByEmailInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  email: Email!
+}
+
+\\"\\"\\"All input for the \`deletePersonById\` mutation.\\"\\"\\"
+input DeletePersonByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deletePerson\` mutation.\\"\\"\\"
+input DeletePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`Person\` mutation.\\"\\"\\"
+type DeletePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonId: ID
+
+  \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonSecretByPersonId\` mutation.\\"\\"\\"
+input DeletePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deletePersonSecret\` mutation.\\"\\"\\"
+input DeletePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`PersonSecret\` mutation.\\"\\"\\"
+type DeletePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonSecretId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+type EdgeCase {
+  computed: String
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\\"\\"\\"
+A condition to be used against \`EdgeCase\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input EdgeCaseCondition {
+  \\"\\"\\"Checks for equality with the object’s \`notNullHasDefault\` field.\\"\\"\\"
+  notNullHasDefault: Boolean
+
+  \\"\\"\\"Checks for equality with the object’s \`rowId\` field.\\"\\"\\"
+  rowId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`wontCastEasy\` field.\\"\\"\\"
+  wontCastEasy: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`EdgeCase\`\\"\\"\\"
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\\"\\"\\"A connection to a list of \`EdgeCase\` values.\\"\\"\\"
+type EdgeCasesConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [EdgeCasesEdge!]!
+
+  \\"\\"\\"A list of \`EdgeCase\` objects.\\"\\"\\"
+  nodes: [EdgeCase!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`EdgeCase\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`EdgeCase\` edge in the connection.\\"\\"\\"
+type EdgeCasesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
+  node: EdgeCase!
+}
+
+\\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+enum EnumCaps {
+  _0_BAR
+  BAR_FOO
+  BAZ_QUX
+  FOO_BAR
+}
+
+enum EnumWithEmptyString {
+  _EMPTY_
+  ONE
+  TWO
+}
+
+\\"\\"\\"
+The value at one end of a range. A range can either include this value, or not.
+\\"\\"\\"
+input FloatRangeBoundInput {
+  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  inclusive: Boolean!
+
+  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  value: Float!
+}
+
+\\"\\"\\"A range of \`Float\`.\\"\\"\\"
+input FloatRangeInput {
+  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  end: FloatRangeBoundInput
+
+  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  start: FloatRangeBoundInput
+}
+
+\\"\\"\\"
+An interval of time that has passed where the smallest distinct unit is a second.
+\\"\\"\\"
+type Interval {
+  \\"\\"\\"A quantity of days.\\"\\"\\"
+  days: Int
+
+  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  hours: Int
+
+  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  minutes: Int
+
+  \\"\\"\\"A quantity of months.\\"\\"\\"
+  months: Int
+
+  \\"\\"\\"
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  \\"\\"\\"
+  seconds: Float
+
+  \\"\\"\\"A quantity of years.\\"\\"\\"
+  years: Int
+}
+
+\\"\\"\\"All input for the \`intSetMutation\` mutation.\\"\\"\\"
+input IntSetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+\\"\\"\\"The output of our \`intSetMutation\` mutation.\\"\\"\\"
+type IntSetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integers: [Int]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+type IntSetQueryConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [IntSetQueryEdge!]!
+
+  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  nodes: [Int!]!
+}
+
+\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+type IntSetQueryEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  node: Int
+}
+
+type Issue756 implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  ts: NotNullTimestamp!
+}
+
+\\"\\"\\"
+A condition to be used against \`Issue756\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input Issue756Condition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`ts\` field.\\"\\"\\"
+  ts: NotNullTimestamp
+}
+
+\\"\\"\\"An input for mutations affecting \`Issue756\`\\"\\"\\"
+input Issue756Input {
+  id: Int
+  ts: NotNullTimestamp!
+}
+
+\\"\\"\\"All input for the \`issue756Mutation\` mutation.\\"\\"\\"
+input Issue756MutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`issue756Mutation\` mutation.\\"\\"\\"
+type Issue756MutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+Represents an update to a \`Issue756\`. Fields that are set will be updated.
+\\"\\"\\"
+input Issue756Patch {
+  id: Int
+  ts: NotNullTimestamp
+}
+
+\\"\\"\\"A connection to a list of \`Issue756\` values.\\"\\"\\"
+type Issue756SConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Issue756\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [Issue756SEdge!]!
+
+  \\"\\"\\"A list of \`Issue756\` objects.\\"\\"\\"
+  nodes: [Issue756!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Issue756\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Issue756\` edge in the connection.\\"\\"\\"
+type Issue756SEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Issue756\` at the end of the edge.\\"\\"\\"
+  node: Issue756!
+}
+
+\\"\\"\\"All input for the \`issue756SetMutation\` mutation.\\"\\"\\"
+input Issue756SetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`issue756SetMutation\` mutation.\\"\\"\\"
+type Issue756SetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+  issue756S: [Issue756]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"Methods to use when ordering \`Issue756\`.\\"\\"\\"
+enum Issue756SOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TS_ASC
+  TS_DESC
+}
+
+\\"\\"\\"
+A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+\\"\\"\\"
+scalar JSON
+
+\\"\\"\\"All input for the \`jsonbIdentityMutation\` mutation.\\"\\"\\"
+input JsonbIdentityMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutation\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonbIdentityMutationPlpgsql\` mutation.\\"\\"\\"
+input JsonbIdentityMutationPlpgsqlInput {
+  _theJson: JSON!
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutationPlpgsql\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPlpgsqlPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonbIdentityMutationPlpgsqlWithDefault\` mutation.\\"\\"\\"
+input JsonbIdentityMutationPlpgsqlWithDefaultInput {
+  _theJson: JSON
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutationPlpgsqlWithDefault\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPlpgsqlWithDefaultPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonIdentityMutation\` mutation.\\"\\"\\"
+input JsonIdentityMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+}
+
+\\"\\"\\"The output of our \`jsonIdentityMutation\` mutation.\\"\\"\\"
+type JsonIdentityMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  id: Int!
+  lengthInMetres: Float
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`LeftArm\`\\"\\"\\"
+input LeftArmInput {
+  id: Int
+  lengthInMetres: Float
+  personId: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`LeftArm\`. Fields that are set will be updated.
+\\"\\"\\"
+input LeftArmPatch {
+  id: Int
+  lengthInMetres: Float
+  personId: Int
+}
+
+\\"\\"\\"A connection to a list of \`LeftArm\` values.\\"\\"\\"
+type LeftArmsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`LeftArm\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [LeftArmsEdge!]!
+
+  \\"\\"\\"A list of \`LeftArm\` objects.\\"\\"\\"
+  nodes: [LeftArm!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`LeftArm\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"
+The root mutation type which contains root level fields which mutate data.
+\\"\\"\\"
+type Mutation {
+  \\"\\"\\"Creates a single \`CompoundKey\`.\\"\\"\\"
+  createCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  \\"\\"\\"Creates a single \`EdgeCase\`.\\"\\"\\"
+  createEdgeCase(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  \\"\\"\\"Creates a single \`Issue756\`.\\"\\"\\"
+  createIssue756(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateIssue756Input!
+  ): CreateIssue756Payload
+
+  \\"\\"\\"Creates a single \`LeftArm\`.\\"\\"\\"
+  createLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateLeftArmInput!
+  ): CreateLeftArmPayload
+
+  \\"\\"\\"Creates a single \`MyTable\`.\\"\\"\\"
+  createMyTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateMyTableInput!
+  ): CreateMyTablePayload
+
+  \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
+  createPerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  \\"\\"\\"Creates a single \`PersonSecret\`.\\"\\"\\"
+  createPersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonSecretInput!
+  ): CreatePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
+  deleteCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`CompoundKey\` using a unique key.\\"\\"\\"
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`Issue756\` using its globally unique id.\\"\\"\\"
+  deleteIssue756(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteIssue756Input!
+  ): DeleteIssue756Payload
+
+  \\"\\"\\"Deletes a single \`Issue756\` using a unique key.\\"\\"\\"
+  deleteIssue756ById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteIssue756ByIdInput!
+  ): DeleteIssue756Payload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
+  deleteLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByPersonIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`MyTable\` using its globally unique id.\\"\\"\\"
+  deleteMyTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteMyTableInput!
+  ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`MyTable\` using a unique key.\\"\\"\\"
+  deleteMyTableById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteMyTableByIdInput!
+  ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
+  deletePerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using a unique key.\\"\\"\\"
+  deletePersonByEmail(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using a unique key.\\"\\"\\"
+  deletePersonById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonByIdInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using its globally unique id.\\"\\"\\"
+  deletePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretInput!
+  ): DeletePersonSecretPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
+  deletePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretByPersonIdInput!
+  ): DeletePersonSecretPayload
+  intSetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload
+  issue756Mutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: Issue756MutationInput!
+  ): Issue756MutationPayload
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Issue756\`.\\"\\"\\"
+  issue756SetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: Issue756SetMutationInput!
+  ): Issue756SetMutationPayload
+  jsonIdentityMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload
+  jsonbIdentityMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationInput!
+  ): JsonbIdentityMutationPayload
+  jsonbIdentityMutationPlpgsql(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationPlpgsqlInput!
+  ): JsonbIdentityMutationPlpgsqlPayload
+  jsonbIdentityMutationPlpgsqlWithDefault(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationPlpgsqlWithDefaultInput!
+  ): JsonbIdentityMutationPlpgsqlWithDefaultPayload
+  noArgsMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload
+  tableMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TableMutationInput!
+  ): TableMutationPayload
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload
+  typesMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TypesMutationInput!
+  ): TypesMutationPayload
+
+  \\"\\"\\"
+  Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  \\"\\"\\"Updates a single \`CompoundKey\` using a unique key and a patch.\\"\\"\\"
+  updateCompoundKeyByPersonId1AndPersonId2(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  \\"\\"\\"Updates a single \`Issue756\` using its globally unique id and a patch.\\"\\"\\"
+  updateIssue756(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateIssue756Input!
+  ): UpdateIssue756Payload
+
+  \\"\\"\\"Updates a single \`Issue756\` using a unique key and a patch.\\"\\"\\"
+  updateIssue756ById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateIssue756ByIdInput!
+  ): UpdateIssue756Payload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using its globally unique id and a patch.\\"\\"\\"
+  updateLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByPersonIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`MyTable\` using its globally unique id and a patch.\\"\\"\\"
+  updateMyTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateMyTableInput!
+  ): UpdateMyTablePayload
+
+  \\"\\"\\"Updates a single \`MyTable\` using a unique key and a patch.\\"\\"\\"
+  updateMyTableById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateMyTableByIdInput!
+  ): UpdateMyTablePayload
+
+  \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
+  updatePerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"Updates a single \`Person\` using a unique key and a patch.\\"\\"\\"
+  updatePersonByEmail(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"Updates a single \`Person\` using a unique key and a patch.\\"\\"\\"
+  updatePersonById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonByIdInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"
+  Updates a single \`PersonSecret\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updatePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretInput!
+  ): UpdatePersonSecretPayload
+
+  \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
+  updatePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretByPersonIdInput!
+  ): UpdatePersonSecretPayload
+}
+
+type MyTable implements Node {
+  id: Int!
+  jsonData: JSON
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"
+A condition to be used against \`MyTable\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input MyTableCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`jsonData\` field.\\"\\"\\"
+  jsonData: JSON
+}
+
+\\"\\"\\"An input for mutations affecting \`MyTable\`\\"\\"\\"
+input MyTableInput {
+  id: Int
+  jsonData: JSON
+}
+
+\\"\\"\\"
+Represents an update to a \`MyTable\`. Fields that are set will be updated.
+\\"\\"\\"
+input MyTablePatch {
+  id: Int
+  jsonData: JSON
+}
+
+\\"\\"\\"A connection to a list of \`MyTable\` values.\\"\\"\\"
+type MyTablesConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`MyTable\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [MyTablesEdge!]!
+
+  \\"\\"\\"A list of \`MyTable\` objects.\\"\\"\\"
+  nodes: [MyTable!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`MyTable\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`MyTable\` edge in the connection.\\"\\"\\"
+type MyTablesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`MyTable\` at the end of the edge.\\"\\"\\"
+  node: MyTable!
+}
+
+\\"\\"\\"Methods to use when ordering \`MyTable\`.\\"\\"\\"
+enum MyTablesOrderBy {
+  ID_ASC
+  ID_DESC
+  JSON_DATA_ASC
+  JSON_DATA_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"All input for the \`noArgsMutation\` mutation.\\"\\"\\"
+input NoArgsMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`noArgsMutation\` mutation.\\"\\"\\"
+type NoArgsMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integer: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+interface Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+scalar NotNullTimestamp
+
+scalar NotNullUrl
+
+\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+type PageInfo {
+  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  endCursor: Cursor
+
+  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  hasNextPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  hasPreviousPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  startCursor: Cursor
+}
+
+\\"\\"\\"A connection to a list of \`Person\` values.\\"\\"\\"
+type PeopleConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PeopleEdge!]!
+
+  \\"\\"\\"A list of \`Person\` objects.\\"\\"\\"
+  nodes: [Person!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Person\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Person\` edge in the connection.\\"\\"\\"
+type PeopleEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
+  node: Person!
+}
+
+\\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  ALIASES_ASC
+  ALIASES_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SITE_ASC
+  SITE_DESC
+}
+
+\\"\\"\\"Person test comment\\"\\"\\"
+type Person implements Node {
+  about: String
+  aliases: [String]!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId1(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId2(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection!
+  createdAt: Datetime
+  email: Email!
+  exists(email: Email): Boolean
+  firstName: String
+  firstPost: Post
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  friends(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int!
+
+  \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
+  leftArmByPersonId: LeftArm
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  leftArmsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection! @deprecated(reason: \\"Please use leftArmByPersonId instead\\")
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`PersonSecret\` that is related to this \`Person\`.\\"\\"\\"
+  personSecretByPersonId: PersonSecret
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  personSecretsByPersonId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection! @deprecated(reason: \\"Please use personSecretByPersonId instead\\")
+  site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
+}
+
+\\"\\"\\"
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonCondition {
+  \\"\\"\\"Checks for equality with the object’s \`about\` field.\\"\\"\\"
+  about: String
+
+  \\"\\"\\"Checks for equality with the object’s \`aliases\` field.\\"\\"\\"
+  aliases: [String]
+
+  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  createdAt: Datetime
+
+  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  email: Email
+
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`site\` field.\\"\\"\\"
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"An input for mutations affecting \`Person\`\\"\\"\\"
+input PersonInput {
+  about: String
+  aliases: [String]
+  createdAt: Datetime
+  email: Email!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String!
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"
+Represents an update to a \`Person\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonPatch {
+  about: String
+  aliases: [String]
+  createdAt: Datetime
+  email: Email
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+
+  \\"\\"\\"A secret held by the associated Person\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"An input for mutations affecting \`PersonSecret\`\\"\\"\\"
+input PersonSecretInput {
+  personId: Int!
+
+  \\"\\"\\"A secret held by the associated Person\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"
+Represents an update to a \`PersonSecret\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonSecretPatch {
+  personId: Int
+
+  \\"\\"\\"A secret held by the associated Person\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"A connection to a list of \`PersonSecret\` values.\\"\\"\\"
+type PersonSecretsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`PersonSecret\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PersonSecretsEdge!]!
+
+  \\"\\"\\"A list of \`PersonSecret\` objects.\\"\\"\\"
+  nodes: [PersonSecret!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`PersonSecret\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
+}
+
+type Post {
+  authorId: Int
+  body: String
+  comptypes: [Comptype]
+  enums: [AnEnum]
+  headline: String!
+  id: Int!
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query implements Node {
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  allCompoundKeys(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`EdgeCase\`.\\"\\"\\"
+  allEdgeCases(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: EdgeCaseCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Issue756\`.\\"\\"\\"
+  allIssue756S(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: Issue756Condition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArms(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`MyTable\`.\\"\\"\\"
+  allMyTables(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: MyTableCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  allPeople(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecrets(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunction(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+
+  \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
+  compoundKey(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundType\`.\\"\\"\\"
+  compoundTypeSetQuery(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): CompoundTypesConnection!
+  intSetQuery(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection!
+
+  \\"\\"\\"Reads a single \`Issue756\` using its globally unique \`ID\`.\\"\\"\\"
+  issue756(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Issue756\`.\\"\\"\\"
+    nodeId: ID!
+  ): Issue756
+  issue756ById(id: Int!): Issue756
+  jsonIdentity(json: JSON): JSON
+  jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    nodeId: ID!
+  ): LeftArm
+  leftArmById(id: Int!): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
+
+  \\"\\"\\"Reads a single \`MyTable\` using its globally unique \`ID\`.\\"\\"\\"
+  myTable(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`MyTable\`.\\"\\"\\"
+    nodeId: ID!
+  ): MyTable
+  myTableById(id: Int!): MyTable
+  noArgsQuery: Int
+
+  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  node(
+    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    nodeId: ID!
+  ): Node
+
+  \\"\\"\\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
+  person(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Person\`.\\"\\"\\"
+    nodeId: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): PersonSecret
+  personSecretByPersonId(personId: Int!): PersonSecret
+
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+  tableQuery(id: Int): Post
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetQuery(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): PeopleConnection!
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+\\"\\"\\"All input for the \`tableMutation\` mutation.\\"\\"\\"
+input TableMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int
+}
+
+\\"\\"\\"The output of our \`tableMutation\` mutation.\\"\\"\\"
+type TableMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  post: Post
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`tableSetMutation\` mutation.\\"\\"\\"
+input TableSetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`tableSetMutation\` mutation.\\"\\"\\"
+type TableSetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  people: [Person]
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`typesMutation\` mutation.\\"\\"\\"
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+\\"\\"\\"The output of our \`typesMutation\` mutation.\\"\\"\\"
+type TypesMutationPayload {
+  boolean: Boolean
+
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+\\"\\"\\"
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \\"\\"\\"
+  compoundKeyPatch: CompoundKeyPatch!
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the \`updateCompoundKey\` mutation.\\"\\"\\"
+input UpdateCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \\"\\"\\"
+  compoundKeyPatch: CompoundKeyPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`CompoundKey\` mutation.\\"\\"\\"
+type UpdateCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateIssue756ById\` mutation.\\"\\"\\"
+input UpdateIssue756ByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Issue756\` being updated.
+  \\"\\"\\"
+  issue756Patch: Issue756Patch!
+}
+
+\\"\\"\\"All input for the \`updateIssue756\` mutation.\\"\\"\\"
+input UpdateIssue756Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Issue756\` being updated.
+  \\"\\"\\"
+  issue756Patch: Issue756Patch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Issue756\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`Issue756\` mutation.\\"\\"\\"
+type UpdateIssue756Payload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Issue756\` that was updated by this mutation.\\"\\"\\"
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateLeftArmById\` mutation.\\"\\"\\"
+input UpdateLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+}
+
+\\"\\"\\"All input for the \`updateLeftArmByPersonId\` mutation.\\"\\"\\"
+input UpdateLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArm\` mutation.\\"\\"\\"
+input UpdateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`LeftArm\` mutation.\\"\\"\\"
+type UpdateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateMyTableById\` mutation.\\"\\"\\"
+input UpdateMyTableByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`MyTable\` being updated.
+  \\"\\"\\"
+  myTablePatch: MyTablePatch!
+}
+
+\\"\\"\\"All input for the \`updateMyTable\` mutation.\\"\\"\\"
+input UpdateMyTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`MyTable\` being updated.
+  \\"\\"\\"
+  myTablePatch: MyTablePatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`MyTable\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`MyTable\` mutation.\\"\\"\\"
+type UpdateMyTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`MyTable\` that was updated by this mutation.\\"\\"\\"
+  myTable: MyTable
+
+  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
+  myTableEdge(
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonByEmail\` mutation.\\"\\"\\"
+input UpdatePersonByEmailInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  email: Email!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonById\` mutation.\\"\\"\\"
+input UpdatePersonByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"All input for the \`updatePerson\` mutation.\\"\\"\\"
+input UpdatePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"The output of our update \`Person\` mutation.\\"\\"\\"
+type UpdatePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonSecretByPersonId\` mutation.\\"\\"\\"
+input UpdatePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonSecret\` mutation.\\"\\"\\"
+input UpdatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"The output of our update \`PersonSecret\` mutation.\\"\\"\\"
+type UpdatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`PersonSecret\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+\\"\\"\\"
+scalar UUID
+
+type WrappedUrl {
+  url: NotNullUrl!
+}
+
+\\"\\"\\"An input for mutations affecting \`WrappedUrl\`\\"\\"\\"
+input WrappedUrlInput {
+  url: NotNullUrl!
+}
+"
+`;

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -1909,7 +1909,13 @@ type Person implements Node {
   ): PeopleConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
-  friendsList: [Person]
+  friendsList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Person]
 
   \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   id: Int!
@@ -2483,7 +2489,13 @@ type Query implements Node {
   ): PeopleConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
-  badlyBehavedFunctionList: [Person]
+  badlyBehavedFunctionList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Person]
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -2516,7 +2528,13 @@ type Query implements Node {
   ): CompoundTypesConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`CompoundType\`.\\"\\"\\"
-  compoundTypeSetQueryList: [CompoundType]
+  compoundTypeSetQueryList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [CompoundType]
   intSetQuery(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
     after: Cursor
@@ -2539,7 +2557,16 @@ type Query implements Node {
     y: Int
     z: Int
   ): IntSetQueryConnection!
-  intSetQueryList(x: Int, y: Int, z: Int): [Int]
+  intSetQueryList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): [Int]
 
   \\"\\"\\"Reads a single \`Issue756\` using its globally unique \`ID\`.\\"\\"\\"
   issue756(
@@ -2623,7 +2650,13 @@ type Query implements Node {
   ): PeopleConnection!
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
-  tableSetQueryList: [Person]
+  tableSetQueryList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Person]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/simple-collections.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema/simple-collections.test.js
@@ -1,0 +1,9 @@
+const core = require("./core");
+
+test(
+  "prints a schema with simple collections",
+  core.test("c", {
+    simpleCollections: "both",
+    setofFunctionsContainNulls: false,
+  })
+);

--- a/packages/postgraphile-core/package.json
+++ b/packages/postgraphile-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile-core",
-  "version": "4.0.0-beta.7.1",
+  "version": "4.0.0-beta.7.2",
   "description": "",
   "main": "node8plus/index.js",
   "scripts": {
@@ -18,8 +18,8 @@
     "url": "https://github.com/graphile/graphile-build/issues"
   },
   "dependencies": {
-    "graphile-build": "4.0.0-beta.7.1",
-    "graphile-build-pg": "4.0.0-beta.7.1"
+    "graphile-build": "4.0.0-beta.7.2",
+    "graphile-build-pg": "4.0.0-beta.7.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/postgraphile-core/package.json
+++ b/packages/postgraphile-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile-core",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.7.1",
   "description": "",
   "main": "node8plus/index.js",
   "scripts": {
@@ -18,8 +18,8 @@
     "url": "https://github.com/graphile/graphile-build/issues"
   },
   "dependencies": {
-    "graphile-build": "4.0.0-beta.7",
-    "graphile-build-pg": "4.0.0-beta.7"
+    "graphile-build": "4.0.0-beta.7.1",
+    "graphile-build-pg": "4.0.0-beta.7.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -44,9 +44,10 @@ type PostGraphileOptions = {
   readCache?: string,
   writeCache?: string,
   setWriteCacheCallback?: (fn: () => Promise<void>) => void,
-  legacyRelations?: "only" | "deprecated",
+  legacyRelations?: "only" | "deprecated" | "omit",
   setofFunctionsContainNulls?: boolean,
   legacyJsonUuid?: boolean,
+  simpleCollections?: "only" | "both" | "omit",
 };
 
 type PgConfig = Client | Pool | string;
@@ -144,6 +145,7 @@ const getPostGraphileBuilder = async (
     legacyRelations = "deprecated", // TODO: Change to 'omit' in v5
     setofFunctionsContainNulls = true,
     legacyJsonUuid = false,
+    simpleCollections = "omit",
   } = options;
 
   if (
@@ -153,6 +155,15 @@ const getPostGraphileBuilder = async (
     throw new Error(
       "Invalid configuration for legacy relations: " +
         JSON.stringify(legacyRelations)
+    );
+  }
+  if (
+    simpleCollections &&
+    ["only", "both", "omit"].indexOf(simpleCollections) < 0
+  ) {
+    throw new Error(
+      "Invalid configuration for simple collections: " +
+        JSON.stringify(simpleCollections)
     );
   }
   if (replaceAllPlugins) {
@@ -271,6 +282,7 @@ const getPostGraphileBuilder = async (
         pgLegacyJsonUuid: legacyJsonUuid,
         persistentMemoizeWithKey,
         pgForbidSetofFunctionsToReturnNull: !setofFunctionsContainNulls,
+        pgSimpleCollections: simpleCollections,
       },
       graphileBuildOptions,
       graphqlBuildOptions // DEPRECATED!

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,10 @@ acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
@@ -1121,7 +1125,7 @@ chalk@0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^1.1.3:
+chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1807,11 +1811,72 @@ eslint@^4.0.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
+eslint@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
+eslint_d@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/eslint_d/-/eslint_d-5.3.1.tgz#d393bc3bd49dd8e60ce58ff22d1c8a50a23d4222"
+  dependencies:
+    chalk "^1.1.1"
+    eslint "^4.19.1"
+    nanolru "^1.0.0"
+    optionator "^0.8.1"
+    resolve "^1.1.7"
+    supports-color "^3.1.2"
+
 espree@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
   dependencies:
     acorn "^5.4.0"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
 esprima@^2.7.1:
@@ -3557,6 +3622,10 @@ nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
+nanolru@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nanolru/-/nanolru-1.0.0.tgz#0a5679cd4e4578c4ca3741e610b71c4c9b5afaf8"
+
 nanomatch@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
@@ -4139,6 +4208,10 @@ regex-not@^1.0.0:
   dependencies:
     extend-shallow "^2.0.1"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -4241,6 +4314,12 @@ resolve-url@^0.2.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.7:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
 
 resolve@^1.3.2:
   version "1.4.0"
@@ -4626,7 +4705,7 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^4.0.1:
+table@4.0.2, table@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:


### PR DESCRIPTION
This adds a way to get lists of table rows without using Relay-compatible pagination - it effectively flattens the requests a bit.

e.g. this:

```graphql
{
  allAlbumsList(condition: {artistId: 127}) {
    id
    title
    tracksByAlbumIdList {
      id
      name
      genreByGenreId {
        name
      }
    }
  }
}
```

instead of this:

```graphql
{
  allAlbums(condition: {artistId: 127}) {
    nodes {
      id
      title
      tracksByAlbumId {
        nodes {
          id
          name
          genreByGenreId {
            name
          }
        }
      }
    }
  }
}
```

The "simple collections" support arguments `first`, `offset`, `condition` and `orderBy` like connections but do NOT support `before`, `after` or `last` because there's no access to cursors in the result set.

Simple collections are significantly lighter on server resources than relay connections.