### PR TITLE
feat(pg): introspection of subtypes, exclude extension resources

### DIFF
--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -170,6 +170,7 @@ with
         (typ.typelem <> 0 and typ.typlen = -1) as "isPgArray",
         nullif(typ.typrelid, 0) as "classId",
         nullif(typ.typbasetype, 0) as "domainBaseTypeId",
+        nullif(typ.typtypmod, -1) as "domainTypeModifier",
         -- If this type is an enum type, let’s select all of its enum variants.
         --
         -- @see https://www.postgresql.org/docs/9.5/static/catalog-pg-enum.html

--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -242,6 +242,23 @@ with
       con.contype in ('f', 'p', 'u')
     order by
       con.conrelid, con.conkey, con.confrelid, con.confkey, con.conname
+  ),
+  -- @see https://www.postgresql.org/docs/9.5/static/catalog-pg-extension.html
+  "extension" as (
+    select
+      'extension' as "kind",
+      ext.oid as "id",
+      ext.extname as "name",
+      ext.extnamespace as "namespaceId",
+      ext.extrelocatable as "relocatable",
+      ext.extversion as "version",
+      ext.extconfig as "configurationClassIds",
+      dsc.description as "description"
+    from
+      pg_catalog.pg_extension as ext
+      left join pg_catalog.pg_description as dsc on dsc.objoid = ext.oid
+    order by
+      ext.extname, ext.oid
   )
 select row_to_json(x) as object from namespace as x
 union all
@@ -254,4 +271,6 @@ union all
 select row_to_json(x) as object from "constraint" as x
 union all
 select row_to_json(x) as object from procedure as x
+union all
+select row_to_json(x) as object from extension as x
 ;

--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -121,6 +121,7 @@ with
       att.attname as "name",
       dsc.description as "description",
       att.atttypid as "typeId",
+      nullif(att.atttypmod, -1) as "typeModifier",
       att.attnotnull as "isNotNull",
       att.atthasdef as "hasDefault"
     from

--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -2,8 +2,8 @@
 -- @see https://github.com/graphile/postgraphile/blob/master/resources/introspection-query.sql
 --
 -- ## Parameters
--- - `$1`: An array of strings that represent the namespaces we are
---   introspecting.
+-- - `$1`: An array of strings that represent the namespaces we are introspecting.
+-- - `$2`: set true to include functions/tables/etc that come from extensions
 with
   -- @see https://www.postgresql.org/docs/9.5/static/catalog-pg-namespace.html
   namespace as (
@@ -69,7 +69,12 @@ with
       -- twice. This leads to duplicate fields in the API which throws an
       -- error. In the future we may support this case. For now though, it is
       -- too complex.
-      (select count(pro2.*) from pg_catalog.pg_proc as pro2 where pro2.pronamespace = pro.pronamespace and pro2.proname = pro.proname) = 1
+      (select count(pro2.*) from pg_catalog.pg_proc as pro2 where pro2.pronamespace = pro.pronamespace and pro2.proname = pro.proname) = 1 and
+      ($2 is true or not exists(
+        select 1
+        from pg_catalog.pg_depend
+        where pg_depend.refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass and pg_depend.deptype = 'e' and pg_depend.objid = pro.oid
+      ))
     order by
       pro.pronamespace, pro.proname
   ),
@@ -108,7 +113,12 @@ with
       rel.relpersistence in ('p') and
       -- We don't want classes that will clash with GraphQL (treat them as private)
       rel.relname not like E'\\_\\_%' and
-      rel.relkind in ('r', 'v', 'm', 'c', 'f')
+      rel.relkind in ('r', 'v', 'm', 'c', 'f') and
+      ($2 is true or not exists(
+        select 1
+        from pg_catalog.pg_depend
+        where pg_depend.refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass and pg_depend.deptype = 'e' and pg_depend.objid = rel.oid
+      ))
     order by
       rel.relnamespace, rel.relname
   ),

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -10,11 +10,7 @@ const debugSql = debugFactory("graphile-build-pg:sql");
 
 export default (async function PgAllRows(
   builder,
-  {
-    pgViewUniqueKey: viewUniqueKey,
-    pgSimpleCollections,
-    pgIncludeExtensionConfigurationTables = false,
-  }
+  { pgViewUniqueKey: viewUniqueKey, pgSimpleCollections }
 ) {
   const hasConnections = pgSimpleCollections !== "only";
   const hasSimpleCollections =
@@ -39,11 +35,6 @@ export default (async function PgAllRows(
       introspectionResultsByKind.class
         .filter(table => table.isSelectable)
         .filter(table => table.namespace)
-        .filter(
-          table =>
-            pgIncludeExtensionConfigurationTables ||
-            !table.isExtensionConfigurationTable
-        )
         .reduce((memo, table) => {
           if (omit(table, "all")) {
             return memo;

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -20,7 +20,7 @@ export default (async function PgAllRows(
       parseResolveInfo,
       extend,
       getTypeByName,
-      pgGetGqlTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
       pgSql: sql,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       inflection,
@@ -39,7 +39,10 @@ export default (async function PgAllRows(
           if (omit(table, "all")) {
             return memo;
           }
-          const TableType = pgGetGqlTypeByTypeId(table.type.id);
+          const TableType = pgGetGqlTypeByTypeIdAndModifier(
+            table.type.id,
+            null
+          );
           const tableTypeName = TableType.name;
           const ConnectionType = getTypeByName(
             inflection.connection(TableType.name)

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -28,7 +28,7 @@ export default (function PgBackwardRelationPlugin(
     const {
       extend,
       getTypeByName,
-      pgGetGqlTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgSql: sql,
       getSafeAliasFromResolveInfo,
@@ -60,7 +60,10 @@ export default (function PgBackwardRelationPlugin(
         }
         const table = introspectionResultsByKind.classById[constraint.classId];
         const tableTypeName = inflection.tableType(table);
-        const gqlTableType = pgGetGqlTypeByTypeId(table.type.id);
+        const gqlTableType = pgGetGqlTypeByTypeIdAndModifier(
+          table.type.id,
+          null
+        );
         if (!gqlTableType) {
           debug(
             `Could not determine type for table with id ${constraint.classId}`
@@ -70,7 +73,10 @@ export default (function PgBackwardRelationPlugin(
         const foreignTable =
           introspectionResultsByKind.classById[constraint.foreignClassId];
         const foreignTableTypeName = inflection.tableType(foreignTable);
-        const gqlForeignTableType = pgGetGqlTypeByTypeId(foreignTable.type.id);
+        const gqlForeignTableType = pgGetGqlTypeByTypeIdAndModifier(
+          foreignTable.type.id,
+          null
+        );
         if (!gqlForeignTableType) {
           debug(
             `Could not determine type for foreign table with id ${
@@ -283,7 +289,10 @@ export default (function PgBackwardRelationPlugin(
                 const ConnectionType = getTypeByName(
                   inflection.connection(gqlTableType.name)
                 );
-                const TableType = pgGetGqlTypeByTypeId(table.type.id);
+                const TableType = pgGetGqlTypeByTypeIdAndModifier(
+                  table.type.id,
+                  null
+                );
                 return {
                   description: `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
                   type: isConnection

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -94,24 +94,27 @@ export default (function PgColumnsPlugin(builder) {
                             end
                           )
                         `;
-                      } else if (type.type === "c") {
+                      } else {
                         const resolveData = getDataFromParsedResolveInfoFragment(
                           parsedResolveInfoFragment,
                           ReturnType
                         );
-                        const jsonBuildObject = queryFromResolveData(
-                          sql.identifier(Symbol()), // Ignore!
-                          sqlFullName,
-                          resolveData,
-                          { onlyJsonField: true, addNullCase: true }
-                        );
-                        return jsonBuildObject;
-                      } else {
-                        return pgTweakFragmentForTypeAndModifier(
-                          sqlFullName,
-                          type,
-                          typeModifier
-                        );
+                        if (type.type === "c") {
+                          const jsonBuildObject = queryFromResolveData(
+                            sql.identifier(Symbol()), // Ignore!
+                            sqlFullName,
+                            resolveData,
+                            { onlyJsonField: true, addNullCase: true }
+                          );
+                          return jsonBuildObject;
+                        } else {
+                          return pgTweakFragmentForTypeAndModifier(
+                            sqlFullName,
+                            type,
+                            typeModifier,
+                            resolveData
+                          );
+                        }
                       }
                     };
                     queryBuilder.select(

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -87,7 +87,7 @@ export default (function PgColumnsPlugin(builder) {
                                 select json_agg(${getSelectValueForFieldAndTypeAndModifier(
                                   ident,
                                   type.arrayItemType,
-                                  typeModifier // TODO: check that type does cascade through array?
+                                  typeModifier
                                 )})
                                 from unnest(${sqlFullName}) as ${ident}
                               )

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -7,7 +7,7 @@ export default (function PgConnectionArgCondition(builder) {
     const {
       newWithHooks,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
-      pgGetGqlInputTypeByTypeId,
+      pgGetGqlInputTypeByTypeIdAndModifier,
       graphql: { GraphQLInputObjectType, GraphQLString },
       pgColumnFilter,
       inflection,
@@ -36,7 +36,10 @@ export default (function PgConnectionArgCondition(builder) {
                     {
                       description: `Checks for equality with the object’s \`${fieldName}\` field.`,
                       type:
-                        pgGetGqlInputTypeByTypeId(attr.typeId) || GraphQLString,
+                        pgGetGqlInputTypeByTypeIdAndModifier(
+                          attr.typeId,
+                          attr.typeModifier
+                        ) || GraphQLString,
                     },
                     {
                       isPgConnectionConditionInputField: true,
@@ -62,7 +65,7 @@ export default (function PgConnectionArgCondition(builder) {
         gql2pg,
         extend,
         getTypeByName,
-        pgGetGqlTypeByTypeId,
+        pgGetGqlTypeByTypeIdAndModifier,
         pgIntrospectionResultsByKind: introspectionResultsByKind,
         pgColumnFilter,
         inflection,
@@ -88,7 +91,7 @@ export default (function PgConnectionArgCondition(builder) {
       ) {
         return args;
       }
-      const TableType = pgGetGqlTypeByTypeId(table.type.id);
+      const TableType = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
       const TableConditionType = getTypeByName(
         inflection.conditionType(TableType.name)
       );

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -45,7 +45,7 @@ export default (function PgConnectionArgOrderBy(builder) {
       const {
         extend,
         getTypeByName,
-        pgGetGqlTypeByTypeId,
+        pgGetGqlTypeByTypeIdAndModifier,
         pgSql: sql,
         graphql: { GraphQLList, GraphQLNonNull },
         inflection,
@@ -71,7 +71,7 @@ export default (function PgConnectionArgOrderBy(builder) {
       ) {
         return args;
       }
-      const TableType = pgGetGqlTypeByTypeId(table.type.id);
+      const TableType = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
       const tableTypeName = TableType.name;
       const TableOrderByType = getTypeByName(
         inflection.orderByType(tableTypeName)

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -5,7 +5,12 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
   builder.hook(
     "GraphQLObjectType:fields:field:args",
     (args, build, context) => {
-      const { extend, getTypeByName, pgGetGqlTypeByTypeId, inflection } = build;
+      const {
+        extend,
+        getTypeByName,
+        pgGetGqlTypeByTypeIdAndModifier,
+        inflection,
+      } = build;
       const {
         scope: { isPgFieldConnection, pgFieldIntrospection: table },
         Self,
@@ -21,7 +26,7 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
       ) {
         return args;
       }
-      const TableType = pgGetGqlTypeByTypeId(table.type.id);
+      const TableType = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
       const tableTypeName = TableType.name;
       const TableOrderByType = getTypeByName(
         inflection.orderByType(tableTypeName)

--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -12,7 +12,7 @@ export default (function PgForwardRelationPlugin(builder) {
       extend,
       getSafeAliasFromResolveInfo,
       getSafeAliasFromAlias,
-      pgGetGqlTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgSql: sql,
       inflection,
@@ -51,7 +51,10 @@ export default (function PgForwardRelationPlugin(builder) {
         if (omit(constraint, "read")) {
           return memo;
         }
-        const gqlTableType = pgGetGqlTypeByTypeId(table.type.id);
+        const gqlTableType = pgGetGqlTypeByTypeIdAndModifier(
+          table.type.id,
+          null
+        );
         const tableTypeName = gqlTableType.name;
         if (!gqlTableType) {
           debug(
@@ -61,7 +64,10 @@ export default (function PgForwardRelationPlugin(builder) {
         }
         const foreignTable =
           introspectionResultsByKind.classById[constraint.foreignClassId];
-        const gqlForeignTableType = pgGetGqlTypeByTypeId(foreignTable.type.id);
+        const gqlForeignTableType = pgGetGqlTypeByTypeIdAndModifier(
+          foreignTable.type.id,
+          null
+        );
         const foreignTableTypeName = gqlForeignTableType.name;
         if (!gqlForeignTableType) {
           debug(

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -84,6 +84,7 @@ export type PgAttribute = {
   name: string,
   description: ?string,
   typeId: string,
+  typeModifier: number,
   isNotNull: boolean,
   hasDefault: boolean,
   class: PgClass,

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -375,8 +375,7 @@ export default (async function PgIntrospectionPlugin(
       "configurationClasses",
       "configurationClassIds",
       introspectionResultsByKind.classById,
-      true, // Because the configuration table could be a defined in a different namespace
-      true
+      true // Because the configuration table could be a defined in a different namespace
     );
 
     return introspectionResultsByKind;

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -76,6 +76,7 @@ export type PgType = {
   isPgArray: boolean,
   classId: ?string,
   domainBaseTypeId: ?string,
+  domainTypeModifier: ?number,
   tags: { [string]: string },
 };
 

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -137,6 +137,7 @@ export default (async function PgIntrospectionPlugin(
     pgEnableTags,
     persistentMemoizeWithKey = (key, fn) => fn(),
     pgThrowOnMissingSchema = false,
+    pgIncludeExtensionResources = false,
   }
 ) {
   async function introspect() {
@@ -156,7 +157,10 @@ export default (async function PgIntrospectionPlugin(
       await persistentMemoizeWithKey(cacheKey, () =>
         withPgClient(pgConfig, async pgClient => {
           const introspectionQuery = await readFile(INTROSPECTION_PATH, "utf8");
-          const { rows } = await pgClient.query(introspectionQuery, [schemas]);
+          const { rows } = await pgClient.query(introspectionQuery, [
+            schemas,
+            pgIncludeExtensionResources,
+          ]);
 
           const result = rows.reduce(
             (memo, { object }) => {

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -20,8 +20,8 @@ export default (function PgMutationCreatePlugin(
       newWithHooks,
       parseResolveInfo,
       pgIntrospectionResultsByKind,
-      pgGetGqlTypeByTypeId,
-      pgGetGqlInputTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
+      pgGetGqlInputTypeByTypeIdAndModifier,
       pgSql: sql,
       gql2pg,
       graphql: {
@@ -45,7 +45,7 @@ export default (function PgMutationCreatePlugin(
         .filter(table => table.isSelectable)
         .filter(table => table.isInsertable && !omit(table, "create"))
         .reduce((memo, table) => {
-          const Table = pgGetGqlTypeByTypeId(table.type.id);
+          const Table = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
           if (!Table) {
             debug(
               `There was no table type for table '${table.namespace.name}.${
@@ -54,7 +54,10 @@ export default (function PgMutationCreatePlugin(
             );
             return memo;
           }
-          const TableInput = pgGetGqlInputTypeByTypeId(table.type.id);
+          const TableInput = pgGetGqlInputTypeByTypeIdAndModifier(
+            table.type.id,
+            null
+          );
           if (!TableInput) {
             debug(
               `There was no input type for table '${table.namespace.name}.${

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -8,7 +8,7 @@ export default (function PgMutationPayloadEdgePlugin(builder) {
     const {
       extend,
       getTypeByName,
-      pgGetGqlTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
       pgSql: sql,
       graphql: { GraphQLList, GraphQLNonNull },
       pgIntrospectionResultsByKind: introspectionResultsByKind,
@@ -31,7 +31,7 @@ export default (function PgMutationPayloadEdgePlugin(builder) {
     ) {
       return fields;
     }
-    const TableType = pgGetGqlTypeByTypeId(table.type.id);
+    const TableType = pgGetGqlTypeByTypeIdAndModifier(table.type.id, null);
     const tableTypeName = TableType.name;
     const TableOrderByType = getTypeByName(
       inflection.orderByType(tableTypeName)

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -10,7 +10,7 @@ const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 
 export default (async function PgMutationUpdateDeletePlugin(
   builder,
-  { pgDisableDefaultMutations, pgIncludeExtensionConfigurationTables = false }
+  { pgDisableDefaultMutations }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -51,11 +51,6 @@ export default (async function PgMutationUpdateDeletePlugin(
         (outerMemo, mode) =>
           introspectionResultsByKind.class
             .filter(table => !!table.namespace)
-            .filter(
-              table =>
-                pgIncludeExtensionConfigurationTables ||
-                !table.isExtensionConfigurationTable
-            )
             .filter(
               table =>
                 (mode === "update" &&

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -25,8 +25,8 @@ export default (async function PgMutationUpdateDeletePlugin(
       parseResolveInfo,
       getTypeByName,
       gql2pg,
-      pgGetGqlTypeByTypeId,
-      pgGetGqlInputTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
+      pgGetGqlInputTypeByTypeIdAndModifier,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgSql: sql,
       getNodeType,
@@ -61,7 +61,10 @@ export default (async function PgMutationUpdateDeletePlugin(
                   !omit(table, "delete"))
             )
             .reduce((memo, table) => {
-              const TableType = pgGetGqlTypeByTypeId(table.type.id);
+              const TableType = pgGetGqlTypeByTypeIdAndModifier(
+                table.type.id,
+                null
+              );
               async function commonCodeRenameMe(
                 pgClient,
                 resolveInfo,
@@ -172,7 +175,10 @@ export default (async function PgMutationUpdateDeletePlugin(
                 const attributes = introspectionResultsByKind.attribute
                   .filter(attr => attr.classId === table.id)
                   .sort((a, b) => a.num - b.num);
-                const Table = pgGetGqlTypeByTypeId(table.type.id);
+                const Table = pgGetGqlTypeByTypeIdAndModifier(
+                  table.type.id,
+                  null
+                );
                 const tableTypeName = Table.name;
                 const TablePatch = getTypeByName(
                   inflection.patchType(Table.name)
@@ -433,7 +439,10 @@ export default (async function PgMutationUpdateDeletePlugin(
                           memo[inflection.column(key)] = {
                             description: key.description,
                             type: new GraphQLNonNull(
-                              pgGetGqlInputTypeByTypeId(key.typeId)
+                              pgGetGqlInputTypeByTypeIdAndModifier(
+                                key.typeId,
+                                key.typeModifier
+                              )
                             ),
                           };
                           return memo;

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -10,7 +10,7 @@ const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 
 export default (async function PgMutationUpdateDeletePlugin(
   builder,
-  { pgDisableDefaultMutations }
+  { pgDisableDefaultMutations, pgIncludeExtensionConfigurationTables = false }
 ) {
   if (pgDisableDefaultMutations) {
     return;
@@ -53,6 +53,11 @@ export default (async function PgMutationUpdateDeletePlugin(
             .filter(table => !!table.namespace)
             .filter(
               table =>
+                pgIncludeExtensionConfigurationTables ||
+                !table.isExtensionConfigurationTable
+            )
+            .filter(
+              table =>
                 (mode === "update" &&
                   table.isUpdatable &&
                   !omit(table, "update")) ||
@@ -65,6 +70,9 @@ export default (async function PgMutationUpdateDeletePlugin(
                 table.type.id,
                 null
               );
+              if (!TableType) {
+                return memo;
+              }
               async function commonCodeRenameMe(
                 pgClient,
                 resolveInfo,

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -5,10 +5,7 @@ import debugFactory from "debug";
 import omit from "../omit";
 const debugSql = debugFactory("graphile-build-pg:sql");
 
-export default (async function PgRowByUniqueConstraint(
-  builder,
-  { pgIncludeExtensionConfigurationTables = false }
-) {
+export default (async function PgRowByUniqueConstraint(builder) {
   builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
     const {
       extend,
@@ -30,11 +27,6 @@ export default (async function PgRowByUniqueConstraint(
       introspectionResultsByKind.class
         .filter(table => !!table.namespace)
         .filter(table => !omit(table, "read"))
-        .filter(
-          table =>
-            pgIncludeExtensionConfigurationTables ||
-            !table.isExtensionConfigurationTable
-        )
         .reduce((memo, table) => {
           const TableType = pgGetGqlTypeByTypeIdAndModifier(
             table.type.id,

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -5,7 +5,10 @@ import debugFactory from "debug";
 import omit from "../omit";
 const debugSql = debugFactory("graphile-build-pg:sql");
 
-export default (async function PgRowByUniqueConstraint(builder) {
+export default (async function PgRowByUniqueConstraint(
+  builder,
+  { pgIncludeExtensionConfigurationTables = false }
+) {
   builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
     const {
       extend,
@@ -27,6 +30,11 @@ export default (async function PgRowByUniqueConstraint(builder) {
       introspectionResultsByKind.class
         .filter(table => !!table.namespace)
         .filter(table => !omit(table, "read"))
+        .filter(
+          table =>
+            pgIncludeExtensionConfigurationTables ||
+            !table.isExtensionConfigurationTable
+        )
         .reduce((memo, table) => {
           const TableType = pgGetGqlTypeByTypeIdAndModifier(
             table.type.id,

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -10,8 +10,8 @@ export default (async function PgRowByUniqueConstraint(builder) {
     const {
       extend,
       parseResolveInfo,
-      pgGetGqlTypeByTypeId,
-      pgGetGqlInputTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
+      pgGetGqlInputTypeByTypeIdAndModifier,
       gql2pg,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgSql: sql,
@@ -28,7 +28,10 @@ export default (async function PgRowByUniqueConstraint(builder) {
         .filter(table => !!table.namespace)
         .filter(table => !omit(table, "read"))
         .reduce((memo, table) => {
-          const TableType = pgGetGqlTypeByTypeId(table.type.id);
+          const TableType = pgGetGqlTypeByTypeIdAndModifier(
+            table.type.id,
+            null
+          );
           const sqlFullTableName = sql.identifier(
             table.namespace.name,
             table.name
@@ -66,7 +69,10 @@ export default (async function PgRowByUniqueConstraint(builder) {
                   return {
                     type: TableType,
                     args: keys.reduce((memo, key) => {
-                      const InputType = pgGetGqlInputTypeByTypeId(key.typeId);
+                      const InputType = pgGetGqlInputTypeByTypeIdAndModifier(
+                        key.typeId,
+                        key.typeModifier
+                      );
                       if (!InputType) {
                         throw new Error(
                           `Could not find input type for key '${

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -7,10 +7,7 @@ import omit from "../omit";
 const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 const debugSql = debugFactory("graphile-build-pg:sql");
 
-export default (async function PgRowNode(
-  builder,
-  { pgIncludeExtensionConfigurationTables = false }
-) {
+export default (async function PgRowNode(builder) {
   builder.hook("GraphQLObjectType", (object, build, context) => {
     const {
       addNodeFetcherForTypeName,
@@ -96,11 +93,6 @@ export default (async function PgRowNode(
       introspectionResultsByKind.class
         .filter(table => !!table.namespace)
         .filter(table => !omit(table, "read"))
-        .filter(
-          table =>
-            pgIncludeExtensionConfigurationTables ||
-            !table.isExtensionConfigurationTable
-        )
         .reduce((memo, table) => {
           const TableType = pgGetGqlTypeByTypeIdAndModifier(
             table.type.id,

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -76,7 +76,7 @@ export default (async function PgRowByUniqueConstraint(builder) {
       nodeIdFieldName,
       extend,
       parseResolveInfo,
-      pgGetGqlTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgSql: sql,
       gql2pg,
@@ -94,7 +94,10 @@ export default (async function PgRowByUniqueConstraint(builder) {
         .filter(table => !!table.namespace)
         .filter(table => !omit(table, "read"))
         .reduce((memo, table) => {
-          const TableType = pgGetGqlTypeByTypeId(table.type.id);
+          const TableType = pgGetGqlTypeByTypeIdAndModifier(
+            table.type.id,
+            null
+          );
           const sqlFullTableName = sql.identifier(
             table.namespace.name,
             table.name

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -7,7 +7,10 @@ import omit from "../omit";
 const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 const debugSql = debugFactory("graphile-build-pg:sql");
 
-export default (async function PgRowByUniqueConstraint(builder) {
+export default (async function PgRowNode(
+  builder,
+  { pgIncludeExtensionConfigurationTables = false }
+) {
   builder.hook("GraphQLObjectType", (object, build, context) => {
     const {
       addNodeFetcherForTypeName,
@@ -93,6 +96,11 @@ export default (async function PgRowByUniqueConstraint(builder) {
       introspectionResultsByKind.class
         .filter(table => !!table.namespace)
         .filter(table => !omit(table, "read"))
+        .filter(
+          table =>
+            pgIncludeExtensionConfigurationTables ||
+            !table.isExtensionConfigurationTable
+        )
         .reduce((memo, table) => {
           const TableType = pgGetGqlTypeByTypeIdAndModifier(
             table.type.id,

--- a/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
@@ -12,7 +12,7 @@ export default (function PgScalarFunctionConnectionPlugin(
       newWithHooks,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       getTypeByName,
-      pgGetGqlTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
       graphql: {
         GraphQLObjectType,
         GraphQLNonNull,
@@ -37,7 +37,11 @@ export default (function PgScalarFunctionConnectionPlugin(
           // Just use the standard table connection from PgTablesPlugin
           return;
         }
-        const NodeType = pgGetGqlTypeByTypeId(returnType.id) || GraphQLString;
+        // TODO: PG10 doesn't support the equivalent of pg_attribute.atttypemod
+        // on function arguments and return types, however maybe a later
+        // version of PG will?
+        const NodeType =
+          pgGetGqlTypeByTypeIdAndModifier(returnType.id, null) || GraphQLString;
         const EdgeType = newWithHooks(
           GraphQLObjectType,
           {

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -41,8 +41,8 @@ export default (function PgTablesPlugin(
       pgSql: sql,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       getTypeByName,
-      pgGetGqlTypeByTypeId,
-      pgGetGqlInputTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier,
+      pgGetGqlInputTypeByTypeIdAndModifier,
       pgRegisterGqlTypeByTypeId,
       pgRegisterGqlInputTypeByTypeId,
       pg2GqlMapper,
@@ -359,7 +359,10 @@ export default (function PgTablesPlugin(
       pgRegisterGqlInputTypeByTypeId(
         tablePgType.id,
         () => {
-          const TableType = pgGetGqlTypeByTypeId(tablePgType.id);
+          const TableType = pgGetGqlTypeByTypeIdAndModifier(
+            tablePgType.id,
+            null
+          );
           return getTypeByName(inflection.inputType(TableType));
         },
         true
@@ -376,7 +379,10 @@ export default (function PgTablesPlugin(
         pgRegisterGqlTypeByTypeId(
           arrayTablePgType.id,
           () => {
-            const TableType = pgGetGqlTypeByTypeId(tablePgType.id);
+            const TableType = pgGetGqlTypeByTypeIdAndModifier(
+              tablePgType.id,
+              null
+            );
             return new GraphQLList(TableType);
           },
           true
@@ -384,7 +390,10 @@ export default (function PgTablesPlugin(
         pgRegisterGqlInputTypeByTypeId(
           arrayTablePgType.id,
           () => {
-            const TableInputType = pgGetGqlInputTypeByTypeId(tablePgType.id);
+            const TableInputType = pgGetGqlInputTypeByTypeIdAndModifier(
+              tablePgType.id,
+              null
+            );
             return new GraphQLList(TableInputType);
           },
           true

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -21,7 +21,10 @@ const hasNonNullKey = row => {
 
 export default (function PgTablesPlugin(
   builder,
-  { pgForbidSetofFunctionsToReturnNull = false }
+  {
+    pgForbidSetofFunctionsToReturnNull = false,
+    pgIncludeExtensionConfigurationTables = false,
+  }
 ) {
   const handleNullRow = pgForbidSetofFunctionsToReturnNull
     ? row => row
@@ -60,21 +63,27 @@ export default (function PgTablesPlugin(
     const nullableIf = (condition, Type) =>
       condition ? Type : new GraphQLNonNull(Type);
     const Cursor = getTypeByName("Cursor");
-    introspectionResultsByKind.class.forEach(table => {
-      const tablePgType = introspectionResultsByKind.type.find(
-        type =>
-          type.type === "c" &&
-          type.category === "C" &&
-          type.namespaceId === table.namespaceId &&
-          type.classId === table.id
-      );
-      if (!tablePgType) {
-        throw new Error("Could not determine the type for this table");
-      }
-      const arrayTablePgType = introspectionResultsByKind.type.find(
-        type => type.arrayItemTypeId === tablePgType.id
-      );
-      /*
+    introspectionResultsByKind.class
+      .filter(
+        table =>
+          pgIncludeExtensionConfigurationTables ||
+          !table.isExtensionConfigurationTable
+      )
+      .forEach(table => {
+        const tablePgType = introspectionResultsByKind.type.find(
+          type =>
+            type.type === "c" &&
+            type.category === "C" &&
+            type.namespaceId === table.namespaceId &&
+            type.classId === table.id
+        );
+        if (!tablePgType) {
+          throw new Error("Could not determine the type for this table");
+        }
+        const arrayTablePgType = introspectionResultsByKind.type.find(
+          type => type.arrayItemTypeId === tablePgType.id
+        );
+        /*
         table =
           { kind: 'class',
             id: '6484790',
@@ -87,319 +96,322 @@ export default (function PgTablesPlugin(
             isUpdatable: true,
             isDeletable: true }
         */
-      const primaryKeyConstraint = introspectionResultsByKind.constraint
-        .filter(con => con.classId === table.id)
-        .filter(con => con.type === "p")[0];
-      const primaryKeys =
-        primaryKeyConstraint &&
-        primaryKeyConstraint.keyAttributeNums.map(
-          num =>
-            introspectionResultsByKind.attributeByClassIdAndNum[table.id][num]
-        );
-      const attributes = introspectionResultsByKind.attribute
-        .filter(attr => attr.classId === table.id)
-        .sort((a1, a2) => a1.num - a2.num);
-      const tableTypeName = inflection.tableType(table);
-      const shouldHaveNodeId: boolean =
-        nodeIdFieldName &&
-        table.isSelectable &&
-        table.namespace &&
-        primaryKeys &&
-        primaryKeys.length
-          ? true
-          : false;
-      pgRegisterGqlTypeByTypeId(
-        tablePgType.id,
-        cb => {
-          if (pg2GqlMapper[tablePgType.id]) {
-            // Already handled
-            throw new Error(
-              `Register was called but there's already a mapper in place for '${
-                tablePgType.id
-              }'!`
-            );
-          }
-          const TableType = newWithHooks(
-            GraphQLObjectType,
-            {
-              description: table.description || tablePgType.description,
-              name: tableTypeName,
-              interfaces: () => {
-                if (shouldHaveNodeId) {
-                  return [getTypeByName("Node")];
-                } else {
-                  return [];
-                }
-              },
-              fields: ({ addDataGeneratorForField, Self }) => {
-                const fields = {};
-                if (shouldHaveNodeId) {
-                  // Enable nodeId interface
-                  addDataGeneratorForField(nodeIdFieldName, () => {
-                    return {
-                      pgQuery: queryBuilder => {
-                        queryBuilder.select(
-                          sql.fragment`json_build_array(${sql.join(
-                            primaryKeys.map(
-                              key =>
-                                sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-                                  key.name
-                                )}`
-                            ),
-                            ", "
-                          )})`,
-                          "__identifiers"
+        const primaryKeyConstraint = introspectionResultsByKind.constraint
+          .filter(con => con.classId === table.id)
+          .filter(con => con.type === "p")[0];
+        const primaryKeys =
+          primaryKeyConstraint &&
+          primaryKeyConstraint.keyAttributeNums.map(
+            num =>
+              introspectionResultsByKind.attributeByClassIdAndNum[table.id][num]
+          );
+        const attributes = introspectionResultsByKind.attribute
+          .filter(attr => attr.classId === table.id)
+          .sort((a1, a2) => a1.num - a2.num);
+        const tableTypeName = inflection.tableType(table);
+        const shouldHaveNodeId: boolean =
+          nodeIdFieldName &&
+          table.isSelectable &&
+          table.namespace &&
+          primaryKeys &&
+          primaryKeys.length
+            ? true
+            : false;
+        pgRegisterGqlTypeByTypeId(
+          tablePgType.id,
+          cb => {
+            if (pg2GqlMapper[tablePgType.id]) {
+              // Already handled
+              throw new Error(
+                `Register was called but there's already a mapper in place for '${
+                  tablePgType.id
+                }'!`
+              );
+            }
+            const TableType = newWithHooks(
+              GraphQLObjectType,
+              {
+                description: table.description || tablePgType.description,
+                name: tableTypeName,
+                interfaces: () => {
+                  if (shouldHaveNodeId) {
+                    return [getTypeByName("Node")];
+                  } else {
+                    return [];
+                  }
+                },
+                fields: ({ addDataGeneratorForField, Self }) => {
+                  const fields = {};
+                  if (shouldHaveNodeId) {
+                    // Enable nodeId interface
+                    addDataGeneratorForField(nodeIdFieldName, () => {
+                      return {
+                        pgQuery: queryBuilder => {
+                          queryBuilder.select(
+                            sql.fragment`json_build_array(${sql.join(
+                              primaryKeys.map(
+                                key =>
+                                  sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
+                                    key.name
+                                  )}`
+                              ),
+                              ", "
+                            )})`,
+                            "__identifiers"
+                          );
+                        },
+                      };
+                    });
+                    fields[nodeIdFieldName] = {
+                      description:
+                        "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
+                      type: new GraphQLNonNull(GraphQLID),
+                      resolve(data) {
+                        return (
+                          data.__identifiers &&
+                          getNodeIdForTypeAndIdentifiers(
+                            Self,
+                            ...data.__identifiers
+                          )
                         );
                       },
                     };
-                  });
-                  fields[nodeIdFieldName] = {
-                    description:
-                      "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
-                    type: new GraphQLNonNull(GraphQLID),
-                    resolve(data) {
-                      return (
-                        data.__identifiers &&
-                        getNodeIdForTypeAndIdentifiers(
-                          Self,
-                          ...data.__identifiers
-                        )
-                      );
-                    },
-                  };
-                }
-                return fields;
-              },
-            },
-            {
-              pgIntrospection: table,
-              isPgRowType: table.isSelectable,
-              isPgCompoundType: !table.isSelectable,
-            }
-          );
-          cb(TableType);
-          const pgInputFields = {};
-          newWithHooks(
-            GraphQLInputObjectType,
-            {
-              description: `An input for mutations affecting \`${tableTypeName}\``,
-              name: inflection.inputType(TableType),
-              fields: context => {
-                pg2GqlMapper[tablePgType.id] = {
-                  map: _ => _,
-                  unmap: obj => {
-                    return sql.fragment`row(${sql.join(
-                      attributes.map(attr => {
-                        if (!pgColumnFilter(attr, build, context)) {
-                          return sql.null; // TODO: return default instead.
-                        }
-                        const fieldName = inflection.column(attr);
-                        const pgInputField = pgInputFields[fieldName];
-                        const v = obj[fieldName];
-                        if (pgInputField && v != null) {
-                          const { type } = pgInputField;
-                          return sql.fragment`${gql2pg(
-                            v,
-                            type
-                          )}::${sql.identifier(type.namespaceName, type.name)}`;
-                        } else {
-                          return sql.null; // TODO: return default instead.
-                        }
-                      }),
-                      ","
-                    )})::${sql.identifier(
-                      tablePgType.namespaceName,
-                      tablePgType.name
-                    )}`;
-                  },
-                };
-                return {};
-              },
-            },
-            {
-              pgIntrospection: table,
-              isInputType: true,
-              isPgRowType: table.isSelectable,
-              isPgCompoundType: !table.isSelectable,
-              pgAddSubfield(fieldName, attrName, pgType, spec) {
-                pgInputFields[fieldName] = {
-                  name: attrName,
-                  type: pgType,
-                };
-                return spec;
-              },
-            }
-          );
-
-          if (table.isSelectable) {
-            /* const TablePatchType = */
-            newWithHooks(
-              GraphQLInputObjectType,
-              {
-                description: `Represents an update to a \`${tableTypeName}\`. Fields that are set will be updated.`,
-                name: inflection.patchType(TableType),
+                  }
+                  return fields;
+                },
               },
               {
                 pgIntrospection: table,
                 isPgRowType: table.isSelectable,
                 isPgCompoundType: !table.isSelectable,
-                isPgPatch: true,
-                pgAddSubfield(fieldName, _attrName, _type, spec) {
-                  // We don't use this currently
+              }
+            );
+            cb(TableType);
+            const pgInputFields = {};
+            newWithHooks(
+              GraphQLInputObjectType,
+              {
+                description: `An input for mutations affecting \`${tableTypeName}\``,
+                name: inflection.inputType(TableType),
+                fields: context => {
+                  pg2GqlMapper[tablePgType.id] = {
+                    map: _ => _,
+                    unmap: obj => {
+                      return sql.fragment`row(${sql.join(
+                        attributes.map(attr => {
+                          if (!pgColumnFilter(attr, build, context)) {
+                            return sql.null; // TODO: return default instead.
+                          }
+                          const fieldName = inflection.column(attr);
+                          const pgInputField = pgInputFields[fieldName];
+                          const v = obj[fieldName];
+                          if (pgInputField && v != null) {
+                            const { type } = pgInputField;
+                            return sql.fragment`${gql2pg(
+                              v,
+                              type
+                            )}::${sql.identifier(
+                              type.namespaceName,
+                              type.name
+                            )}`;
+                          } else {
+                            return sql.null; // TODO: return default instead.
+                          }
+                        }),
+                        ","
+                      )})::${sql.identifier(
+                        tablePgType.namespaceName,
+                        tablePgType.name
+                      )}`;
+                    },
+                  };
+                  return {};
+                },
+              },
+              {
+                pgIntrospection: table,
+                isInputType: true,
+                isPgRowType: table.isSelectable,
+                isPgCompoundType: !table.isSelectable,
+                pgAddSubfield(fieldName, attrName, pgType, spec) {
+                  pgInputFields[fieldName] = {
+                    name: attrName,
+                    type: pgType,
+                  };
                   return spec;
                 },
               }
             );
-          }
-          const EdgeType = newWithHooks(
-            GraphQLObjectType,
-            {
-              description: `A \`${tableTypeName}\` edge in the connection.`,
-              name: inflection.edge(TableType.name),
-              fields: ({ fieldWithHooks, recurseDataGeneratorsForField }) => {
-                recurseDataGeneratorsForField("node");
-                return {
-                  cursor: fieldWithHooks(
-                    "cursor",
-                    ({ addDataGenerator }) => {
-                      addDataGenerator(() => ({
-                        usesCursor: [true],
-                      }));
-                      return {
-                        description: "A cursor for use in pagination.",
-                        type: Cursor,
-                        resolve(data) {
-                          return (
-                            data.__cursor &&
-                            base64(JSON.stringify(data.__cursor))
-                          );
-                        },
-                      };
-                    },
-                    {
-                      isCursorField: true,
-                    }
-                  ),
-                  node: {
-                    description: `The \`${tableTypeName}\` at the end of the edge.`,
-                    type: nullableIf(
-                      !pgForbidSetofFunctionsToReturnNull,
-                      TableType
-                    ),
-                    resolve(data) {
-                      return handleNullRow(data);
-                    },
-                  },
-                };
-              },
-            },
-            {
-              isEdgeType: true,
-              isPgRowEdgeType: true,
-              nodeType: TableType,
-              pgIntrospection: table,
-            }
-          );
-          const PageInfo = getTypeByName("PageInfo");
-          /*const ConnectionType = */
-          newWithHooks(
-            GraphQLObjectType,
-            {
-              description: `A connection to a list of \`${tableTypeName}\` values.`,
-              name: inflection.connection(TableType.name),
-              fields: ({ recurseDataGeneratorsForField }) => {
-                recurseDataGeneratorsForField("edges");
-                recurseDataGeneratorsForField("nodes");
-                recurseDataGeneratorsForField("pageInfo");
-                return {
-                  nodes: {
-                    description: `A list of \`${tableTypeName}\` objects.`,
-                    type: new GraphQLNonNull(
-                      new GraphQLList(
-                        nullableIf(
-                          !pgForbidSetofFunctionsToReturnNull,
-                          TableType
-                        )
-                      )
-                    ),
-                    resolve(data) {
-                      return data.data.map(handleNullRow);
-                    },
-                  },
-                  edges: {
-                    description: `A list of edges which contains the \`${tableTypeName}\` and cursor to aid in pagination.`,
-                    type: new GraphQLNonNull(
-                      new GraphQLList(new GraphQLNonNull(EdgeType))
-                    ),
-                    resolve(data) {
-                      return data.data;
-                    },
-                  },
-                  pageInfo: PageInfo && {
-                    description: "Information to aid in pagination.",
-                    type: new GraphQLNonNull(PageInfo),
-                    resolve(data) {
-                      return data;
-                    },
-                  },
-                };
-              },
-            },
-            {
-              isConnectionType: true,
-              isPgRowConnectionType: true,
-              edgeType: EdgeType,
-              nodeType: TableType,
-              pgIntrospection: table,
-            }
-          );
-        },
-        true
-      );
-      pgRegisterGqlInputTypeByTypeId(
-        tablePgType.id,
-        () => {
-          const TableType = pgGetGqlTypeByTypeIdAndModifier(
-            tablePgType.id,
-            null
-          );
-          return getTypeByName(inflection.inputType(TableType));
-        },
-        true
-      );
 
-      if (arrayTablePgType) {
-        // Note: these do not return
-        //
-        // `new GraphQLList(new GraphQLNonNull(...))`
-        //
-        // because it's possible to return null entries from postgresql
-        // functions. We should probably add a flag to instead export
-        // the non-null version as that's more typical.
-        pgRegisterGqlTypeByTypeId(
-          arrayTablePgType.id,
+            if (table.isSelectable) {
+              /* const TablePatchType = */
+              newWithHooks(
+                GraphQLInputObjectType,
+                {
+                  description: `Represents an update to a \`${tableTypeName}\`. Fields that are set will be updated.`,
+                  name: inflection.patchType(TableType),
+                },
+                {
+                  pgIntrospection: table,
+                  isPgRowType: table.isSelectable,
+                  isPgCompoundType: !table.isSelectable,
+                  isPgPatch: true,
+                  pgAddSubfield(fieldName, _attrName, _type, spec) {
+                    // We don't use this currently
+                    return spec;
+                  },
+                }
+              );
+            }
+            const EdgeType = newWithHooks(
+              GraphQLObjectType,
+              {
+                description: `A \`${tableTypeName}\` edge in the connection.`,
+                name: inflection.edge(TableType.name),
+                fields: ({ fieldWithHooks, recurseDataGeneratorsForField }) => {
+                  recurseDataGeneratorsForField("node");
+                  return {
+                    cursor: fieldWithHooks(
+                      "cursor",
+                      ({ addDataGenerator }) => {
+                        addDataGenerator(() => ({
+                          usesCursor: [true],
+                        }));
+                        return {
+                          description: "A cursor for use in pagination.",
+                          type: Cursor,
+                          resolve(data) {
+                            return (
+                              data.__cursor &&
+                              base64(JSON.stringify(data.__cursor))
+                            );
+                          },
+                        };
+                      },
+                      {
+                        isCursorField: true,
+                      }
+                    ),
+                    node: {
+                      description: `The \`${tableTypeName}\` at the end of the edge.`,
+                      type: nullableIf(
+                        !pgForbidSetofFunctionsToReturnNull,
+                        TableType
+                      ),
+                      resolve(data) {
+                        return handleNullRow(data);
+                      },
+                    },
+                  };
+                },
+              },
+              {
+                isEdgeType: true,
+                isPgRowEdgeType: true,
+                nodeType: TableType,
+                pgIntrospection: table,
+              }
+            );
+            const PageInfo = getTypeByName("PageInfo");
+            /*const ConnectionType = */
+            newWithHooks(
+              GraphQLObjectType,
+              {
+                description: `A connection to a list of \`${tableTypeName}\` values.`,
+                name: inflection.connection(TableType.name),
+                fields: ({ recurseDataGeneratorsForField }) => {
+                  recurseDataGeneratorsForField("edges");
+                  recurseDataGeneratorsForField("nodes");
+                  recurseDataGeneratorsForField("pageInfo");
+                  return {
+                    nodes: {
+                      description: `A list of \`${tableTypeName}\` objects.`,
+                      type: new GraphQLNonNull(
+                        new GraphQLList(
+                          nullableIf(
+                            !pgForbidSetofFunctionsToReturnNull,
+                            TableType
+                          )
+                        )
+                      ),
+                      resolve(data) {
+                        return data.data.map(handleNullRow);
+                      },
+                    },
+                    edges: {
+                      description: `A list of edges which contains the \`${tableTypeName}\` and cursor to aid in pagination.`,
+                      type: new GraphQLNonNull(
+                        new GraphQLList(new GraphQLNonNull(EdgeType))
+                      ),
+                      resolve(data) {
+                        return data.data;
+                      },
+                    },
+                    pageInfo: PageInfo && {
+                      description: "Information to aid in pagination.",
+                      type: new GraphQLNonNull(PageInfo),
+                      resolve(data) {
+                        return data;
+                      },
+                    },
+                  };
+                },
+              },
+              {
+                isConnectionType: true,
+                isPgRowConnectionType: true,
+                edgeType: EdgeType,
+                nodeType: TableType,
+                pgIntrospection: table,
+              }
+            );
+          },
+          true
+        );
+        pgRegisterGqlInputTypeByTypeId(
+          tablePgType.id,
           () => {
             const TableType = pgGetGqlTypeByTypeIdAndModifier(
               tablePgType.id,
               null
             );
-            return new GraphQLList(TableType);
+            return getTypeByName(inflection.inputType(TableType));
           },
           true
         );
-        pgRegisterGqlInputTypeByTypeId(
-          arrayTablePgType.id,
-          () => {
-            const TableInputType = pgGetGqlInputTypeByTypeIdAndModifier(
-              tablePgType.id,
-              null
-            );
-            return new GraphQLList(TableInputType);
-          },
-          true
-        );
-      }
-    });
+
+        if (arrayTablePgType) {
+          // Note: these do not return
+          //
+          // `new GraphQLList(new GraphQLNonNull(...))`
+          //
+          // because it's possible to return null entries from postgresql
+          // functions. We should probably add a flag to instead export
+          // the non-null version as that's more typical.
+          pgRegisterGqlTypeByTypeId(
+            arrayTablePgType.id,
+            () => {
+              const TableType = pgGetGqlTypeByTypeIdAndModifier(
+                tablePgType.id,
+                null
+              );
+              return new GraphQLList(TableType);
+            },
+            true
+          );
+          pgRegisterGqlInputTypeByTypeId(
+            arrayTablePgType.id,
+            () => {
+              const TableInputType = pgGetGqlInputTypeByTypeIdAndModifier(
+                tablePgType.id,
+                null
+              );
+              return new GraphQLList(TableInputType);
+            },
+            true
+          );
+        }
+      });
     return _;
   });
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -21,10 +21,7 @@ const hasNonNullKey = row => {
 
 export default (function PgTablesPlugin(
   builder,
-  {
-    pgForbidSetofFunctionsToReturnNull = false,
-    pgIncludeExtensionConfigurationTables = false,
-  }
+  { pgForbidSetofFunctionsToReturnNull = false }
 ) {
   const handleNullRow = pgForbidSetofFunctionsToReturnNull
     ? row => row
@@ -63,27 +60,21 @@ export default (function PgTablesPlugin(
     const nullableIf = (condition, Type) =>
       condition ? Type : new GraphQLNonNull(Type);
     const Cursor = getTypeByName("Cursor");
-    introspectionResultsByKind.class
-      .filter(
-        table =>
-          pgIncludeExtensionConfigurationTables ||
-          !table.isExtensionConfigurationTable
-      )
-      .forEach(table => {
-        const tablePgType = introspectionResultsByKind.type.find(
-          type =>
-            type.type === "c" &&
-            type.category === "C" &&
-            type.namespaceId === table.namespaceId &&
-            type.classId === table.id
-        );
-        if (!tablePgType) {
-          throw new Error("Could not determine the type for this table");
-        }
-        const arrayTablePgType = introspectionResultsByKind.type.find(
-          type => type.arrayItemTypeId === tablePgType.id
-        );
-        /*
+    introspectionResultsByKind.class.forEach(table => {
+      const tablePgType = introspectionResultsByKind.type.find(
+        type =>
+          type.type === "c" &&
+          type.category === "C" &&
+          type.namespaceId === table.namespaceId &&
+          type.classId === table.id
+      );
+      if (!tablePgType) {
+        throw new Error("Could not determine the type for this table");
+      }
+      const arrayTablePgType = introspectionResultsByKind.type.find(
+        type => type.arrayItemTypeId === tablePgType.id
+      );
+      /*
         table =
           { kind: 'class',
             id: '6484790',
@@ -96,322 +87,319 @@ export default (function PgTablesPlugin(
             isUpdatable: true,
             isDeletable: true }
         */
-        const primaryKeyConstraint = introspectionResultsByKind.constraint
-          .filter(con => con.classId === table.id)
-          .filter(con => con.type === "p")[0];
-        const primaryKeys =
-          primaryKeyConstraint &&
-          primaryKeyConstraint.keyAttributeNums.map(
-            num =>
-              introspectionResultsByKind.attributeByClassIdAndNum[table.id][num]
-          );
-        const attributes = introspectionResultsByKind.attribute
-          .filter(attr => attr.classId === table.id)
-          .sort((a1, a2) => a1.num - a2.num);
-        const tableTypeName = inflection.tableType(table);
-        const shouldHaveNodeId: boolean =
-          nodeIdFieldName &&
-          table.isSelectable &&
-          table.namespace &&
-          primaryKeys &&
-          primaryKeys.length
-            ? true
-            : false;
-        pgRegisterGqlTypeByTypeId(
-          tablePgType.id,
-          cb => {
-            if (pg2GqlMapper[tablePgType.id]) {
-              // Already handled
-              throw new Error(
-                `Register was called but there's already a mapper in place for '${
-                  tablePgType.id
-                }'!`
-              );
-            }
-            const TableType = newWithHooks(
-              GraphQLObjectType,
-              {
-                description: table.description || tablePgType.description,
-                name: tableTypeName,
-                interfaces: () => {
-                  if (shouldHaveNodeId) {
-                    return [getTypeByName("Node")];
-                  } else {
-                    return [];
-                  }
-                },
-                fields: ({ addDataGeneratorForField, Self }) => {
-                  const fields = {};
-                  if (shouldHaveNodeId) {
-                    // Enable nodeId interface
-                    addDataGeneratorForField(nodeIdFieldName, () => {
-                      return {
-                        pgQuery: queryBuilder => {
-                          queryBuilder.select(
-                            sql.fragment`json_build_array(${sql.join(
-                              primaryKeys.map(
-                                key =>
-                                  sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-                                    key.name
-                                  )}`
-                              ),
-                              ", "
-                            )})`,
-                            "__identifiers"
-                          );
-                        },
-                      };
-                    });
-                    fields[nodeIdFieldName] = {
-                      description:
-                        "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
-                      type: new GraphQLNonNull(GraphQLID),
-                      resolve(data) {
-                        return (
-                          data.__identifiers &&
-                          getNodeIdForTypeAndIdentifiers(
-                            Self,
-                            ...data.__identifiers
-                          )
+      const primaryKeyConstraint = introspectionResultsByKind.constraint
+        .filter(con => con.classId === table.id)
+        .filter(con => con.type === "p")[0];
+      const primaryKeys =
+        primaryKeyConstraint &&
+        primaryKeyConstraint.keyAttributeNums.map(
+          num =>
+            introspectionResultsByKind.attributeByClassIdAndNum[table.id][num]
+        );
+      const attributes = introspectionResultsByKind.attribute
+        .filter(attr => attr.classId === table.id)
+        .sort((a1, a2) => a1.num - a2.num);
+      const tableTypeName = inflection.tableType(table);
+      const shouldHaveNodeId: boolean =
+        nodeIdFieldName &&
+        table.isSelectable &&
+        table.namespace &&
+        primaryKeys &&
+        primaryKeys.length
+          ? true
+          : false;
+      pgRegisterGqlTypeByTypeId(
+        tablePgType.id,
+        cb => {
+          if (pg2GqlMapper[tablePgType.id]) {
+            // Already handled
+            throw new Error(
+              `Register was called but there's already a mapper in place for '${
+                tablePgType.id
+              }'!`
+            );
+          }
+          const TableType = newWithHooks(
+            GraphQLObjectType,
+            {
+              description: table.description || tablePgType.description,
+              name: tableTypeName,
+              interfaces: () => {
+                if (shouldHaveNodeId) {
+                  return [getTypeByName("Node")];
+                } else {
+                  return [];
+                }
+              },
+              fields: ({ addDataGeneratorForField, Self }) => {
+                const fields = {};
+                if (shouldHaveNodeId) {
+                  // Enable nodeId interface
+                  addDataGeneratorForField(nodeIdFieldName, () => {
+                    return {
+                      pgQuery: queryBuilder => {
+                        queryBuilder.select(
+                          sql.fragment`json_build_array(${sql.join(
+                            primaryKeys.map(
+                              key =>
+                                sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
+                                  key.name
+                                )}`
+                            ),
+                            ", "
+                          )})`,
+                          "__identifiers"
                         );
                       },
                     };
-                  }
-                  return fields;
-                },
+                  });
+                  fields[nodeIdFieldName] = {
+                    description:
+                      "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
+                    type: new GraphQLNonNull(GraphQLID),
+                    resolve(data) {
+                      return (
+                        data.__identifiers &&
+                        getNodeIdForTypeAndIdentifiers(
+                          Self,
+                          ...data.__identifiers
+                        )
+                      );
+                    },
+                  };
+                }
+                return fields;
               },
-              {
-                pgIntrospection: table,
-                isPgRowType: table.isSelectable,
-                isPgCompoundType: !table.isSelectable,
-              }
-            );
-            cb(TableType);
-            const pgInputFields = {};
+            },
+            {
+              pgIntrospection: table,
+              isPgRowType: table.isSelectable,
+              isPgCompoundType: !table.isSelectable,
+            }
+          );
+          cb(TableType);
+          const pgInputFields = {};
+          newWithHooks(
+            GraphQLInputObjectType,
+            {
+              description: `An input for mutations affecting \`${tableTypeName}\``,
+              name: inflection.inputType(TableType),
+              fields: context => {
+                pg2GqlMapper[tablePgType.id] = {
+                  map: _ => _,
+                  unmap: obj => {
+                    return sql.fragment`row(${sql.join(
+                      attributes.map(attr => {
+                        if (!pgColumnFilter(attr, build, context)) {
+                          return sql.null; // TODO: return default instead.
+                        }
+                        const fieldName = inflection.column(attr);
+                        const pgInputField = pgInputFields[fieldName];
+                        const v = obj[fieldName];
+                        if (pgInputField && v != null) {
+                          const { type } = pgInputField;
+                          return sql.fragment`${gql2pg(
+                            v,
+                            type
+                          )}::${sql.identifier(type.namespaceName, type.name)}`;
+                        } else {
+                          return sql.null; // TODO: return default instead.
+                        }
+                      }),
+                      ","
+                    )})::${sql.identifier(
+                      tablePgType.namespaceName,
+                      tablePgType.name
+                    )}`;
+                  },
+                };
+                return {};
+              },
+            },
+            {
+              pgIntrospection: table,
+              isInputType: true,
+              isPgRowType: table.isSelectable,
+              isPgCompoundType: !table.isSelectable,
+              pgAddSubfield(fieldName, attrName, pgType, spec) {
+                pgInputFields[fieldName] = {
+                  name: attrName,
+                  type: pgType,
+                };
+                return spec;
+              },
+            }
+          );
+
+          if (table.isSelectable) {
+            /* const TablePatchType = */
             newWithHooks(
               GraphQLInputObjectType,
               {
-                description: `An input for mutations affecting \`${tableTypeName}\``,
-                name: inflection.inputType(TableType),
-                fields: context => {
-                  pg2GqlMapper[tablePgType.id] = {
-                    map: _ => _,
-                    unmap: obj => {
-                      return sql.fragment`row(${sql.join(
-                        attributes.map(attr => {
-                          if (!pgColumnFilter(attr, build, context)) {
-                            return sql.null; // TODO: return default instead.
-                          }
-                          const fieldName = inflection.column(attr);
-                          const pgInputField = pgInputFields[fieldName];
-                          const v = obj[fieldName];
-                          if (pgInputField && v != null) {
-                            const { type } = pgInputField;
-                            return sql.fragment`${gql2pg(
-                              v,
-                              type
-                            )}::${sql.identifier(
-                              type.namespaceName,
-                              type.name
-                            )}`;
-                          } else {
-                            return sql.null; // TODO: return default instead.
-                          }
-                        }),
-                        ","
-                      )})::${sql.identifier(
-                        tablePgType.namespaceName,
-                        tablePgType.name
-                      )}`;
-                    },
-                  };
-                  return {};
-                },
+                description: `Represents an update to a \`${tableTypeName}\`. Fields that are set will be updated.`,
+                name: inflection.patchType(TableType),
               },
               {
                 pgIntrospection: table,
-                isInputType: true,
                 isPgRowType: table.isSelectable,
                 isPgCompoundType: !table.isSelectable,
-                pgAddSubfield(fieldName, attrName, pgType, spec) {
-                  pgInputFields[fieldName] = {
-                    name: attrName,
-                    type: pgType,
-                  };
+                isPgPatch: true,
+                pgAddSubfield(fieldName, _attrName, _type, spec) {
+                  // We don't use this currently
                   return spec;
                 },
               }
             );
-
-            if (table.isSelectable) {
-              /* const TablePatchType = */
-              newWithHooks(
-                GraphQLInputObjectType,
-                {
-                  description: `Represents an update to a \`${tableTypeName}\`. Fields that are set will be updated.`,
-                  name: inflection.patchType(TableType),
-                },
-                {
-                  pgIntrospection: table,
-                  isPgRowType: table.isSelectable,
-                  isPgCompoundType: !table.isSelectable,
-                  isPgPatch: true,
-                  pgAddSubfield(fieldName, _attrName, _type, spec) {
-                    // We don't use this currently
-                    return spec;
-                  },
-                }
-              );
-            }
-            const EdgeType = newWithHooks(
-              GraphQLObjectType,
-              {
-                description: `A \`${tableTypeName}\` edge in the connection.`,
-                name: inflection.edge(TableType.name),
-                fields: ({ fieldWithHooks, recurseDataGeneratorsForField }) => {
-                  recurseDataGeneratorsForField("node");
-                  return {
-                    cursor: fieldWithHooks(
-                      "cursor",
-                      ({ addDataGenerator }) => {
-                        addDataGenerator(() => ({
-                          usesCursor: [true],
-                        }));
-                        return {
-                          description: "A cursor for use in pagination.",
-                          type: Cursor,
-                          resolve(data) {
-                            return (
-                              data.__cursor &&
-                              base64(JSON.stringify(data.__cursor))
-                            );
-                          },
-                        };
-                      },
-                      {
-                        isCursorField: true,
-                      }
+          }
+          const EdgeType = newWithHooks(
+            GraphQLObjectType,
+            {
+              description: `A \`${tableTypeName}\` edge in the connection.`,
+              name: inflection.edge(TableType.name),
+              fields: ({ fieldWithHooks, recurseDataGeneratorsForField }) => {
+                recurseDataGeneratorsForField("node");
+                return {
+                  cursor: fieldWithHooks(
+                    "cursor",
+                    ({ addDataGenerator }) => {
+                      addDataGenerator(() => ({
+                        usesCursor: [true],
+                      }));
+                      return {
+                        description: "A cursor for use in pagination.",
+                        type: Cursor,
+                        resolve(data) {
+                          return (
+                            data.__cursor &&
+                            base64(JSON.stringify(data.__cursor))
+                          );
+                        },
+                      };
+                    },
+                    {
+                      isCursorField: true,
+                    }
+                  ),
+                  node: {
+                    description: `The \`${tableTypeName}\` at the end of the edge.`,
+                    type: nullableIf(
+                      !pgForbidSetofFunctionsToReturnNull,
+                      TableType
                     ),
-                    node: {
-                      description: `The \`${tableTypeName}\` at the end of the edge.`,
-                      type: nullableIf(
-                        !pgForbidSetofFunctionsToReturnNull,
-                        TableType
-                      ),
-                      resolve(data) {
-                        return handleNullRow(data);
-                      },
+                    resolve(data) {
+                      return handleNullRow(data);
                     },
-                  };
-                },
+                  },
+                };
               },
-              {
-                isEdgeType: true,
-                isPgRowEdgeType: true,
-                nodeType: TableType,
-                pgIntrospection: table,
-              }
-            );
-            const PageInfo = getTypeByName("PageInfo");
-            /*const ConnectionType = */
-            newWithHooks(
-              GraphQLObjectType,
-              {
-                description: `A connection to a list of \`${tableTypeName}\` values.`,
-                name: inflection.connection(TableType.name),
-                fields: ({ recurseDataGeneratorsForField }) => {
-                  recurseDataGeneratorsForField("edges");
-                  recurseDataGeneratorsForField("nodes");
-                  recurseDataGeneratorsForField("pageInfo");
-                  return {
-                    nodes: {
-                      description: `A list of \`${tableTypeName}\` objects.`,
-                      type: new GraphQLNonNull(
-                        new GraphQLList(
-                          nullableIf(
-                            !pgForbidSetofFunctionsToReturnNull,
-                            TableType
-                          )
+            },
+            {
+              isEdgeType: true,
+              isPgRowEdgeType: true,
+              nodeType: TableType,
+              pgIntrospection: table,
+            }
+          );
+          const PageInfo = getTypeByName("PageInfo");
+          /*const ConnectionType = */
+          newWithHooks(
+            GraphQLObjectType,
+            {
+              description: `A connection to a list of \`${tableTypeName}\` values.`,
+              name: inflection.connection(TableType.name),
+              fields: ({ recurseDataGeneratorsForField }) => {
+                recurseDataGeneratorsForField("edges");
+                recurseDataGeneratorsForField("nodes");
+                recurseDataGeneratorsForField("pageInfo");
+                return {
+                  nodes: {
+                    description: `A list of \`${tableTypeName}\` objects.`,
+                    type: new GraphQLNonNull(
+                      new GraphQLList(
+                        nullableIf(
+                          !pgForbidSetofFunctionsToReturnNull,
+                          TableType
                         )
-                      ),
-                      resolve(data) {
-                        return data.data.map(handleNullRow);
-                      },
+                      )
+                    ),
+                    resolve(data) {
+                      return data.data.map(handleNullRow);
                     },
-                    edges: {
-                      description: `A list of edges which contains the \`${tableTypeName}\` and cursor to aid in pagination.`,
-                      type: new GraphQLNonNull(
-                        new GraphQLList(new GraphQLNonNull(EdgeType))
-                      ),
-                      resolve(data) {
-                        return data.data;
-                      },
+                  },
+                  edges: {
+                    description: `A list of edges which contains the \`${tableTypeName}\` and cursor to aid in pagination.`,
+                    type: new GraphQLNonNull(
+                      new GraphQLList(new GraphQLNonNull(EdgeType))
+                    ),
+                    resolve(data) {
+                      return data.data;
                     },
-                    pageInfo: PageInfo && {
-                      description: "Information to aid in pagination.",
-                      type: new GraphQLNonNull(PageInfo),
-                      resolve(data) {
-                        return data;
-                      },
+                  },
+                  pageInfo: PageInfo && {
+                    description: "Information to aid in pagination.",
+                    type: new GraphQLNonNull(PageInfo),
+                    resolve(data) {
+                      return data;
                     },
-                  };
-                },
+                  },
+                };
               },
-              {
-                isConnectionType: true,
-                isPgRowConnectionType: true,
-                edgeType: EdgeType,
-                nodeType: TableType,
-                pgIntrospection: table,
-              }
-            );
-          },
-          true
-        );
-        pgRegisterGqlInputTypeByTypeId(
-          tablePgType.id,
+            },
+            {
+              isConnectionType: true,
+              isPgRowConnectionType: true,
+              edgeType: EdgeType,
+              nodeType: TableType,
+              pgIntrospection: table,
+            }
+          );
+        },
+        true
+      );
+      pgRegisterGqlInputTypeByTypeId(
+        tablePgType.id,
+        () => {
+          const TableType = pgGetGqlTypeByTypeIdAndModifier(
+            tablePgType.id,
+            null
+          );
+          return getTypeByName(inflection.inputType(TableType));
+        },
+        true
+      );
+
+      if (arrayTablePgType) {
+        // Note: these do not return
+        //
+        // `new GraphQLList(new GraphQLNonNull(...))`
+        //
+        // because it's possible to return null entries from postgresql
+        // functions. We should probably add a flag to instead export
+        // the non-null version as that's more typical.
+        pgRegisterGqlTypeByTypeId(
+          arrayTablePgType.id,
           () => {
             const TableType = pgGetGqlTypeByTypeIdAndModifier(
               tablePgType.id,
               null
             );
-            return getTypeByName(inflection.inputType(TableType));
+            return new GraphQLList(TableType);
           },
           true
         );
-
-        if (arrayTablePgType) {
-          // Note: these do not return
-          //
-          // `new GraphQLList(new GraphQLNonNull(...))`
-          //
-          // because it's possible to return null entries from postgresql
-          // functions. We should probably add a flag to instead export
-          // the non-null version as that's more typical.
-          pgRegisterGqlTypeByTypeId(
-            arrayTablePgType.id,
-            () => {
-              const TableType = pgGetGqlTypeByTypeIdAndModifier(
-                tablePgType.id,
-                null
-              );
-              return new GraphQLList(TableType);
-            },
-            true
-          );
-          pgRegisterGqlInputTypeByTypeId(
-            arrayTablePgType.id,
-            () => {
-              const TableInputType = pgGetGqlInputTypeByTypeIdAndModifier(
-                tablePgType.id,
-                null
-              );
-              return new GraphQLList(TableInputType);
-            },
-            true
-          );
-        }
-      });
+        pgRegisterGqlInputTypeByTypeId(
+          arrayTablePgType.id,
+          () => {
+            const TableInputType = pgGetGqlInputTypeByTypeIdAndModifier(
+              tablePgType.id,
+              null
+            );
+            return new GraphQLList(TableInputType);
+          },
+          true
+        );
+      }
+    });
     return _;
   });
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -92,10 +92,19 @@ export default (function PgTypesPlugin(
 
     const gqlTypeByTypeIdGenerator = {};
     const gqlInputTypeByTypeIdGenerator = {};
-    const gqlTypeByTypeId = Object.assign({}, build.pgGqlTypeByTypeId);
-    const gqlInputTypeByTypeId = Object.assign(
+    if (build.pgGqlTypeByTypeId || build.pgGqlInputTypeByTypeId) {
+      // I don't expect anyone to receive this error, because I don't think anyone uses this interface.
+      throw new Error(
+        "Sorry! This interface is no longer supported because it is not granular enough. It's not hard to port it to the new system - please contact Benjie and he'll walk you through it."
+      );
+    }
+    const gqlTypeByTypeIdAndModifier = Object.assign(
       {},
-      build.pgGqlInputTypeByTypeId
+      build.pgGqlTypeByTypeIdAndModifier
+    );
+    const gqlInputTypeByTypeIdAndModifier = Object.assign(
+      {},
+      build.pgGqlInputTypeByTypeIdAndModifier
     );
     const pg2GqlMapper = {};
     const pg2gql = (val, type) => {
@@ -252,6 +261,7 @@ export default (function PgTypesPlugin(
 
     const tweakToJson = fragment => fragment; // Since everything is to_json'd now, just pass through
     const tweakToText = fragment => sql.fragment`(${fragment})::text`;
+    const pgTweaksByTypeIdAndModifer = {};
     const pgTweaksByTypeId = Object.assign(
       // ::text rawTypes
       rawTypes.reduce((memo, typeId) => {
@@ -283,21 +293,30 @@ export default (function PgTypesPlugin(
 
       A: type =>
         new GraphQLList(
-          enforceGqlTypeByPgType(pgTypeById[type.arrayItemTypeId])
+          enforceGqlTypeByPgType(pgTypeById[type.arrayItemTypeId], null)
         ),
     };
 
-    const pgTweakFragmentForType = (fragment, type) => {
-      const tweaker = pgTweaksByTypeId[type.id];
+    const pgTweakFragmentForTypeAndModifier = (fragment, type, modifier) => {
+      const tweaker =
+        (pgTweaksByTypeIdAndModifer[type.id] &&
+          pgTweaksByTypeIdAndModifer[type.id][modifier]) ||
+        pgTweaksByTypeId[type.id];
       if (tweaker) {
         return tweaker(fragment);
       } else if (type.domainBaseType) {
-        return pgTweakFragmentForType(fragment, type.domainBaseType);
+        // TODO: check that domains don't support atttypemod
+        return pgTweakFragmentForTypeAndModifier(
+          fragment,
+          type.domainBaseType,
+          null
+        );
       } else if (type.isPgArray) {
         const error = new Error(
           "Internal graphile-build-pg error: should not attempt to tweak an array, please process array before tweaking (type: `${type.namespaceName}.${type.name}`)"
         );
         if (process.env.NODE_ENV === "test") {
+          // This is to ensure that Graphile core does not introduce these problems
           throw error;
         }
         // eslint-disable-next-line no-console
@@ -473,13 +492,13 @@ export default (function PgTypesPlugin(
     // TODO: add more support for geometric types
 
     let depth = 0;
-    const enforceGqlTypeByPgType = type => {
+    const enforceGqlTypeByPgType = (type, typeModifier) => {
       depth++;
       if (depth > 50) {
         throw new Error("Type enforcement went too deep - infinite loop?");
       }
       try {
-        return reallyEnforceGqlTypeByPgType(type);
+        return reallyEnforceGqlTypeByPgTypeAndModifier(type, typeModifier);
       } catch (e) {
         const error = new Error(
           `Error occurred when processing database type '${
@@ -493,28 +512,42 @@ export default (function PgTypesPlugin(
         depth--;
       }
     };
-    const reallyEnforceGqlTypeByPgType = type => {
+    const reallyEnforceGqlTypeByPgTypeAndModifier = (type, typeModifier) => {
       if (!type.id) {
         throw new Error(
           `Invalid argument to enforceGqlTypeByPgType - expected a full type, received '${type}'`
         );
       }
+      if (!gqlTypeByTypeIdAndModifier[type.id]) {
+        gqlTypeByTypeIdAndModifier[type.id] = {};
+      }
+      if (!gqlInputTypeByTypeIdAndModifier[type.id]) {
+        gqlInputTypeByTypeIdAndModifier[type.id] = {};
+      }
+      const typeModifierKey = typeModifier ? typeModifier : -1;
       // Explicit overrides
-      if (!gqlTypeByTypeId[type.id]) {
+      if (!gqlTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
         const gqlType = oidLookup[type.id];
         if (gqlType) {
-          gqlTypeByTypeId[type.id] = gqlType;
+          gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = gqlType;
         }
       }
-      if (!gqlInputTypeByTypeId[type.id]) {
+      if (!gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
         const gqlInputType = oidInputLookup[type.id];
         if (gqlInputType) {
-          gqlInputTypeByTypeId[type.id] = gqlInputType;
+          gqlInputTypeByTypeIdAndModifier[type.id][
+            typeModifierKey
+          ] = gqlInputType;
         }
       }
       // Enums
-      if (!gqlTypeByTypeId[type.id] && type.type === "e") {
-        gqlTypeByTypeId[type.id] = new GraphQLEnumType({
+      if (
+        !gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] &&
+        type.type === "e"
+      ) {
+        gqlTypeByTypeIdAndModifier[type.id][
+          typeModifierKey
+        ] = new GraphQLEnumType({
           name: inflection.enumType(type),
           description: type.description,
           values: type.enumVariants.reduce((memo, value) => {
@@ -526,10 +559,13 @@ export default (function PgTypesPlugin(
         });
       }
       // Ranges
-      if (!gqlTypeByTypeId[type.id] && type.type === "r") {
+      if (
+        !gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] &&
+        type.type === "r"
+      ) {
         const subtype =
           introspectionResultsByKind.typeById[type.rangeSubTypeId];
-        const gqlRangeSubType = enforceGqlTypeByPgType(subtype);
+        const gqlRangeSubType = enforceGqlTypeByPgType(subtype, typeModifier);
         if (!gqlRangeSubType) {
           throw new Error("Range of unsupported");
         }
@@ -601,8 +637,8 @@ export default (function PgTypesPlugin(
         } else {
           RangeInput = getTypeByName(inflection.inputType(Range.name));
         }
-        gqlTypeByTypeId[type.id] = Range;
-        gqlInputTypeByTypeId[type.id] = RangeInput;
+        gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = Range;
+        gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] = RangeInput;
         pg2GqlMapper[type.id] = {
           map: pgRange => {
             const parsed = pgRangeParser.parse(pgRange);
@@ -647,57 +683,74 @@ export default (function PgTypesPlugin(
 
       // Domains
       if (
-        !gqlTypeByTypeId[type.id] &&
+        !gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] &&
         type.type === "d" &&
         type.domainBaseTypeId
       ) {
-        const baseType = enforceGqlTypeByPgType(type.domainBaseType);
-        const baseInputType = gqlInputTypeByTypeId[type.domainBaseTypeId];
+        const baseType = enforceGqlTypeByPgType(
+          type.domainBaseType,
+          typeModifier
+        );
+        const baseInputType =
+          gqlInputTypeByTypeIdAndModifier[type.domainBaseTypeId][
+            typeModifierKey
+          ];
         // Hack stolen from: https://github.com/graphile/postgraphile/blob/ade728ed8f8e3ecdc5fdad7d770c67aa573578eb/src/graphql/schema/type/aliasGqlType.ts#L16
-        gqlTypeByTypeId[type.id] = Object.assign(Object.create(baseType), {
-          name: inflection.domainType(type),
-          description: type.description,
-        });
+        gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = Object.assign(
+          Object.create(baseType),
+          {
+            name: inflection.domainType(type),
+            description: type.description,
+          }
+        );
         if (baseInputType && baseInputType !== baseType) {
-          gqlInputTypeByTypeId[type.id] = Object.assign(
-            Object.create(baseInputType),
-            {
-              name: inflection.inputType(gqlTypeByTypeId[type.id]),
-              description: type.description,
-            }
-          );
+          gqlInputTypeByTypeIdAndModifier[type.id][
+            typeModifierKey
+          ] = Object.assign(Object.create(baseInputType), {
+            name: inflection.inputType(
+              gqlTypeByTypeIdAndModifier[type.id][typeModifierKey]
+            ),
+            description: type.description,
+          });
         }
       }
 
       // Fall back to categories
-      if (!gqlTypeByTypeId[type.id]) {
+      if (!gqlTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
         const gen = categoryLookup[type.category];
         if (gen) {
-          gqlTypeByTypeId[type.id] = gen(type);
+          gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = gen(type);
         }
       }
 
       // Nothing else worked; pass through as string!
-      if (!gqlTypeByTypeId[type.id]) {
+      if (!gqlTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
         // XXX: consider using stringType(upperFirst(camelCase(`fallback_${type.name}`)), type.description)?
-        gqlTypeByTypeId[type.id] = GraphQLString;
+        gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = GraphQLString;
       }
       // Now for input types, fall back to output types if possible
-      if (!gqlInputTypeByTypeId[type.id]) {
-        if (isInputType(gqlTypeByTypeId[type.id])) {
-          gqlInputTypeByTypeId[type.id] = gqlTypeByTypeId[type.id];
+      if (!gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
+        if (isInputType(gqlTypeByTypeIdAndModifier[type.id][typeModifierKey])) {
+          gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] =
+            gqlTypeByTypeIdAndModifier[type.id][typeModifierKey];
         }
       }
-      addType(getNamedType(gqlTypeByTypeId[type.id]));
-      return gqlTypeByTypeId[type.id];
+      addType(
+        getNamedType(gqlTypeByTypeIdAndModifier[type.id][typeModifierKey])
+      );
+      return gqlTypeByTypeIdAndModifier[type.id][typeModifierKey];
     };
 
-    function getGqlTypeByTypeId(typeId) {
+    function getGqlTypeByTypeIdAndModifier(typeId, typeModifier = null) {
+      const typeModifierKey = typeModifier ? typeModifier : -1;
       if (!gqlInputTypeByTypeIdGenerator[typeId]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
-        return enforceGqlTypeByPgType(type);
+        return enforceGqlTypeByPgType(type, typeModifier);
       }
-      if (!gqlTypeByTypeId[typeId]) {
+      if (!gqlTypeByTypeIdAndModifier[typeId]) {
+        gqlTypeByTypeIdAndModifier[typeId] = {};
+      }
+      if (!gqlTypeByTypeIdAndModifier[typeId][typeModifierKey]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
         if (!type) {
           throw new Error(
@@ -707,13 +760,13 @@ export default (function PgTypesPlugin(
         const gen = gqlTypeByTypeIdGenerator[type.id];
         if (gen) {
           const set = Type => {
-            gqlTypeByTypeId[type.id] = Type;
+            gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = Type;
           };
-          const result = gen(set);
+          const result = gen(set, typeModifier);
           if (result) {
             if (
-              gqlTypeByTypeId[type.id] &&
-              gqlTypeByTypeId[type.id] !== result
+              gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] &&
+              gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] !== result
             ) {
               throw new Error(
                 `Callback and return types differ when defining type for '${
@@ -721,21 +774,29 @@ export default (function PgTypesPlugin(
                 }'`
               );
             }
-            gqlTypeByTypeId[type.id] = result;
+            gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = result;
           }
         }
       }
-      return gqlTypeByTypeId[typeId];
+      if (
+        !gqlTypeByTypeIdAndModifier[typeId][typeModifierKey] &&
+        typeModifierKey > -1
+      ) {
+        // Fall back to default
+        return getGqlTypeByTypeIdAndModifier(typeId, null);
+      }
+      return gqlTypeByTypeIdAndModifier[typeId][typeModifierKey];
     }
-    function getGqlInputTypeByTypeId(typeId) {
+    function getGqlInputTypeByTypeIdAndModifier(typeId, typeModifier) {
+      const typeModifierKey = typeModifier ? typeModifier : -1;
       if (!gqlInputTypeByTypeIdGenerator[typeId]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
-        enforceGqlTypeByPgType(type);
-        return gqlInputTypeByTypeId[typeId];
+        enforceGqlTypeByPgType(type, typeModifier);
+        return gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey];
       }
-      if (!gqlInputTypeByTypeId[typeId]) {
+      if (!gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
-        getGqlTypeByTypeId(typeId);
+        getGqlTypeByTypeIdAndModifier(typeId, typeModifier);
         if (!type) {
           throw new Error(
             `Type '${typeId}' not present in introspection results`
@@ -744,13 +805,14 @@ export default (function PgTypesPlugin(
         const gen = gqlInputTypeByTypeIdGenerator[type.id];
         if (gen) {
           const set = Type => {
-            gqlInputTypeByTypeId[type.id] = Type;
+            gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] = Type;
           };
-          const result = gen(set);
+          const result = gen(set, typeModifier);
           if (result) {
             if (
-              gqlInputTypeByTypeId[type.id] &&
-              gqlInputTypeByTypeId[type.id] !== result
+              gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] &&
+              gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] !==
+                result
             ) {
               throw new Error(
                 `Callback and return types differ when defining type for '${
@@ -758,13 +820,19 @@ export default (function PgTypesPlugin(
                 }'`
               );
             }
-            gqlInputTypeByTypeId[type.id] = result;
+            gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] = result;
           }
         }
       }
-      return gqlInputTypeByTypeId[typeId];
+      if (
+        !gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey] &&
+        typeModifierKey > -1
+      ) {
+        // Fall back to default
+        return getGqlInputTypeByTypeIdAndModifier(typeId, null);
+      }
+      return gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey];
     }
-
     function registerGqlTypeByTypeId(typeId, gen, yieldToExisting = false) {
       if (gqlTypeByTypeIdGenerator[typeId]) {
         if (yieldToExisting) {
@@ -792,16 +860,46 @@ export default (function PgTypesPlugin(
       gqlInputTypeByTypeIdGenerator[typeId] = gen;
     }
 
+    // DEPRECATIONS!
+    function getGqlTypeByTypeId(typeId) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "DEPRECATION WARNING: getGqlTypeByTypeId should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the second parameter (or null if it's not available)."
+      );
+      return getGqlTypeByTypeIdAndModifier(typeId, null);
+    }
+    function getGqlInputTypeByTypeId(typeId) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "DEPRECATION WARNING: getGqlInputTypeByTypeId should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the second parameter (or null if it's not available)."
+      );
+      return getGqlInputTypeByTypeIdAndModifier(typeId, null);
+    }
+    function pgTweakFragmentForType(fragment, type) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "DEPRECATION WARNING: pgTweakFragmentForType should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the third parameter (or null if it's not available)."
+      );
+      return pgTweakFragmentForTypeAndModifier(fragment, type, null);
+    }
+    // END OF DEPRECATIONS!
+
     return build.extend(build, {
       pgRegisterGqlTypeByTypeId: registerGqlTypeByTypeId,
       pgRegisterGqlInputTypeByTypeId: registerGqlInputTypeByTypeId,
-      pgGetGqlTypeByTypeId: getGqlTypeByTypeId,
-      pgGetGqlInputTypeByTypeId: getGqlInputTypeByTypeId,
+      pgGetGqlTypeByTypeIdAndModifier: getGqlTypeByTypeIdAndModifier,
+      pgGetGqlInputTypeByTypeIdAndModifier: getGqlInputTypeByTypeIdAndModifier,
       pg2GqlMapper,
       pg2gql,
       gql2pg,
-      pgTweakFragmentForType,
+      pgTweakFragmentForTypeAndModifier,
       pgTweaksByTypeId,
+      pgTweaksByTypeIdAndModifer,
+
+      // DEPRECATED METHODS:
+      pgGetGqlTypeByTypeId: getGqlTypeByTypeId, // DEPRECATED, replaced by getGqlTypeByTypeIdAndModifier
+      pgGetGqlInputTypeByTypeId: getGqlInputTypeByTypeId, // DEPRECATED, replaced by getGqlInputTypeByTypeIdAndModifier
+      pgTweakFragmentForType, // DEPRECATED, replaced by pgTweakFragmentForTypeAndModifier
     });
   });
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -297,10 +297,15 @@ export default (function PgTypesPlugin(
         ),
     };
 
-    const pgTweakFragmentForTypeAndModifier = (fragment, type, modifier) => {
+    const pgTweakFragmentForTypeAndModifier = (
+      fragment,
+      type,
+      typeModifier = null
+    ) => {
+      const typeModifierKey = typeModifier != null ? typeModifier : -1;
       const tweaker =
         (pgTweaksByTypeIdAndModifer[type.id] &&
-          pgTweaksByTypeIdAndModifer[type.id][modifier]) ||
+          pgTweaksByTypeIdAndModifer[type.id][typeModifierKey]) ||
         pgTweaksByTypeId[type.id];
       if (tweaker) {
         return tweaker(fragment);
@@ -524,7 +529,7 @@ export default (function PgTypesPlugin(
       if (!gqlInputTypeByTypeIdAndModifier[type.id]) {
         gqlInputTypeByTypeIdAndModifier[type.id] = {};
       }
-      const typeModifierKey = typeModifier ? typeModifier : -1;
+      const typeModifierKey = typeModifier != null ? typeModifier : -1;
       // Explicit overrides
       if (!gqlTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
         const gqlType = oidLookup[type.id];
@@ -742,7 +747,7 @@ export default (function PgTypesPlugin(
     };
 
     function getGqlTypeByTypeIdAndModifier(typeId, typeModifier = null) {
-      const typeModifierKey = typeModifier ? typeModifier : -1;
+      const typeModifierKey = typeModifier != null ? typeModifier : -1;
       if (!gqlInputTypeByTypeIdGenerator[typeId]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
         return enforceGqlTypeByPgType(type, typeModifier);
@@ -790,8 +795,8 @@ export default (function PgTypesPlugin(
       }
       return gqlTypeByTypeIdAndModifier[typeId][typeModifierKey];
     }
-    function getGqlInputTypeByTypeIdAndModifier(typeId, typeModifier) {
-      const typeModifierKey = typeModifier ? typeModifier : -1;
+    function getGqlInputTypeByTypeIdAndModifier(typeId, typeModifier = null) {
+      const typeModifierKey = typeModifier != null ? typeModifier : -1;
       if (!gqlInputTypeByTypeIdGenerator[typeId]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
         enforceGqlTypeByPgType(type, typeModifier);
@@ -874,26 +879,32 @@ export default (function PgTypesPlugin(
     }
 
     // DEPRECATIONS!
-    function getGqlTypeByTypeId(typeId) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "DEPRECATION WARNING: getGqlTypeByTypeId should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the second parameter (or null if it's not available)."
-      );
-      return getGqlTypeByTypeIdAndModifier(typeId, null);
+    function getGqlTypeByTypeId(typeId, typeModifier) {
+      if (typeModifier === undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "DEPRECATION WARNING: getGqlTypeByTypeId should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the second parameter (or null if it's not available)."
+        );
+      }
+      return getGqlTypeByTypeIdAndModifier(typeId, typeModifier);
     }
-    function getGqlInputTypeByTypeId(typeId) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "DEPRECATION WARNING: getGqlInputTypeByTypeId should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the second parameter (or null if it's not available)."
-      );
-      return getGqlInputTypeByTypeIdAndModifier(typeId, null);
+    function getGqlInputTypeByTypeId(typeId, typeModifier) {
+      if (typeModifier === undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "DEPRECATION WARNING: getGqlInputTypeByTypeId should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the second parameter (or null if it's not available)."
+        );
+      }
+      return getGqlInputTypeByTypeIdAndModifier(typeId, typeModifier);
     }
-    function pgTweakFragmentForType(fragment, type) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "DEPRECATION WARNING: pgTweakFragmentForType should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the third parameter (or null if it's not available)."
-      );
-      return pgTweakFragmentForTypeAndModifier(fragment, type, null);
+    function pgTweakFragmentForType(fragment, type, typeModifier) {
+      if (typeModifier === undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "DEPRECATION WARNING: pgTweakFragmentForType should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the third parameter (or null if it's not available)."
+        );
+      }
+      return pgTweakFragmentForTypeAndModifier(fragment, type, typeModifier);
     }
     // END OF DEPRECATIONS!
 

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -220,11 +220,6 @@ export default (function PgTypesPlugin(
     });
     addType(GQLIntervalInput);
 
-    const pgTypeById = introspectionResultsByKind.type.reduce((memo, type) => {
-      memo[type.id] = type;
-      return memo;
-    }, {});
-
     const stringType = (name, description) =>
       new GraphQLScalarType({
         name,

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -286,9 +286,9 @@ export default (function PgTypesPlugin(
         return BigFloat;
       },
 
-      A: type =>
+      A: (type, typeModifier) =>
         new GraphQLList(
-          getGqlTypeByTypeIdAndModifier(type.arrayItemTypeId, null)
+          getGqlTypeByTypeIdAndModifier(type.arrayItemTypeId, typeModifier)
         ),
     };
 
@@ -731,7 +731,10 @@ export default (function PgTypesPlugin(
       if (!gqlTypeByTypeIdAndModifier[type.id][typeModifierKey]) {
         const gen = categoryLookup[type.category];
         if (gen) {
-          gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = gen(type);
+          gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = gen(
+            type,
+            typeModifier
+          );
         }
       }
 

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -300,7 +300,8 @@ export default (function PgTypesPlugin(
     const pgTweakFragmentForTypeAndModifier = (
       fragment,
       type,
-      typeModifier = null
+      typeModifier = null,
+      resolveData
     ) => {
       const typeModifierKey = typeModifier != null ? typeModifier : -1;
       const tweaker =
@@ -308,13 +309,14 @@ export default (function PgTypesPlugin(
           pgTweaksByTypeIdAndModifer[type.id][typeModifierKey]) ||
         pgTweaksByTypeId[type.id];
       if (tweaker) {
-        return tweaker(fragment);
+        return tweaker(fragment, resolveData);
       } else if (type.domainBaseType) {
         // TODO: check that domains don't support atttypemod
         return pgTweakFragmentForTypeAndModifier(
           fragment,
           type.domainBaseType,
-          type.domainBaseTypeModifier
+          type.domainBaseTypeModifier,
+          resolveData
         );
       } else if (type.isPgArray) {
         const error = new Error(
@@ -906,14 +908,19 @@ export default (function PgTypesPlugin(
       }
       return getGqlInputTypeByTypeIdAndModifier(typeId, typeModifier);
     }
-    function pgTweakFragmentForType(fragment, type, typeModifier) {
+    function pgTweakFragmentForType(fragment, type, typeModifier, resolveData) {
       if (typeModifier === undefined) {
         // eslint-disable-next-line no-console
         console.warn(
           "DEPRECATION WARNING: pgTweakFragmentForType should not be used - for some columns we also require typeModifier to be specified. Please update your code ASAP to pass `attribute.typeModifier` through as the third parameter (or null if it's not available)."
         );
       }
-      return pgTweakFragmentForTypeAndModifier(fragment, type, typeModifier);
+      return pgTweakFragmentForTypeAndModifier(
+        fragment,
+        type,
+        typeModifier,
+        resolveData
+      );
     }
     // END OF DEPRECATIONS!
 

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -309,7 +309,7 @@ export default (function PgTypesPlugin(
         return pgTweakFragmentForTypeAndModifier(
           fragment,
           type.domainBaseType,
-          null
+          type.domainBaseTypeModifier
         );
       } else if (type.isPgArray) {
         const error = new Error(
@@ -805,7 +805,11 @@ export default (function PgTypesPlugin(
       }
       if (!gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
+
+        // Calling the output type generator might be necessary for the input
+        // type - typically output types should be defined first
         getGqlTypeByTypeIdAndModifier(typeId, typeModifier);
+
         if (!type) {
           throw new Error(
             `Type '${typeId}' not present in introspection results`

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -750,6 +750,9 @@ export default (function PgTypesPlugin(
       if (!gqlTypeByTypeIdAndModifier[typeId]) {
         gqlTypeByTypeIdAndModifier[typeId] = {};
       }
+      if (!gqlInputTypeByTypeIdAndModifier[typeId]) {
+        gqlInputTypeByTypeIdAndModifier[typeId] = {};
+      }
       if (!gqlTypeByTypeIdAndModifier[typeId][typeModifierKey]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
         if (!type) {
@@ -793,6 +796,12 @@ export default (function PgTypesPlugin(
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);
         enforceGqlTypeByPgType(type, typeModifier);
         return gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey];
+      }
+      if (!gqlTypeByTypeIdAndModifier[typeId]) {
+        gqlTypeByTypeIdAndModifier[typeId] = {};
+      }
+      if (!gqlInputTypeByTypeIdAndModifier[typeId]) {
+        gqlInputTypeByTypeIdAndModifier[typeId] = {};
       }
       if (!gqlInputTypeByTypeIdAndModifier[typeId][typeModifierKey]) {
         const type = introspectionResultsByKind.type.find(t => t.id === typeId);

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -282,7 +282,8 @@ export default function makeProcField(
                   pgTweakFragmentForTypeAndModifier(
                     sql.fragment`${functionAlias}`,
                     returnTypeTable.type,
-                    null
+                    null,
+                    resolveData
                   ),
                   "value"
                 );
@@ -291,7 +292,8 @@ export default function makeProcField(
                   pgTweakFragmentForTypeAndModifier(
                     sql.fragment`${functionAlias}.${functionAlias}`,
                     returnType,
-                    null // We can't determine a type modifier for functions
+                    null, // We can't determine a type modifier for functions
+                    resolveData
                   ),
                   "value"
                 );

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -24,8 +24,8 @@ export default function makeProcField(
   proc: PgProc,
   {
     pgIntrospectionResultsByKind: introspectionResultsByKind,
-    pgGetGqlTypeByTypeId,
-    pgGetGqlInputTypeByTypeId,
+    pgGetGqlTypeByTypeIdAndModifier,
+    pgGetGqlInputTypeByTypeIdAndModifier,
     getTypeByName,
     pgSql: sql,
     parseResolveInfo,
@@ -35,7 +35,7 @@ export default function makeProcField(
     pg2gql,
     newWithHooks,
     pgStrictFunctions: strictFunctions,
-    pgTweakFragmentForType,
+    pgTweakFragmentForTypeAndModifier,
     graphql: {
       GraphQLNonNull,
       GraphQLList,
@@ -96,7 +96,9 @@ export default function makeProcField(
   const notNullArgCount =
     proc.isStrict || strictFunctions ? requiredArgCount : 0;
   const argGqlTypes = argTypes.map((type, idx) => {
-    const Type = pgGetGqlInputTypeByTypeId(type.id) || GraphQLString;
+    // TODO: PG10 doesn't support the equivalent of pg_attribute.atttypemod on function return values, but maybe a later version might
+    const Type =
+      pgGetGqlInputTypeByTypeIdAndModifier(type.id, null) || GraphQLString;
     if (idx >= notNullArgCount) {
       return Type;
     } else {
@@ -122,7 +124,8 @@ export default function makeProcField(
   payloadTypeScope.pgIntrospection = proc;
   let returnFirstValueAsValue = false;
   const TableType =
-    returnTypeTable && pgGetGqlTypeByTypeId(returnTypeTable.type.id);
+    returnTypeTable &&
+    pgGetGqlTypeByTypeIdAndModifier(returnTypeTable.type.id, null);
 
   const isTableLike: boolean =
     (TableType && isCompositeType(TableType)) || false;
@@ -158,7 +161,9 @@ export default function makeProcField(
       payloadTypeScope.pgIntrospectionTable = returnTypeTable;
     }
   } else {
-    const Type = pgGetGqlTypeByTypeId(returnType.id) || GraphQLString;
+    // TODO: PG10 doesn't support the equivalent of pg_attribute.atttypemod on function return values, but maybe a later version might
+    const Type =
+      pgGetGqlTypeByTypeIdAndModifier(returnType.id, null) || GraphQLString;
     if (proc.returnsSet) {
       const connectionTypeName = inflection.scalarFunctionConnection(proc);
       const ConnectionType = getTypeByName(connectionTypeName);
@@ -274,17 +279,19 @@ export default function makeProcField(
             if (!isTableLike) {
               if (returnTypeTable) {
                 innerQueryBuilder.select(
-                  pgTweakFragmentForType(
+                  pgTweakFragmentForTypeAndModifier(
                     sql.fragment`${functionAlias}`,
-                    returnTypeTable.type
+                    returnTypeTable.type,
+                    null
                   ),
                   "value"
                 );
               } else {
                 innerQueryBuilder.select(
-                  pgTweakFragmentForType(
+                  pgTweakFragmentForTypeAndModifier(
                     sql.fragment`${functionAlias}.${functionAlias}`,
-                    returnType
+                    returnType,
+                    null // We can't determine a type modifier for functions
                   ),
                   "value"
                 );

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -3814,12 +3814,6 @@ type Mutation {
     \\"\\"\\"
     input: NoArgsMutationInput!
   ): NoArgsMutationPayload
-  normalRand(
-    \\"\\"\\"
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    \\"\\"\\"
-    input: NormalRandInput!
-  ): NormalRandPayload
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postMany(
@@ -4430,34 +4424,6 @@ enum NonUpdatableViewsOrderBy {
   COLUMN_ASC
   COLUMN_DESC
   NATURAL
-}
-
-\\"\\"\\"All input for the \`normalRand\` mutation.\\"\\"\\"
-input NormalRandInput {
-  arg0: Int!
-  arg1: Float!
-  arg2: Float!
-
-  \\"\\"\\"
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  \\"\\"\\"
-  clientMutationId: String
-}
-
-\\"\\"\\"The output of our \`normalRand\` mutation.\\"\\"\\"
-type NormalRandPayload {
-  \\"\\"\\"
-  The exact same \`clientMutationId\` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  \\"\\"\\"
-  clientMutationId: String
-  floats: [Float]
-
-  \\"\\"\\"
-  Our root query field type. Allows us to run any query from our mutation payload.
-  \\"\\"\\"
-  query: Query
 }
 
 scalar NotNullTimestamp
@@ -5891,72 +5857,6 @@ type Query implements Node {
     offset: Int
   ): CompoundTypesConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`TablefuncCrosstab2\`.\\"\\"\\"
-  crosstab2(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-    arg0: String!
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-  ): TablefuncCrosstab2SConnection!
-
-  \\"\\"\\"Reads and enables pagination through a set of \`TablefuncCrosstab3\`.\\"\\"\\"
-  crosstab3(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-    arg0: String!
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-  ): TablefuncCrosstab3SConnection!
-
-  \\"\\"\\"Reads and enables pagination through a set of \`TablefuncCrosstab4\`.\\"\\"\\"
-  crosstab4(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-    arg0: String!
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-  ): TablefuncCrosstab4SConnection!
-
   \\"\\"\\"Reads a single \`DefaultValue\` using its globally unique \`ID\`.\\"\\"\\"
   defaultValue(
     \\"\\"\\"
@@ -6641,111 +6541,6 @@ type StaticBigIntegerEdge {
 
   \\"\\"\\"The \`BigInt\` at the end of the edge.\\"\\"\\"
   node: BigInt
-}
-
-type TablefuncCrosstab2 {
-  category1: String
-  category2: String
-  rowName: String
-}
-
-\\"\\"\\"A connection to a list of \`TablefuncCrosstab2\` values.\\"\\"\\"
-type TablefuncCrosstab2SConnection {
-  \\"\\"\\"
-  A list of edges which contains the \`TablefuncCrosstab2\` and cursor to aid in pagination.
-  \\"\\"\\"
-  edges: [TablefuncCrosstab2SEdge!]!
-
-  \\"\\"\\"A list of \`TablefuncCrosstab2\` objects.\\"\\"\\"
-  nodes: [TablefuncCrosstab2]!
-
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
-  pageInfo: PageInfo!
-
-  \\"\\"\\"
-  The count of *all* \`TablefuncCrosstab2\` you could get from the connection.
-  \\"\\"\\"
-  totalCount: Int
-}
-
-\\"\\"\\"A \`TablefuncCrosstab2\` edge in the connection.\\"\\"\\"
-type TablefuncCrosstab2SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`TablefuncCrosstab2\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab2
-}
-
-type TablefuncCrosstab3 {
-  category1: String
-  category2: String
-  category3: String
-  rowName: String
-}
-
-\\"\\"\\"A connection to a list of \`TablefuncCrosstab3\` values.\\"\\"\\"
-type TablefuncCrosstab3SConnection {
-  \\"\\"\\"
-  A list of edges which contains the \`TablefuncCrosstab3\` and cursor to aid in pagination.
-  \\"\\"\\"
-  edges: [TablefuncCrosstab3SEdge!]!
-
-  \\"\\"\\"A list of \`TablefuncCrosstab3\` objects.\\"\\"\\"
-  nodes: [TablefuncCrosstab3]!
-
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
-  pageInfo: PageInfo!
-
-  \\"\\"\\"
-  The count of *all* \`TablefuncCrosstab3\` you could get from the connection.
-  \\"\\"\\"
-  totalCount: Int
-}
-
-\\"\\"\\"A \`TablefuncCrosstab3\` edge in the connection.\\"\\"\\"
-type TablefuncCrosstab3SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`TablefuncCrosstab3\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab3
-}
-
-type TablefuncCrosstab4 {
-  category1: String
-  category2: String
-  category3: String
-  category4: String
-  rowName: String
-}
-
-\\"\\"\\"A connection to a list of \`TablefuncCrosstab4\` values.\\"\\"\\"
-type TablefuncCrosstab4SConnection {
-  \\"\\"\\"
-  A list of edges which contains the \`TablefuncCrosstab4\` and cursor to aid in pagination.
-  \\"\\"\\"
-  edges: [TablefuncCrosstab4SEdge!]!
-
-  \\"\\"\\"A list of \`TablefuncCrosstab4\` objects.\\"\\"\\"
-  nodes: [TablefuncCrosstab4]!
-
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
-  pageInfo: PageInfo!
-
-  \\"\\"\\"
-  The count of *all* \`TablefuncCrosstab4\` you could get from the connection.
-  \\"\\"\\"
-  totalCount: Int
-}
-
-\\"\\"\\"A \`TablefuncCrosstab4\` edge in the connection.\\"\\"\\"
-type TablefuncCrosstab4SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`TablefuncCrosstab4\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab4
 }
 
 \\"\\"\\"All input for the \`tableMutation\` mutation.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
@@ -1705,12 +1705,6 @@ type Mutation {
     \\"\\"\\"
     input: MutationTextArrayInput!
   ): MutationTextArrayPayload
-  normalRand(
-    \\"\\"\\"
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    \\"\\"\\"
-    input: NormalRandInput!
-  ): NormalRandPayload
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postMany(
@@ -2060,34 +2054,6 @@ enum NonUpdatableViewsOrderBy {
   COLUMN_ASC
   COLUMN_DESC
   NATURAL
-}
-
-\\"\\"\\"All input for the \`normalRand\` mutation.\\"\\"\\"
-input NormalRandInput {
-  arg0: Int!
-  arg1: Float!
-  arg2: Float!
-
-  \\"\\"\\"
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  \\"\\"\\"
-  clientMutationId: String
-}
-
-\\"\\"\\"The output of our \`normalRand\` mutation.\\"\\"\\"
-type NormalRandPayload {
-  \\"\\"\\"
-  The exact same \`clientMutationId\` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  \\"\\"\\"
-  clientMutationId: String
-  floats: [Float]
-
-  \\"\\"\\"
-  Our root query field type. Allows us to run any query from our mutation payload.
-  \\"\\"\\"
-  query: Query
 }
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
@@ -2765,72 +2731,6 @@ type Query implements Node {
     orderBy: [ViewTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ViewTablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`TablefuncCrosstab2\`.\\"\\"\\"
-  crosstab2(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-    arg0: String!
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-  ): TablefuncCrosstab2SConnection!
-
-  \\"\\"\\"Reads and enables pagination through a set of \`TablefuncCrosstab3\`.\\"\\"\\"
-  crosstab3(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-    arg0: String!
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-  ): TablefuncCrosstab3SConnection!
-
-  \\"\\"\\"Reads and enables pagination through a set of \`TablefuncCrosstab4\`.\\"\\"\\"
-  crosstab4(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
-    after: Cursor
-    arg0: String!
-
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
-    before: Cursor
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
-    last: Int
-
-    \\"\\"\\"
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    \\"\\"\\"
-    offset: Int
-  ): TablefuncCrosstab4SConnection!
-
   \\"\\"\\"Reads a single \`DefaultValue\` using its globally unique \`ID\`.\\"\\"\\"
   defaultValue(
     \\"\\"\\"
@@ -3421,111 +3321,6 @@ type StaticBigIntegerEdge {
 
   \\"\\"\\"The \`BigInt\` at the end of the edge.\\"\\"\\"
   node: BigInt
-}
-
-type TablefuncCrosstab2 {
-  category1: String
-  category2: String
-  rowName: String
-}
-
-\\"\\"\\"A connection to a list of \`TablefuncCrosstab2\` values.\\"\\"\\"
-type TablefuncCrosstab2SConnection {
-  \\"\\"\\"
-  A list of edges which contains the \`TablefuncCrosstab2\` and cursor to aid in pagination.
-  \\"\\"\\"
-  edges: [TablefuncCrosstab2SEdge!]!
-
-  \\"\\"\\"A list of \`TablefuncCrosstab2\` objects.\\"\\"\\"
-  nodes: [TablefuncCrosstab2!]!
-
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
-  pageInfo: PageInfo!
-
-  \\"\\"\\"
-  The count of *all* \`TablefuncCrosstab2\` you could get from the connection.
-  \\"\\"\\"
-  totalCount: Int
-}
-
-\\"\\"\\"A \`TablefuncCrosstab2\` edge in the connection.\\"\\"\\"
-type TablefuncCrosstab2SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`TablefuncCrosstab2\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab2!
-}
-
-type TablefuncCrosstab3 {
-  category1: String
-  category2: String
-  category3: String
-  rowName: String
-}
-
-\\"\\"\\"A connection to a list of \`TablefuncCrosstab3\` values.\\"\\"\\"
-type TablefuncCrosstab3SConnection {
-  \\"\\"\\"
-  A list of edges which contains the \`TablefuncCrosstab3\` and cursor to aid in pagination.
-  \\"\\"\\"
-  edges: [TablefuncCrosstab3SEdge!]!
-
-  \\"\\"\\"A list of \`TablefuncCrosstab3\` objects.\\"\\"\\"
-  nodes: [TablefuncCrosstab3!]!
-
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
-  pageInfo: PageInfo!
-
-  \\"\\"\\"
-  The count of *all* \`TablefuncCrosstab3\` you could get from the connection.
-  \\"\\"\\"
-  totalCount: Int
-}
-
-\\"\\"\\"A \`TablefuncCrosstab3\` edge in the connection.\\"\\"\\"
-type TablefuncCrosstab3SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`TablefuncCrosstab3\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab3!
-}
-
-type TablefuncCrosstab4 {
-  category1: String
-  category2: String
-  category3: String
-  category4: String
-  rowName: String
-}
-
-\\"\\"\\"A connection to a list of \`TablefuncCrosstab4\` values.\\"\\"\\"
-type TablefuncCrosstab4SConnection {
-  \\"\\"\\"
-  A list of edges which contains the \`TablefuncCrosstab4\` and cursor to aid in pagination.
-  \\"\\"\\"
-  edges: [TablefuncCrosstab4SEdge!]!
-
-  \\"\\"\\"A list of \`TablefuncCrosstab4\` objects.\\"\\"\\"
-  nodes: [TablefuncCrosstab4!]!
-
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
-  pageInfo: PageInfo!
-
-  \\"\\"\\"
-  The count of *all* \`TablefuncCrosstab4\` you could get from the connection.
-  \\"\\"\\"
-  totalCount: Int
-}
-
-\\"\\"\\"A \`TablefuncCrosstab4\` edge in the connection.\\"\\"\\"
-type TablefuncCrosstab4SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`TablefuncCrosstab4\` at the end of the edge.\\"\\"\\"
-  node: TablefuncCrosstab4!
 }
 
 type Testview {

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -48,6 +48,7 @@ type PostGraphileOptions = {
   setofFunctionsContainNulls?: boolean,
   legacyJsonUuid?: boolean,
   simpleCollections?: "only" | "both" | "omit",
+  includeExtensionResources?: boolean,
 };
 
 type PgConfig = Client | Pool | string;
@@ -146,6 +147,7 @@ const getPostGraphileBuilder = async (
     setofFunctionsContainNulls = true,
     legacyJsonUuid = false,
     simpleCollections = "omit",
+    includeExtensionResources = false,
   } = options;
 
   if (
@@ -283,6 +285,7 @@ const getPostGraphileBuilder = async (
         persistentMemoizeWithKey,
         pgForbidSetofFunctionsToReturnNull: !setofFunctionsContainNulls,
         pgSimpleCollections: simpleCollections,
+        pgIncludeExtensionResources: includeExtensionResources,
       },
       graphileBuildOptions,
       graphqlBuildOptions // DEPRECATED!


### PR DESCRIPTION
We now auto-filter functions/tables from extensions; this is technically a breaking change but I don't think many people were using this deliberately. You can go back to the old functionality with the CLI flag `--include-extension-resources`

---

[pg_attribute](https://www.postgresql.org/docs/10/static/catalog-pg-attribute.html) contains a field `atttypmod` which is a modifier for the type of a column, for example your column could be a `decimal`; but it could be `decimal(3,2)`. This `atttypmod` is where this distinction is stored (or `-1` if there is no subtype).

So we really need this in our modelling. Annoyingly this means that I've had to rebuild all the code that assumes we can do things based on type alone.

I've managed to do all these changes whilst maintaining backwards compatibility, *except* if you use the (undocumented) build properties `pgGqlTypeByTypeId` or `pgGqlInputTypeByTypeId` in a custom plugin you're using. If this is the case then an error will be thrown which will make it very clear you need to fix it - so if you upgrade and there's no error then you're safe. I don't expect anyone at all to hit this issue, but in case someone does, the fix is simple - the object has become two dimensional so rename the property to `pgGqlTypeByTypeIdAndModifier` and insert a [-1] as the modifier; e.g. `pgGqlTypeByTypeId[1234] = Type` would become `pgGqlTypeByTypeIdAndModifier[1234] = {"-1": Type}`. **CHANGES TO UNDOCUMENTED PROPERTIES ARE NOT DEEMED TO BE BREAKING CHANGES; IF YOU WANT TO RELY ON AN UNDOCUMENTED PROPERTY THEN PLEASE SUBMIT A DOCUMENTATION PR!**

A few methods that you might be using are now deprecated (but will continue to work, albeit not supporting advanced types): `pgGetGqlTypeByTypeId`, `pgGetGqlInputTypeByTypeId` and `pgTweakFragmentForType`; please switch to using the `AndModifier` variants - if you're using it to find a table type you can just pass `null` as the modifier.

Here's an example of `atttypmod`:

```sql
drop table decimals;
create table decimals (
  decimal_1_1 decimal(1,1),
  decimal_2_1 decimal(2,1),
  decimal_3_2 decimal(3,2),
  decimal_4_3 decimal(4,3),
  decimal_4_4 decimal(4,4),
  decimal_10_4 decimal(10,4),
  decimal_60_45 decimal(60, 45),
  decimal_97_79 decimal(97, 79)
);
select
  attname,
  atttypid,
  atttypmod,
  atttypmod >> 16,
  (atttypmod & ((1 << 16) - 1)) - 4
from pg_attribute
where attname like 'decimal_%';
```

this generates the following table:

```
    attname    | atttypid | atttypmod | ?column? | ?column?
---------------+----------+-----------+----------+----------
 decimal_1_1   |     1700 |     65541 |        1 |        1
 decimal_2_1   |     1700 |    131077 |        2 |        1
 decimal_3_2   |     1700 |    196614 |        3 |        2
 decimal_4_3   |     1700 |    262151 |        4 |        3
 decimal_4_4   |     1700 |    262152 |        4 |        4
 decimal_10_4  |     1700 |    655368 |       10 |        4
 decimal_60_45 |     1700 |   3932209 |       60 |       45
 decimal_97_79 |     1700 |   6357075 |       97 |       79
(8 rows)
```

- [x] atttypmod
- [x] typtypmod
- [x] pg_extension (exclude tables from extension config)
- [x] exclude tables/functions from extensions automatically
- [ ] tests