### PR TITLE
chore(graphile-build-pg): Remove GraphQL require

### DIFF
--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -45,7 +45,6 @@
     "postgres-interval": "1.1.1"
   },
   "peerDependencies": {
-    "graphql": ">=0.9 <0.14",
     "pg": ">=6.1.0 <8"
   },
   "devDependencies": {

--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "eslint_d": "5.3.1",
     "flow-copy-source": "^1.2.0",
     "jest": "^20.0.4"
   },

--- a/packages/graphile-build-pg/src/GraphQLJSON.js
+++ b/packages/graphile-build-pg/src/GraphQLJSON.js
@@ -27,60 +27,63 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-import { GraphQLScalarType } from "graphql";
-import { Kind } from "graphql/language";
+export default function makeGraphQLJSONTypes(graphql) {
+  const { GraphQLScalarType, Kind } = graphql;
 
-function identity(value) {
-  return value;
-}
-
-function parseLiteral(ast, variables) {
-  switch (ast.kind) {
-    case Kind.STRING:
-    case Kind.BOOLEAN:
-      return ast.value;
-    case Kind.INT:
-    case Kind.FLOAT:
-      return parseFloat(ast.value);
-    case Kind.OBJECT: {
-      const value = Object.create(null);
-      ast.fields.forEach(field => {
-        value[field.name.value] = parseLiteral(field.value, variables);
-      });
-
-      return value;
-    }
-    case Kind.LIST:
-      return ast.values.map(n => parseLiteral(n, variables));
-    case Kind.NULL:
-      return null;
-    case Kind.VARIABLE: {
-      const name = ast.name.value;
-      return variables ? variables[name] : undefined;
-    }
-    default:
-      return undefined;
+  function identity(value) {
+    return value;
   }
+
+  function parseLiteral(ast, variables) {
+    switch (ast.kind) {
+      case Kind.STRING:
+      case Kind.BOOLEAN:
+        return ast.value;
+      case Kind.INT:
+      case Kind.FLOAT:
+        return parseFloat(ast.value);
+      case Kind.OBJECT: {
+        const value = Object.create(null);
+        ast.fields.forEach(field => {
+          value[field.name.value] = parseLiteral(field.value, variables);
+        });
+
+        return value;
+      }
+      case Kind.LIST:
+        return ast.values.map(n => parseLiteral(n, variables));
+      case Kind.NULL:
+        return null;
+      case Kind.VARIABLE: {
+        const name = ast.name.value;
+        return variables ? variables[name] : undefined;
+      }
+      default:
+        return undefined;
+    }
+  }
+
+  const GraphQLJSON = new GraphQLScalarType({
+    name: "JSON",
+    description:
+      "The `JSON` scalar type represents JSON values as specified by " +
+      "[ECMA-404](http://www.ecma-international.org/" +
+      "publications/files/ECMA-ST/ECMA-404.pdf).",
+    serialize: identity,
+    parseValue: identity,
+    parseLiteral,
+  });
+
+  const GraphQLJson = new GraphQLScalarType({
+    name: "Json",
+    description:
+      "The `Json` scalar type represents JSON values as specified by " +
+      "[ECMA-404](http://www.ecma-international.org/" +
+      "publications/files/ECMA-ST/ECMA-404.pdf).",
+    serialize: identity,
+    parseValue: identity,
+    parseLiteral,
+  });
+
+  return { GraphQLJSON, GraphQLJson };
 }
-
-export const GraphQLJSON = new GraphQLScalarType({
-  name: "JSON",
-  description:
-    "The `JSON` scalar type represents JSON values as specified by " +
-    "[ECMA-404](http://www.ecma-international.org/" +
-    "publications/files/ECMA-ST/ECMA-404.pdf).",
-  serialize: identity,
-  parseValue: identity,
-  parseLiteral,
-});
-
-export const GraphQLJson = new GraphQLScalarType({
-  name: "Json",
-  description:
-    "The `Json` scalar type represents JSON values as specified by " +
-    "[ECMA-404](http://www.ecma-international.org/" +
-    "publications/files/ECMA-ST/ECMA-404.pdf).",
-  serialize: identity,
-  parseValue: identity,
-  parseLiteral,
-});

--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "eslint_d": "5.3.1",
     "flow-copy-source": "^1.2.0",
     "jest": "^20.0.4"
   },

--- a/packages/graphql-parse-resolve-info/package.json
+++ b/packages/graphql-parse-resolve-info/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "eslint_d": "5.3.1",
     "flow-copy-source": "^1.2.0",
     "jest": "^20.0.4"
   },

--- a/packages/postgraphile-core/package.json
+++ b/packages/postgraphile-core/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "debug": ">=2 <3",
+    "eslint_d": "5.3.1",
     "flow-copy-source": "^1.2.0",
     "jest": "^20.0.4",
     "jsonwebtoken": "^8.1.1",


### PR DESCRIPTION
We should just use graphql off the build object to avoid version conflicts.