### PR TITLE
fix(rbac): don't exclude tables that use column-based select permissions

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -79,7 +79,8 @@ function omitWithRBACChecks(
     const tableEntity: PgClass = entity;
     if (
       (permission === READ || permission === ALL || permission === MANY) &&
-      !tableEntity.aclSelectable
+      (!tableEntity.aclSelectable &&
+        !tableEntity.attributes.some(attr => attr.aclSelectable))
     ) {
       return true;
     } else if (

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -1,39 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema from non-root role, using RBAC permissions 1`] = `
-"enum AnEnum {
-  _ASTERISK_BAR_
-  _ASTERISK_BAZ_ASTERISK_
-  _FOO_ASTERISK
-  ASTERISK
-  ASTERISK_ASTERISK
-  ASTERISK_ASTERISK_ASTERISK
-  ASTERISK_BAR
-  ASTERISK_BAR_
-  ASTERISK_BAZ_ASTERISK
-  AWAITING
-  DOLLAR
-  FOO_ASTERISK
-  FOO_ASTERISK_
-  GREATER_THAN_OR_EQUAL
-  LIKE
-  PERCENT
-  PUBLISHED
-  REJECTED
-}
-
-type Comptype {
-  isOptimised: Boolean
-  schedule: Datetime
-}
-
-\\"\\"\\"An input for mutations affecting \`Comptype\`\\"\\"\\"
-input ComptypeInput {
-  isOptimised: Boolean
-  schedule: Datetime
-}
-
-\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+"\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
 input CreateLeftArmInput {
   \\"\\"\\"
   An arbitrary string value with no semantic meaning. Will be included in the
@@ -856,8 +824,6 @@ enum PersonSecretsOrderBy {
 type Post implements Node {
   authorId: Int
   body: String
-  comptypes: [Comptype]
-  enums: [AnEnum]
   headline: String!
   id: Int!
 
@@ -879,12 +845,6 @@ input PostCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`body\` field.\\"\\"\\"
   body: String
-
-  \\"\\"\\"Checks for equality with the object’s \`comptypes\` field.\\"\\"\\"
-  comptypes: [ComptypeInput]
-
-  \\"\\"\\"Checks for equality with the object’s \`enums\` field.\\"\\"\\"
-  enums: [AnEnum]
 
   \\"\\"\\"Checks for equality with the object’s \`headline\` field.\\"\\"\\"
   headline: String
@@ -925,10 +885,6 @@ enum PostsOrderBy {
   AUTHOR_ID_DESC
   BODY_ASC
   BODY_DESC
-  COMPTYPES_ASC
-  COMPTYPES_DESC
-  ENUMS_ASC
-  ENUMS_DESC
   HEADLINE_ASC
   HEADLINE_DESC
   ID_ASC

--- a/packages/postgraphile-core/__tests__/integration/schema/rbac.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema/rbac.test.js
@@ -4,12 +4,12 @@ const fs = require("fs");
 test(
   "prints a schema from non-root role, using RBAC permissions",
   core.test(["a", "b", "c"], {}, client =>
-    client.query("set role postgraphile_test_visitor")
+    client.query("set role postgraphile_test_authenticator")
   )
 );
 test(
   "prints a schema from non-root role, with RBAC ignored",
   core.test(["a", "b", "c"], { ignoreRBAC: true }, client =>
-    client.query("set role postgraphile_test_visitor")
+    client.query("set role postgraphile_test_authenticator")
   )
 );

--- a/packages/postgraphile-core/__tests__/kitchen-sink-permissions.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-permissions.sql
@@ -16,4 +16,4 @@ grant insert(length_in_metres) on c.left_arm to postgraphile_test_visitor;
 grant update(length_in_metres) on c.left_arm to postgraphile_test_visitor;
 grant delete on c.left_arm to postgraphile_test_visitor;
 
-grant select on a.post to postgraphile_test_visitor;
+grant select(id, headline, body, author_id) on a.post to postgraphile_test_visitor;

--- a/packages/postgraphile-core/scripts/test
+++ b/packages/postgraphile-core/scripts/test
@@ -18,10 +18,17 @@ fi;
 psql -Xqv ON_ERROR_STOP=1 "$TEST_DATABASE_URL" <<HERE
 drop schema if exists a, b, c, d cascade;
 drop role if exists postgraphile_test_authenticator;
+drop role if exists postgraphile_test_user1;
+drop role if exists postgraphile_test_user2;
 drop role if exists postgraphile_test_visitor;
 create role postgraphile_test_authenticator noinherit login password 'testpassword';
-create role postgraphile_test_visitor;
-grant postgraphile_test_visitor to postgraphile_test_authenticator;
+create role postgraphile_test_visitor noinherit;
+create role postgraphile_test_user1;
+create role postgraphile_test_user2;
+grant postgraphile_test_visitor to postgraphile_test_user1;
+grant postgraphile_test_visitor to postgraphile_test_user2;
+grant postgraphile_test_user1 to postgraphile_test_authenticator;
+grant postgraphile_test_user2 to postgraphile_test_authenticator;
 HERE
 psql -Xqv ON_ERROR_STOP=1 -f __tests__/kitchen-sink-schema.sql "$TEST_DATABASE_URL"
 psql -Xqv ON_ERROR_STOP=1 -f __tests__/kitchen-sink-permissions.sql "$TEST_DATABASE_URL"


### PR DESCRIPTION
Previously tables that did `grant select(col1, col2) to role_name` would be excluded unless `--ignore-rbac` was enabled.