### PR TITLE
feat(utils): can define `subscribe` along with `resolve`

### DIFF
--- a/packages/graphile-build/src/index.js
+++ b/packages/graphile-build/src/index.js
@@ -44,11 +44,13 @@ export const getBuilder = async (
   options: Options = {}
 ): Promise<SchemaBuilder> => {
   const builder = new SchemaBuilder();
-  for (const plugin of plugins) {
+  for (let i = 0, l = plugins.length; i < l; i++) {
+    const plugin = plugins[i];
     if (typeof plugin !== "function") {
       throw new Error(
-        "Expected a list of plugin functions, instead list contained a non-function: " +
-          util.inspect(plugin)
+        `Expected a list of plugin functions, instead list contained a non-function at index ${i}: ${util.inspect(
+          plugin
+        )}`
       );
     }
     builder._setPluginName(plugin.displayName || plugin.name);
@@ -81,6 +83,7 @@ export {
   NodePlugin,
   QueryPlugin,
   MutationPlugin,
+  SubscriptionPlugin,
   ClientMutationIdDescriptionPlugin,
   MutationPayloadQueryPlugin,
   // resolveNode: EXPERIMENTAL, API might change!

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
@@ -73,11 +73,20 @@ const resolvers = {
   },
   Subscription: {
     clockTicks: {
-      resolve() {
-        return Date.now();
+      resolve(_subscription, args) {
+        const { frequency } = args;
+        if (frequency == null) {
+          throw new Error("No frequency specified");
+        }
+        return new Promise(resolve =>
+          setTimeout(() => resolve(Date.now()), frequency)
+        );
       },
       subscribe(_subscription, args) {
         const { frequency } = args;
+        if (frequency == null) {
+          throw new Error("No frequency specified");
+        }
         const callbackQueue = [];
         const valueQueue = [];
         // In a normal application you'd define timerRunning here:
@@ -587,7 +596,7 @@ it("supports defining a simple subscription", async () => {
             """
             How frequently to fire a clock tick (milliseconds)
             """
-            frequency: Int = 1000
+            frequency: Int = 100
           ): Float
         }
       `,
@@ -609,6 +618,7 @@ it("supports defining a simple subscription", async () => {
     `
   );
   let after = Date.now();
+  expect(after).toBeGreaterThanOrEqual(before + 100);
   expect(errors).toBeFalsy();
   expect(data.clockTicks).toBeGreaterThanOrEqual(before);
   expect(data.clockTicks).toBeLessThanOrEqual(after);

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
@@ -188,7 +188,9 @@ it("allows adding a field with arguments named using a custom inflector", async 
       `,
       resolvers: {
         Query: {
-          [build.inflection.echoFieldName()]: resolvers.Query.echo,
+          [build.inflection.echoFieldName()]: {
+            resolve: resolvers.Query.echo,
+          }
         },
       },
     })),
@@ -361,9 +363,11 @@ it("supports defining new types", async () => {
       `,
       resolvers: {
         Query: {
-          echo(_query, args) {
-            return args.input;
-          },
+          echo: {
+            resolve(_query, args) {
+              return args.input;
+            },
+          }
         },
       },
     })),

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
@@ -587,7 +587,7 @@ it("supports defining a simple subscription", async () => {
             """
             How frequently to fire a clock tick (milliseconds)
             """
-            frequency: Int!
+            frequency: Int = 1000
           ): Float
         }
       `,
@@ -604,7 +604,7 @@ it("supports defining a simple subscription", async () => {
     schema,
     `
       subscription {
-        clockTicks(frequency: 50)
+        clockTicks
       }
     `
   );

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -175,6 +175,92 @@ type Query {
 "
 `;
 
+exports[`supports defining a more complex mutation 1`] = `
+"input EchoInput {
+  text: String!
+  int: Int
+  float: Float!
+  intList: [Int!]
+}
+
+type EchoOutput {
+  text: String!
+  int: Int
+  float: Float!
+  intList: [Int!]
+}
+
+\\"\\"\\"
+The root mutation type which contains root level fields which mutate data.
+\\"\\"\\"
+type Mutation {
+  \\"\\"\\"Gives you back what you put in\\"\\"\\"
+  echo(input: EchoInput): EchoOutput
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+}
+"
+`;
+
+exports[`supports defining a more complex mutation 2`] = `
+Object {
+  "t1": Object {
+    "float": 0.23,
+    "int": null,
+    "intList": null,
+    "text": "Hi1",
+  },
+  "t2": Object {
+    "float": 1.23,
+    "int": 42,
+    "intList": null,
+    "text": "Hi2",
+  },
+  "t3": Object {
+    "float": 2.23,
+    "int": 88,
+    "intList": Array [
+      99,
+      22,
+      33,
+    ],
+    "text": "Hi3",
+  },
+}
+`;
+
+exports[`supports defining a simple mutation 1`] = `
+"\\"\\"\\"
+The root mutation type which contains root level fields which mutate data.
+\\"\\"\\"
+type Mutation {
+  add(a: Int, b: Int): Int
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+}
+"
+`;
+
+exports[`supports defining a simple mutation 2`] = `
+Object {
+  "add": 143,
+}
+`;
+
 exports[`supports defining new types 1`] = `
 "input EchoInput {
   text: String!

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -277,7 +277,7 @@ The root subscription type which contains root level fields which mutate data.
 type Subscription {
   clockTicks(
     \\"\\"\\"How frequently to fire a clock tick (milliseconds)\\"\\"\\"
-    frequency: Int!
+    frequency: Int = 1000
   ): Float
 }
 "

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -261,6 +261,28 @@ Object {
 }
 `;
 
+exports[`supports defining a simple subscription 1`] = `
+"\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+}
+
+\\"\\"\\"
+The root subscription type which contains root level fields which mutate data.
+\\"\\"\\"
+type Subscription {
+  clockTicks(
+    \\"\\"\\"How frequently to fire a clock tick (milliseconds)\\"\\"\\"
+    frequency: Int!
+  ): Float
+}
+"
+`;
+
 exports[`supports defining new types 1`] = `
 "input EchoInput {
   text: String!

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -277,7 +277,7 @@ The root subscription type which contains root level fields which mutate data.
 type Subscription {
   clockTicks(
     \\"\\"\\"How frequently to fire a clock tick (milliseconds)\\"\\"\\"
-    frequency: Int = 1000
+    frequency: Int = 100
   ): Float
 }
 "

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.js
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.js
@@ -288,18 +288,14 @@ function getArguments(args, build) {
         const name = getName(arg.name);
         const type = getType(arg.type, build);
         const description = getDescription(arg.description);
+        let defaultValue;
         if (arg.defaultValue) {
-          throw new Error(
-            `We don't support default values on args yet, PRs welcome!`
-          );
+          defaultValue = getValue(arg.defaultValue);
         }
         memo[name] = {
           type,
-          ...(description
-            ? {
-                description,
-              }
-            : null),
+          ...(defaultValue ? { defaultValue } : null),
+          ...(description ? { description } : null),
         };
       } else {
         throw new Error(

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.js
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.js
@@ -364,8 +364,10 @@ function getFields(
         };
         const deprecationReason =
           directives.deprecated && directives.deprecated.reason;
-        const functionToResolveObject = something =>
-          typeof something === "function" ? { resolve: something } : something;
+        const functionToResolveObject = functionOrResolveObject =>
+          typeof functionOrResolveObject === "function"
+            ? { resolve: functionOrResolveObject }
+            : functionOrResolveObject;
         /*
          * We accept a resolver function directly, or an object which can
          * define 'resolve', 'subscribe' and other relevant methods.


### PR DESCRIPTION
- [x] manually test
- [x] add automated tests