### PR TITLE
fix(rbac): revert default to ignoring RBAC

### DIFF
--- a/packages/postgraphile-core/__tests__/integration/schema/rbac.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema/rbac.test.js
@@ -2,7 +2,7 @@ const core = require("./core");
 
 test(
   "prints a schema from non-root role, using RBAC permissions",
-  core.test(["a", "b", "c"], {}, client =>
+  core.test(["a", "b", "c"], { ignoreRBAC: false }, client =>
     client.query("set role postgraphile_test_authenticator")
   )
 );

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -279,7 +279,7 @@ create function b.compound_type_array_mutation(object c.compound_type) returns c
 create function c.table_query(id int) returns a.post as $$ select * from a.post where id = $1 $$ language sql stable;
 create function c.table_mutation(id int) returns a.post as $$ select * from a.post where id = $1 $$ language sql;
 create function c.table_set_query() returns setof c.person as $$ select * from c.person $$ language sql stable;
-create function c.table_set_mutation() returns setof c.person as $$ select * from c.person $$ language sql;
+create function c.table_set_mutation() returns setof c.person as $$ select * from c.person order by id asc $$ language sql;
 create function c.int_set_query(x int, y int, z int) returns setof integer as $$ values (1), (2), (3), (4), (x), (y), (z) $$ language sql stable;
 create function c.int_set_mutation(x int, y int, z int) returns setof integer as $$ values (1), (2), (3), (4), (x), (y), (z) $$ language sql;
 create function c.no_args_query() returns int as $$ select 2 $$ language sql stable;

--- a/packages/postgraphile-core/src/index.js
+++ b/packages/postgraphile-core/src/index.js
@@ -149,7 +149,7 @@ const getPostGraphileBuilder = async (
     legacyJsonUuid = false,
     simpleCollections = "omit",
     includeExtensionResources = false,
-    ignoreRBAC = false,
+    ignoreRBAC = true, // TODO: Change to 'false' in v5
   } = options;
 
   if (


### PR DESCRIPTION
Because it turns out some people use PostGraphile in interesting ways (e.g. defining and/or granting permissions after the server starts) this would be too much of a breaking change.