### PR TITLE
fix(errors): More explicit error on schema build fail

### DIFF
--- a/packages/graphile-build-pg/src/omit.js
+++ b/packages/graphile-build-pg/src/omit.js
@@ -110,14 +110,16 @@ export default function omit(
       return true;
     }
     if (omitSpec.indexOf(READ) >= 0) {
-      const bad = PERMISSIONS_THAT_REQUIRE_READ.find(
+      const bad = PERMISSIONS_THAT_REQUIRE_READ.filter(
         p => omitSpec.indexOf(p) === -1
       );
       if (bad) {
         throw new Error(
-          `Error when processing @omit for ${entity.kind} '${
-            entity.name
-          }' - we currently don't support '${bad}' when '${READ}' is forbidden, to solve this add '${bad}' to the @omit clause or use ‘@omit‘ to omit from everything`
+          `Processing @omit for ${entity.kind} '${entity.name}' - '${bad.join(
+            ","
+          )}' must be omitted when '${READ}' is omitted. Add '${bad.join(
+            ","
+          )}' to the @omit clause, or use '@omit' to omit all actions.`
         );
       }
     }

--- a/packages/graphile-build-pg/src/omit.js
+++ b/packages/graphile-build-pg/src/omit.js
@@ -113,7 +113,7 @@ export default function omit(
       const bad = PERMISSIONS_THAT_REQUIRE_READ.filter(
         p => omitSpec.indexOf(p) === -1
       );
-      if (bad) {
+      if (bad.length > 0) {
         throw new Error(
           `Processing @omit for ${entity.kind} '${entity.name}' - '${bad.join(
             ","

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -332,7 +332,19 @@ class SchemaBuilder extends EventEmitter {
       this.triggerChange = () => {
         this._generatedSchema = null;
         // XXX: optionally debounce
-        this.emit("schema", this.buildSchema());
+        try {
+          const schema = this.buildSchema();
+          this.emit("schema", schema);
+        } catch (e) {
+          // Build errors introduced while watching are ignored because it's
+          // primarily used in development.
+          // eslint-disable-next-line no-console
+          console.error(
+            "⚠️⚠️⚠️ An error occured when building the schema on watch:"
+          );
+          // eslint-disable-next-line no-console
+          console.error(e);
+        }
       };
       if (listener) {
         this.on("schema", listener);

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -723,6 +723,9 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
         } catch (e) {
           // This is the error we're expecting to handle:
           // https://github.com/graphql/graphql-js/blob/831598ba76f015078ecb6c5c1fbaf133302f3f8e/src/type/definition.js#L526-L531
+          if (inScope && inScope.isRootQuery) {
+            throw e;
+          }
           const isProbablyAnEmptyObjectError = !!e.message.match(
             /function which returns such an object/
           );

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -268,7 +268,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
       Type: Class<T>,
       spec: ConfigType,
       inScope: Scope,
-      returnNullOnInvalid = false
+      performNonEmptyFieldsCheck = false
     ): ?T {
       const scope = inScope || {};
       if (!inScope) {
@@ -701,7 +701,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
       const finalSpec: ConfigType = newSpec;
 
       const Self: T = new Type(finalSpec);
-      if (!(Self instanceof GraphQLSchema) && returnNullOnInvalid) {
+      if (!(Self instanceof GraphQLSchema) && performNonEmptyFieldsCheck) {
         try {
           if (
             Self instanceof GraphQLInterfaceType ||

--- a/packages/graphile-build/src/swallowError.js
+++ b/packages/graphile-build/src/swallowError.js
@@ -14,14 +14,14 @@ export default function swallowError(e: Error): void {
     const errorSnippet =
       e && typeof e.toString === "function"
         ? String(e)
-            .replace(/\n/g, "  ")
-            .substr(0, 75)
+            .replace(/\n.*/g, "")
+            .substr(0, 160)
             .trim()
         : null;
     if (errorSnippet) {
       // eslint-disable-next-line no-console
       console.warn(
-        `Recoverable error occurred; use envvar 'DEBUG="graphile-build:warn"' for full error\n> ${errorSnippet}...`
+        `Recoverable error occurred; use envvar 'DEBUG="graphile-build:warn"' for full error\n> ${errorSnippet}…`
       );
     } else {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
- Does not allow errors building `Query` to be swallowed
- Increases length of error snippets
- Improves wording of `@omit` error message relating to read dependency


Fixes graphile/postgraphile#813