### PR TITLE
fix(rbac): allow exposing hidden types when sensible

### DIFF
--- a/packages/postgraphile-core/__tests__/fixtures/queries/rbac.basic.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/rbac.basic.graphql
@@ -10,4 +10,7 @@ query {
   postById(id:7) { nodeId id headline body authorId }
   allPosts { nodes { nodeId id headline body authorId } }
   personForPosts: personById(id: 3) { nodeId postsByAuthorId { nodes { nodeId id headline body authorId } } }
+
+  # https://github.com/graphile/postgraphile/issues/812
+  returnTableWithoutGrants { nodeId personId1 personId2 }
 }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -4250,6 +4250,11 @@ Object {
       "id": 7,
       "nodeId": "WyJwb3N0cyIsN10=",
     },
+    "returnTableWithoutGrants": Object {
+      "nodeId": "WyJjb21wb3VuZF9rZXlzIiwxLDJd",
+      "personId1": 1,
+      "personId2": 2,
+    },
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -65,7 +65,9 @@ beforeAll(() => {
     // Now for RBAC-enabled tests
     await pgClient.query("set role postgraphile_test_authenticator");
     const [rbac] = await Promise.all([
-      createPostGraphileSchema(pgClient, ["a", "b", "c"], {}),
+      createPostGraphileSchema(pgClient, ["a", "b", "c"], {
+        ignoreRBAC: false,
+      }),
     ]);
     debug(printSchema(normal));
     return {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -6076,6 +6076,7 @@ type Query implements Node {
     nodeId: ID!
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
+  returnTableWithoutGrants: CompoundKey
 
   \\"\\"\\"Reads a single \`SimilarTable1\` using its globally unique \`ID\`.\\"\\"\\"
   similarTable1(

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
@@ -2456,6 +2456,7 @@ type Query implements Node {
   which can only query top level fields if they are in a particular form.
   \\"\\"\\"
   query: Query!
+  returnTableWithoutGrants: CompoundKey
   tableQuery(id: Int): Post
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
@@ -2508,6 +2508,7 @@ type Query implements Node {
   which can only query top level fields if they are in a particular form.
   \\"\\"\\"
   query: Query!
+  returnTableWithoutGrants: CompoundKey
   tableQuery(id: Int): Post
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
@@ -1509,6 +1509,7 @@ type Query implements Node {
   which can only query top level fields if they are in a particular form.
   \\"\\"\\"
   query: Query!
+  returnTableWithoutGrants: CompoundKey
   tableQuery(id: Int): Post
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -1,7 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema from non-root role, using RBAC permissions 1`] = `
-"\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+"type CompoundKey implements Node {
+  extra: Boolean
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
 input CreateLeftArmInput {
   \\"\\"\\"
   An arbitrary string value with no semantic meaning. Will be included in the

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -1115,6 +1115,7 @@ type Query implements Node {
   which can only query top level fields if they are in a particular form.
   \\"\\"\\"
   query: Query!
+  returnTableWithoutGrants: CompoundKey
 }
 
 \\"\\"\\"All input for the \`updateLeftArmById\` mutation.\\"\\"\\"
@@ -7353,6 +7354,7 @@ type Query implements Node {
     nodeId: ID!
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
+  returnTableWithoutGrants: CompoundKey
 
   \\"\\"\\"Reads a single \`SimilarTable1\` using its globally unique \`ID\`.\\"\\"\\"
   similarTable1(

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
@@ -2490,6 +2490,7 @@ type Query implements Node {
   which can only query top level fields if they are in a particular form.
   \\"\\"\\"
   query: Query!
+  returnTableWithoutGrants: CompoundKey
   tableQuery(id: Int): Post
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -2683,6 +2683,7 @@ type Query implements Node {
   which can only query top level fields if they are in a particular form.
   \\"\\"\\"
   query: Query!
+  returnTableWithoutGrants: CompoundKey
   tableQuery(id: Int): Post
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/kitchen-sink-permissions.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-permissions.sql
@@ -22,3 +22,6 @@ grant update(mood) on c.left_arm to postgraphile_test_visitor;
 grant delete on c.left_arm to postgraphile_test_visitor;
 
 grant select(id, headline, body, author_id) on a.post to postgraphile_test_visitor;
+
+-- DO NOT GRANT ANYTHING ON c.compound_key!
+grant execute on function c.return_table_without_grants() to postgraphile_test_visitor;

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -434,6 +434,10 @@ begin
 end;
 $$ language plpgsql volatile;
 
+create function c.return_table_without_grants() returns c.compound_key as $$
+  select * from c.compound_key order by person_id_1, person_id_2 limit 1
+$$ language sql stable security definer;
+
 -- Begin tests for smart comments
 
 -- Rename table and columns
@@ -555,4 +559,3 @@ create table d.tv_episodes (
     title       varchar(40),
     show_id     integer references d.tv_shows on delete cascade
 );
-


### PR DESCRIPTION
Fixes https://github.com/graphile/postgraphile/issues/812

If you define a type in a non-exposed schema, or define a type but don't grant access to it, then that type will generally not appear in your schema (if `ignoreRBAC: false`). If it does appear, chances are it's been pulled in by a SQL function or similar; if this is the case then pulling it through with no columns doesn't make any sense (and if there's no PK it can cause a crash as the type now has no fields). This PR adds attributes back on tables that haven't been granted *any* read permissions.