### PR TITLE
feat(makeExtendSchemaPlugin): add support for enum

### DIFF
--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -284,10 +284,17 @@ type Subscription {
 `;
 
 exports[`supports defining new types 1`] = `
-"input EchoInput {
+"enum EchoCount {
+  ONCE
+  TWICE
+  FOREVER
+}
+
+input EchoInput {
   text: String!
   int: Int
   float: Float!
+  count: EchoCount
   intList: [Int!]
 }
 
@@ -295,6 +302,7 @@ type EchoOutput {
   text: String!
   int: Int
   float: Float!
+  count: EchoCount!
   intList: [Int!]
 }
 
@@ -315,18 +323,21 @@ type Query {
 exports[`supports defining new types 2`] = `
 Object {
   "t1": Object {
+    "count": "ONCE",
     "float": 0.23,
     "int": null,
     "intList": null,
     "text": "Hi1",
   },
   "t2": Object {
+    "count": "TWICE",
     "float": 1.23,
     "int": 42,
     "intList": null,
     "text": "Hi2",
   },
   "t3": Object {
+    "count": "FOREVER",
     "float": 2.23,
     "int": 88,
     "intList": Array [

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.js
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.js
@@ -149,7 +149,9 @@ export default function makeExtendSchemaPlugin(
             scope
           );
         } else {
-          throw new Error("Coding error.");
+          throw new Error(
+            `We have no code to build an object of type '${type}'; it should not have reached this area of the code.`
+          );
         }
       });
       return _;

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.js
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.js
@@ -71,6 +71,7 @@ export default function makeExtendSchemaPlugin(
       } = build;
       newTypes.forEach(({ type, definition }) => {
         if (type === GraphQLEnumType) {
+          // https://graphql.org/graphql-js/type/#graphqlenumtype
           const name = getName(definition.name);
           const description = getDescription(definition.description);
           const directives = getDirectives(definition.directives);
@@ -90,6 +91,7 @@ export default function makeExtendSchemaPlugin(
           };
           newWithHooks(type, { name, description, values }, scope);
         } else if (type === GraphQLObjectType) {
+          // https://graphql.org/graphql-js/type/#graphqlobjecttype
           const name = getName(definition.name);
           const description = getDescription(definition.description);
           const interfaces = getInterfaces(definition.interfaces, build);
@@ -124,6 +126,7 @@ export default function makeExtendSchemaPlugin(
             scope
           );
         } else if (type === GraphQLInputObjectType) {
+          // https://graphql.org/graphql-js/type/#graphqlinputobjecttype
           const name = getName(definition.name);
           const description = getDescription(definition.description);
           const directives = getDirectives(definition.directives);

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.js
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.js
@@ -89,7 +89,10 @@ export default function makeExtendSchemaPlugin(
             //   }
             // }
             // Ref: https://github.com/graphql/graphql-js/issues/525#issuecomment-255834625
-            const valueValue = relevantResolver[valueName]; // Defaults to undefined
+            const valueValue =
+              relevantResolver[valueName] !== undefined
+                ? relevantResolver[valueName]
+                : valueName;
 
             const valueDeprecationReason =
               valueDirectives.deprecated && valueDirectives.deprecated.reason;


### PR DESCRIPTION
I want support for enum types, so that I can extend the GraphQL schema to include enums. I'm fairly unfamiliar with this code base, so any guidance here would be appreciated.