### PR TITLE
feat(query-builder): reference parent query builder on child

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -108,36 +108,38 @@ export default (async function PgAllRows(
                       {
                         withPaginationAsFields: isConnection,
                       },
-                      builder => {
+                      queryBuilder => {
                         if (primaryKeys) {
-                          builder.beforeLock("orderBy", () => {
-                            if (!builder.isOrderUnique(false)) {
+                          queryBuilder.beforeLock("orderBy", () => {
+                            if (!queryBuilder.isOrderUnique(false)) {
                               // Order by PK if no order specified
-                              builder.data.cursorPrefix = ["primary_key_asc"];
+                              queryBuilder.data.cursorPrefix = [
+                                "primary_key_asc",
+                              ];
                               primaryKeys.forEach(key => {
-                                builder.orderBy(
-                                  sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                                queryBuilder.orderBy(
+                                  sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
                                     key.name
                                   )}`,
                                   true
                                 );
                               });
-                              builder.setOrderIsUnique();
+                              queryBuilder.setOrderIsUnique();
                             }
                           });
                         } else if (isView(table) && !!uniqueIdAttribute) {
-                          builder.beforeLock("orderBy", () => {
-                            if (!builder.isOrderUnique(false)) {
-                              builder.data.cursorPrefix = [
+                          queryBuilder.beforeLock("orderBy", () => {
+                            if (!queryBuilder.isOrderUnique(false)) {
+                              queryBuilder.data.cursorPrefix = [
                                 "view_unique_key_asc",
                               ];
-                              builder.orderBy(
-                                sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                              queryBuilder.orderBy(
+                                sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
                                   uniqueIdAttribute.name
                                 )}`,
                                 true
                               );
-                              builder.setOrderIsUnique();
+                              queryBuilder.setOrderIsUnique();
                             }
                           });
                         }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -204,6 +204,7 @@ export default (function PgBackwardRelationPlugin(
             },
             {
               pgFieldIntrospection: table,
+              isPgBackwardSingleRelationField: true,
             }
           );
         }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -176,6 +176,7 @@ export default (function PgBackwardRelationPlugin(
                           withPagination: false,
                         },
                         innerQueryBuilder => {
+                          innerQueryBuilder.parentQueryBuilder = queryBuilder;
                           keys.forEach((key, i) => {
                             innerQueryBuilder.where(
                               sql.fragment`${tableAlias}.${sql.identifier(
@@ -251,6 +252,7 @@ export default (function PgBackwardRelationPlugin(
                             asJsonAggregate: !isConnection,
                           },
                           innerQueryBuilder => {
+                            innerQueryBuilder.parentQueryBuilder = queryBuilder;
                             if (primaryKeys) {
                               innerQueryBuilder.beforeLock("orderBy", () => {
                                 // append order by primary key to the list of orders

--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -133,6 +133,7 @@ export default (function PgForwardRelationPlugin(builder) {
                       resolveData,
                       { asJson: true },
                       innerQueryBuilder => {
+                        innerQueryBuilder.parentQueryBuilder = queryBuilder;
                         keys.forEach((key, i) => {
                           innerQueryBuilder.where(
                             sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -101,10 +101,10 @@ export default (async function PgRowByUniqueConstraint(builder) {
                         undefined,
                         resolveData,
                         {},
-                        builder => {
+                        queryBuilder => {
                           keys.forEach(key => {
-                            builder.where(
-                              sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                            queryBuilder.where(
+                              sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
                                 key.name
                               )} = ${gql2pg(
                                 args[inflection.column(key)],

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -54,10 +54,10 @@ export default (async function PgRowNode(builder) {
           undefined,
           resolveData,
           {},
-          builder => {
+          queryBuilder => {
             primaryKeys.forEach((key, idx) => {
-              builder.where(
-                sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+              queryBuilder.where(
+                sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
                   key.name
                 )} = ${gql2pg(
                   identifiers[idx],
@@ -173,10 +173,10 @@ export default (async function PgRowNode(builder) {
                         undefined,
                         resolveData,
                         {},
-                        builder => {
+                        queryBuilder => {
                           primaryKeys.forEach((key, idx) => {
-                            builder.where(
-                              sql.fragment`${builder.getTableAlias()}.${sql.identifier(
+                            queryBuilder.where(
+                              sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
                                 key.name
                               )} = ${gql2pg(
                                 identifiers[idx],

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -285,7 +285,8 @@ export default function makeProcField(
         parsedResolveInfoFragment,
         ReturnType,
         sqlMutationQuery,
-        functionAlias
+        functionAlias,
+        parentQueryBuilder
       ) {
         const resolveData = getDataFromParsedResolveInfoFragment(
           parsedResolveInfoFragment,
@@ -309,6 +310,7 @@ export default function makeProcField(
               !proc.returnsSet && !rawReturnType.isPgArray && isTableLike,
           },
           innerQueryBuilder => {
+            innerQueryBuilder.parentQueryBuilder = parentQueryBuilder;
             if (!isTableLike) {
               if (returnTypeTable) {
                 innerQueryBuilder.select(
@@ -354,7 +356,8 @@ export default function makeProcField(
                   parsedResolveInfoFragment,
                   ReturnType,
                   sqlMutationQuery,
-                  functionAlias
+                  functionAlias,
+                  queryBuilder
                 );
                 return sql.fragment`(${query})`;
               }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
@@ -514,7 +517,8 @@ export default function makeProcField(
                   parsedResolveInfoFragment,
                   resolveInfo.returnType,
                   functionAlias,
-                  functionAlias
+                  functionAlias,
+                  null
                 );
                 const intermediateIdentifier = sql.identifier(Symbol());
                 const isVoid = returnType.id === "2278";
@@ -551,7 +555,8 @@ export default function makeProcField(
                   parsedResolveInfoFragment,
                   resolveInfo.returnType,
                   sqlMutationQuery,
-                  functionAlias
+                  functionAlias,
+                  null
                 );
                 const { text, values } = sql.compile(query);
                 if (debugSql.enabled) debugSql(text);


### PR DESCRIPTION
This allows plugins to get a reference to the parent builder so they can get the parent table name (for example) enabling them to add additional where clauses or whatever is necessary.

The motivation for this was so that I can add an 'INHERIT' option to my [PgOmitArchived](https://gist.github.com/benjie/5481c00e5847d82c1b4e9988eee6092e) plugin - this way if the parent record is archived then we can include archived children; otherwise if the parent is not archived then we omit archived children. I'm sure there's a lot more powerful uses it can be put to though 👍

- Refactored so all query builder references are `queryBuilder` (or `innerQueryBuilder` or whatever) - rather than using lazy `builder` name in some places
- Added a scope boolean to singular backward relations so they can be hooked more easily
- Found locations (manually) where a query builder is built to reference another query builder (e.g. relations) and gave the new (child) query builder a reference to the old (parent) query builder.