### PR TITLE
fix(graphql): handle all long aliases

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -186,7 +186,7 @@ class QueryBuilder {
       // https://github.com/graphql/graphql-js/blob/680685dd14bd52c6475305e150e5f295ead2aa7e/src/language/lexer.js#L551-L581
       //
       // so this should not cause any issues in practice.
-      if (/^@*[_A-Za-z][_0-9A-Za-z]*$/.test(alias) !== true) {
+      if (/^(@+|[_A-Za-z])[_0-9A-Za-z]*$/.test(alias) !== true) {
         throw new Error(`Disallowed alias '${alias}'.`);
       }
     }

--- a/packages/postgraphile-core/__tests__/fixtures/queries/longAliases.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/longAliases.graphql
@@ -1,0 +1,9 @@
+query {
+  person: personByEmail(email: "sara.smith@email.com") {
+    nodeId
+    email
+    aVeryLongAliasInOrderToTestThatThingsGoThroughPostgresJustFineAndWeDontGetAnyIssuesDueToAliasLength: friends {
+      totalCount
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/longAliases.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/longAliases.graphql
@@ -2,7 +2,14 @@ query {
   person: personByEmail(email: "sara.smith@email.com") {
     nodeId
     email
+
+    # safe alias: @@25fa9871b4d4d16ffd41359c88e7e851739819c6
     aVeryLongAliasInOrderToTestThatThingsGoThroughPostgresJustFineAndWeDontGetAnyIssuesDueToAliasLength: friends {
+      totalCount
+    }
+
+    # safe alias: @@e82261e340b3c5fc784bd0d54ec53541f5a4e2fe
+    anotherLongAliasInOrderToTestThatThingsGoThroughPostgresJustFineAndWeDontGetAnyIssuesDueToAliasLength: friends {
       totalCount
     }
   }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1035,6 +1035,20 @@ Object {
 }
 `;
 
+exports[`longAliases.graphql 1`] = `
+Object {
+  "data": Object {
+    "person": Object {
+      "aVeryLongAliasInOrderToTestThatThingsGoThroughPostgresJustFineAndWeDontGetAnyIssuesDueToAliasLength": Object {
+        "totalCount": 2,
+      },
+      "email": "sara.smith@email.com",
+      "nodeId": "WyJwZW9wbGUiLDJd",
+    },
+  },
+}
+`;
+
 exports[`node.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1042,6 +1042,9 @@ Object {
       "aVeryLongAliasInOrderToTestThatThingsGoThroughPostgresJustFineAndWeDontGetAnyIssuesDueToAliasLength": Object {
         "totalCount": 2,
       },
+      "anotherLongAliasInOrderToTestThatThingsGoThroughPostgresJustFineAndWeDontGetAnyIssuesDueToAliasLength": Object {
+        "totalCount": 2,
+      },
       "email": "sara.smith@email.com",
       "nodeId": "WyJwZW9wbGUiLDJd",
     },


### PR DESCRIPTION
Fixes #268; previously only long aliases whose sha1sum began with a letter passed 😳 