### PR TITLE
feat(utils): add `@requires(columns: [...])` directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "prettier": "^1.4.4"
   },
   "scripts": {
+    "check": "yarn clean && yarn lint && yarn prepack:all && yarn test",
     "lint": "eslint packages && lerna run tslint",
     "flow": "flow",
     "flow:check": "flow check",
-    "test": "lerna run test",
+    "test": "lerna run --concurrency 1 test",
     "prepack:all": "scripts/prepack-all",
     "watch": "for I in packages/*/; do echo \"cd $I && npm run watch\" | perl -p -e 's/\\n/\\0/;'; done | xargs -0 node_modules/.bin/concurrently --kill-others",
     "clean": "rm -Rf packages/*/node8plus/"

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin-pg.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin-pg.test.js
@@ -306,22 +306,18 @@ it("allows adding a field to an existing table, and requesting necessary data al
   const schema = await createPostGraphileSchema(pgPool, ["a"], {
     disableDefaultMutations: true,
     appendPlugins: [
-      makeExtendSchemaPlugin(build => {
-        const { pgSql: sql } = build;
-        return {
-          typeDefs: gql`
-            extend type User {
-              customField: String @requires(columns: ["id", "name"])
-            }
-          `,
-          resolvers: {
-            User: {
-              customField: user =>
-                `User ${user.id} fetched (name: ${user.name})`,
-            },
+      makeExtendSchemaPlugin(() => ({
+        typeDefs: gql`
+          extend type User {
+            customField: String @requires(columns: ["id", "name"])
+          }
+        `,
+        resolvers: {
+          User: {
+            customField: user => `User ${user.id} fetched (name: ${user.name})`,
           },
-        };
-      }),
+        },
+      })),
     ],
   });
   const printedSchema = printSchema(schema);

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin-pg.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin-pg.test.js
@@ -309,12 +309,16 @@ it("allows adding a field to an existing table, and requesting necessary data al
       makeExtendSchemaPlugin(() => ({
         typeDefs: gql`
           extend type User {
-            customField: String @requires(columns: ["id", "name"])
+            customField: String
+              @requires(columns: ["id", "name", "slightly_more_complex_column"])
           }
         `,
         resolvers: {
           User: {
-            customField: user => `User ${user.id} fetched (name: ${user.name})`,
+            customField: user =>
+              `User ${user.id} fetched (name: ${user.name}) ${JSON.stringify(
+                user.renamedComplexColumn
+              )}`,
           },
         },
       })),
@@ -340,7 +344,9 @@ it("allows adding a field to an existing table, and requesting necessary data al
     expect(errors).toBeFalsy();
     expect(data).toBeTruthy();
     expect(data.userById).toBeTruthy();
-    expect(data.userById.customField).toEqual(`User 1 fetched (name: Alice)`);
+    expect(data.userById.customField).toEqual(
+      `User 1 fetched (name: Alice) [{"number_int":1,"string_text":"hi"},{"number_int":2,"string_text":"bye"}]`
+    );
   } finally {
     pgClient.release();
   }

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -1,7 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows adding a custom field returning a list to PG schema 1`] = `
-"\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
 scalar Cursor
 
 \\"\\"\\"
@@ -99,6 +110,7 @@ type User implements Node {
   name: String!
   email: String!
   bio: String
+  renamedComplexColumn: [Complex]
   createdAt: Datetime!
 }
 
@@ -117,6 +129,9 @@ input UserCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
   bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  renamedComplexColumn: [ComplexInput]
 
   \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
   createdAt: Datetime
@@ -159,6 +174,8 @@ enum UsersOrderBy {
   EMAIL_DESC
   BIO_ASC
   BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   PRIMARY_KEY_ASC
@@ -168,7 +185,18 @@ enum UsersOrderBy {
 `;
 
 exports[`allows adding a custom single field to PG schema 1`] = `
-"\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
 scalar Cursor
 
 \\"\\"\\"
@@ -266,6 +294,7 @@ type User implements Node {
   name: String!
   email: String!
   bio: String
+  renamedComplexColumn: [Complex]
   createdAt: Datetime!
 }
 
@@ -284,6 +313,9 @@ input UserCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
   bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  renamedComplexColumn: [ComplexInput]
 
   \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
   createdAt: Datetime
@@ -326,6 +358,8 @@ enum UsersOrderBy {
   EMAIL_DESC
   BIO_ASC
   BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   PRIMARY_KEY_ASC
@@ -335,7 +369,18 @@ enum UsersOrderBy {
 `;
 
 exports[`allows adding a field to an existing table, and requesting necessary data along with it 1`] = `
-"\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
 scalar Cursor
 
 \\"\\"\\"
@@ -432,6 +477,7 @@ type User implements Node {
   name: String!
   email: String!
   bio: String
+  renamedComplexColumn: [Complex]
   createdAt: Datetime!
   customField: String
 }
@@ -451,6 +497,9 @@ input UserCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
   bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  renamedComplexColumn: [ComplexInput]
 
   \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
   createdAt: Datetime
@@ -493,6 +542,8 @@ enum UsersOrderBy {
   EMAIL_DESC
   BIO_ASC
   BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   PRIMARY_KEY_ASC
@@ -502,7 +553,18 @@ enum UsersOrderBy {
 `;
 
 exports[`allows adding a simple mutation field to PG schema 1`] = `
-"\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
 scalar Cursor
 
 \\"\\"\\"
@@ -621,6 +683,7 @@ type User implements Node {
   name: String!
   email: String!
   bio: String
+  renamedComplexColumn: [Complex]
   createdAt: Datetime!
 }
 
@@ -639,6 +702,9 @@ input UserCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
   bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  renamedComplexColumn: [ComplexInput]
 
   \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
   createdAt: Datetime
@@ -681,6 +747,8 @@ enum UsersOrderBy {
   EMAIL_DESC
   BIO_ASC
   BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   PRIMARY_KEY_ASC

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -334,6 +334,173 @@ enum UsersOrderBy {
 "
 `;
 
+exports[`allows adding a field to an existing table, and requesting necessary data along with it 1`] = `
+"\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+scalar Cursor
+
+\\"\\"\\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\\"\\"\\"
+scalar Datetime
+
+\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+interface Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+type PageInfo {
+  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  hasNextPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  hasPreviousPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  startCursor: Cursor
+
+  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  endCursor: Cursor
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query implements Node {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+
+  \\"\\"\\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  node(
+    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    nodeId: ID!
+  ): Node
+
+  \\"\\"\\"Reads and enables pagination through a set of \`User\`.\\"\\"\\"
+  allUsers(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"The method to use when ordering \`User\`.\\"\\"\\"
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: UserCondition
+  ): UsersConnection
+  userById(id: Int!): User
+
+  \\"\\"\\"Reads a single \`User\` using its globally unique \`ID\`.\\"\\"\\"
+  user(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`User\`.\\"\\"\\"
+    nodeId: ID!
+  ): User
+}
+
+type User implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  createdAt: Datetime!
+  customField: String
+}
+
+\\"\\"\\"
+A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input UserCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  email: String
+
+  \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
+  bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  createdAt: Datetime
+}
+
+\\"\\"\\"A connection to a list of \`User\` values.\\"\\"\\"
+type UsersConnection {
+  \\"\\"\\"A list of \`User\` objects.\\"\\"\\"
+  nodes: [User]!
+
+  \\"\\"\\"
+  A list of edges which contains the \`User\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [UsersEdge!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`User\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`User\` edge in the connection.\\"\\"\\"
+type UsersEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`User\` at the end of the edge.\\"\\"\\"
+  node: User
+}
+
+\\"\\"\\"Methods to use when ordering \`User\`.\\"\\"\\"
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  BIO_ASC
+  BIO_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+"
+`;
+
 exports[`allows adding a simple mutation field to PG schema 1`] = `
 "\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
 scalar Cursor

--- a/packages/graphile-utils/__tests__/utils-schema.sql
+++ b/packages/graphile-utils/__tests__/utils-schema.sql
@@ -6,13 +6,21 @@ create schema b;
 create schema c;
 create schema d;
 
+create type a.complex as (
+  number_int int,
+  string_text text
+);
+
 create table a.users (
   id serial primary key,
   name text not null,
   email text not null,
   bio text,
+  slightly_more_complex_column a.complex[] default array[row(1,'hi'),row(2, 'bye')]::a.complex[],
   created_at timestamptz not null default now()
 );
+
+comment on column a.users.slightly_more_complex_column is E'@name renamedComplexColumn';
 
 insert into a.users (name, email, bio) values
   ('Alice', 'alice@example.com', null),

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -265,7 +265,7 @@ export default function makeExtendSchemaPlugin(
       return _;
     });
 
-    builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
+    builder.hook("GraphQLObjectType:fields", (fields, build, context: any) => {
       const {
         extend,
         [`ExtendSchemaPlugin_${uniqueId}_typeExtensions`]: typeExtensions,

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -388,6 +388,8 @@ function getValue(value: ValueNode | GraphileEmbed) {
     return parseInt(value.value, 10);
   } else if (value.kind === "FloatValue") {
     return parseFloat(value.value);
+  } else if (value.kind === "ListValue") {
+    return value.values.map(getValue);
   } else if (value.kind === "NullValue") {
     return null;
   } else if (value.kind === "GraphileEmbed") {


### PR DESCRIPTION
e.g.:

typeDefs:
```graphql
extend type MyTable {
  fieldFromExternalSource: Whatever @requires(columns: ["id", "external_source_id"])
}
```

resolvers (note that the columns are converted to fields, so the case changes):
```js
{ MyTable: {
  fieldFromExternalSource({id, externalSourceId}) {
    // return fetch(`http://example.com/${externalSourceId}`)...
  }
}}
```

Guarantees that the requested columns exist on the result set.