### PR TITLE
feat(debugging): massively improve name collision errors

### DIFF
--- a/packages/graphile-build-pg/res/introspection-query.sql
+++ b/packages/graphile-build-pg/res/introspection-query.sql
@@ -41,6 +41,7 @@ with
       pro.proname as "name",
       dsc.description as "description",
       pro.pronamespace as "namespaceId",
+      nsp.nspname as "namespaceName",
       pro.proisstrict as "isStrict",
       pro.proretset as "returnsSet",
       case
@@ -56,6 +57,7 @@ with
     from
       pg_catalog.pg_proc as pro
       left join pg_catalog.pg_description as dsc on dsc.objoid = pro.oid
+      left join pg_catalog.pg_namespace as nsp on nsp.oid = pro.pronamespace
     where
       pro.pronamespace in (select "id" from namespace) and
       -- Currently we don’t support functions with variadic arguments. In the

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -128,7 +128,7 @@ export default (function PgBackwardRelationPlugin(
         const isDeprecated = isUnique && legacyRelationMode === DEPRECATED;
 
         const singleRelationFieldName = isUnique
-          ? inflection.singleRelationByKeys(
+          ? inflection.singleRelationByKeysBackwards(
               keys,
               table,
               foreignTable,
@@ -153,62 +153,83 @@ export default (function PgBackwardRelationPlugin(
           legacyRelationMode === ONLY;
 
         if (shouldAddSingleRelation && !omit(table, "read")) {
-          memo[singleRelationFieldName] = fieldWithHooks(
-            singleRelationFieldName,
-            ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
-              addDataGenerator(parsedResolveInfoFragment => {
-                return {
-                  pgQuery: queryBuilder => {
-                    queryBuilder.select(() => {
-                      const resolveData = getDataFromParsedResolveInfoFragment(
-                        parsedResolveInfoFragment,
-                        gqlTableType
-                      );
-                      const tableAlias = sql.identifier(Symbol());
-                      const foreignTableAlias = queryBuilder.getTableAlias();
-                      const query = queryFromResolveData(
-                        sql.identifier(schema.name, table.name),
-                        tableAlias,
-                        resolveData,
-                        {
-                          asJson: true,
-                          addNullCase: true,
-                          withPagination: false,
-                        },
-                        innerQueryBuilder => {
-                          innerQueryBuilder.parentQueryBuilder = queryBuilder;
-                          keys.forEach((key, i) => {
-                            innerQueryBuilder.where(
-                              sql.fragment`${tableAlias}.${sql.identifier(
-                                key.name
-                              )} = ${foreignTableAlias}.${sql.identifier(
-                                foreignKeys[i].name
-                              )}`
-                            );
-                          });
-                        }
-                      );
-                      return sql.fragment`(${query})`;
-                    }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
-                  },
-                };
-              });
-              return {
-                description:
-                  constraint.tags.backwardDescription ||
-                  `Reads a single \`${tableTypeName}\` that is related to this \`${foreignTableTypeName}\`.`,
-                type: gqlTableType,
-                args: {},
-                resolve: (data, _args, _context, resolveInfo) => {
-                  const safeAlias = getSafeAliasFromResolveInfo(resolveInfo);
-                  return data[safeAlias];
-                },
-              };
-            },
+          memo = extend(
+            memo,
             {
-              pgFieldIntrospection: table,
-              isPgBackwardSingleRelationField: true,
-            }
+              [singleRelationFieldName]: fieldWithHooks(
+                singleRelationFieldName,
+                ({
+                  getDataFromParsedResolveInfoFragment,
+                  addDataGenerator,
+                }) => {
+                  addDataGenerator(parsedResolveInfoFragment => {
+                    return {
+                      pgQuery: queryBuilder => {
+                        queryBuilder.select(() => {
+                          const resolveData = getDataFromParsedResolveInfoFragment(
+                            parsedResolveInfoFragment,
+                            gqlTableType
+                          );
+                          const tableAlias = sql.identifier(Symbol());
+                          const foreignTableAlias = queryBuilder.getTableAlias();
+                          const query = queryFromResolveData(
+                            sql.identifier(schema.name, table.name),
+                            tableAlias,
+                            resolveData,
+                            {
+                              asJson: true,
+                              addNullCase: true,
+                              withPagination: false,
+                            },
+                            innerQueryBuilder => {
+                              innerQueryBuilder.parentQueryBuilder = queryBuilder;
+                              keys.forEach((key, i) => {
+                                innerQueryBuilder.where(
+                                  sql.fragment`${tableAlias}.${sql.identifier(
+                                    key.name
+                                  )} = ${foreignTableAlias}.${sql.identifier(
+                                    foreignKeys[i].name
+                                  )}`
+                                );
+                              });
+                            }
+                          );
+                          return sql.fragment`(${query})`;
+                        }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
+                      },
+                    };
+                  });
+                  return {
+                    description:
+                      constraint.tags.backwardDescription ||
+                      `Reads a single \`${tableTypeName}\` that is related to this \`${foreignTableTypeName}\`.`,
+                    type: gqlTableType,
+                    args: {},
+                    resolve: (data, _args, _context, resolveInfo) => {
+                      const safeAlias = getSafeAliasFromResolveInfo(
+                        resolveInfo
+                      );
+                      return data[safeAlias];
+                    },
+                  };
+                },
+                {
+                  pgFieldIntrospection: table,
+                  isPgBackwardSingleRelationField: true,
+                }
+              ),
+            },
+            `Backward relation (single) for constraint '${
+              constraint.name
+            }' on table '${table.namespaceName}.${
+              table.name
+            }'. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
+              constraint.name
+            }" ON "${table.namespaceName}"."${
+              table.name
+            }" IS E'@foreignSingleFieldName newNameHere\\n${
+              constraint.description
+            }';`
           );
         }
         function makeFields(isConnection) {
@@ -231,103 +252,130 @@ export default (function PgBackwardRelationPlugin(
                   constraint
                 );
 
-            memo[manyRelationFieldName] = fieldWithHooks(
-              manyRelationFieldName,
-              ({ getDataFromParsedResolveInfoFragment, addDataGenerator }) => {
-                addDataGenerator(parsedResolveInfoFragment => {
-                  return {
-                    pgQuery: queryBuilder => {
-                      queryBuilder.select(() => {
-                        const resolveData = getDataFromParsedResolveInfoFragment(
-                          parsedResolveInfoFragment,
-                          isConnection ? ConnectionType : TableType
-                        );
-                        const tableAlias = sql.identifier(Symbol());
-                        const foreignTableAlias = queryBuilder.getTableAlias();
-                        const query = queryFromResolveData(
-                          sql.identifier(schema.name, table.name),
-                          tableAlias,
-                          resolveData,
-                          {
-                            withPagination: isConnection,
-                            withPaginationAsFields: false,
-                            asJsonAggregate: !isConnection,
-                          },
-                          innerQueryBuilder => {
-                            innerQueryBuilder.parentQueryBuilder = queryBuilder;
-                            if (primaryKeys) {
-                              innerQueryBuilder.beforeLock("orderBy", () => {
-                                // append order by primary key to the list of orders
-                                if (!innerQueryBuilder.isOrderUnique(false)) {
-                                  innerQueryBuilder.data.cursorPrefix = [
-                                    "primary_key_asc",
-                                  ];
-                                  primaryKeys.forEach(key => {
-                                    innerQueryBuilder.orderBy(
-                                      sql.fragment`${innerQueryBuilder.getTableAlias()}.${sql.identifier(
-                                        key.name
-                                      )}`,
-                                      true
-                                    );
-                                  });
-                                  innerQueryBuilder.setOrderIsUnique();
-                                }
-                              });
-                            }
-
-                            keys.forEach((key, i) => {
-                              innerQueryBuilder.where(
-                                sql.fragment`${tableAlias}.${sql.identifier(
-                                  key.name
-                                )} = ${foreignTableAlias}.${sql.identifier(
-                                  foreignKeys[i].name
-                                )}`
-                              );
-                            });
-                          }
-                        );
-                        return sql.fragment`(${query})`;
-                      }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
-                    },
-                  };
-                });
-                const ConnectionType = getTypeByName(
-                  inflection.connection(gqlTableType.name)
-                );
-                const TableType = pgGetGqlTypeByTypeIdAndModifier(
-                  table.type.id,
-                  null
-                );
-                return {
-                  description:
-                    constraint.tags.backwardDescription ||
-                    `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
-                  type: isConnection
-                    ? new GraphQLNonNull(ConnectionType)
-                    : new GraphQLNonNull(
-                        new GraphQLList(new GraphQLNonNull(TableType))
-                      ),
-                  args: {},
-                  resolve: (data, _args, _context, resolveInfo) => {
-                    const safeAlias = getSafeAliasFromResolveInfo(resolveInfo);
-                    if (isConnection) {
-                      return addStartEndCursor(data[safeAlias]);
-                    } else {
-                      return data[safeAlias];
-                    }
-                  },
-                  deprecationReason: isDeprecated
-                    ? // $FlowFixMe
-                      `Please use ${singleRelationFieldName} instead`
-                    : undefined,
-                };
-              },
+            memo = extend(
+              memo,
               {
-                isPgFieldConnection: isConnection,
-                isPgFieldSimpleCollection: !isConnection,
-                isPgBackwardRelationField: true,
-                pgFieldIntrospection: table,
-              }
+                [manyRelationFieldName]: fieldWithHooks(
+                  manyRelationFieldName,
+                  ({
+                    getDataFromParsedResolveInfoFragment,
+                    addDataGenerator,
+                  }) => {
+                    addDataGenerator(parsedResolveInfoFragment => {
+                      return {
+                        pgQuery: queryBuilder => {
+                          queryBuilder.select(() => {
+                            const resolveData = getDataFromParsedResolveInfoFragment(
+                              parsedResolveInfoFragment,
+                              isConnection ? ConnectionType : TableType
+                            );
+                            const tableAlias = sql.identifier(Symbol());
+                            const foreignTableAlias = queryBuilder.getTableAlias();
+                            const query = queryFromResolveData(
+                              sql.identifier(schema.name, table.name),
+                              tableAlias,
+                              resolveData,
+                              {
+                                withPagination: isConnection,
+                                withPaginationAsFields: false,
+                                asJsonAggregate: !isConnection,
+                              },
+                              innerQueryBuilder => {
+                                innerQueryBuilder.parentQueryBuilder = queryBuilder;
+                                if (primaryKeys) {
+                                  innerQueryBuilder.beforeLock(
+                                    "orderBy",
+                                    () => {
+                                      // append order by primary key to the list of orders
+                                      if (
+                                        !innerQueryBuilder.isOrderUnique(false)
+                                      ) {
+                                        innerQueryBuilder.data.cursorPrefix = [
+                                          "primary_key_asc",
+                                        ];
+                                        primaryKeys.forEach(key => {
+                                          innerQueryBuilder.orderBy(
+                                            sql.fragment`${innerQueryBuilder.getTableAlias()}.${sql.identifier(
+                                              key.name
+                                            )}`,
+                                            true
+                                          );
+                                        });
+                                        innerQueryBuilder.setOrderIsUnique();
+                                      }
+                                    }
+                                  );
+                                }
+
+                                keys.forEach((key, i) => {
+                                  innerQueryBuilder.where(
+                                    sql.fragment`${tableAlias}.${sql.identifier(
+                                      key.name
+                                    )} = ${foreignTableAlias}.${sql.identifier(
+                                      foreignKeys[i].name
+                                    )}`
+                                  );
+                                });
+                              }
+                            );
+                            return sql.fragment`(${query})`;
+                          }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
+                        },
+                      };
+                    });
+                    const ConnectionType = getTypeByName(
+                      inflection.connection(gqlTableType.name)
+                    );
+                    const TableType = pgGetGqlTypeByTypeIdAndModifier(
+                      table.type.id,
+                      null
+                    );
+                    return {
+                      description:
+                        constraint.tags.backwardDescription ||
+                        `Reads and enables pagination through a set of \`${tableTypeName}\`.`,
+                      type: isConnection
+                        ? new GraphQLNonNull(ConnectionType)
+                        : new GraphQLNonNull(
+                            new GraphQLList(new GraphQLNonNull(TableType))
+                          ),
+                      args: {},
+                      resolve: (data, _args, _context, resolveInfo) => {
+                        const safeAlias = getSafeAliasFromResolveInfo(
+                          resolveInfo
+                        );
+                        if (isConnection) {
+                          return addStartEndCursor(data[safeAlias]);
+                        } else {
+                          return data[safeAlias];
+                        }
+                      },
+                      deprecationReason: isDeprecated
+                        ? // $FlowFixMe
+                          `Please use ${singleRelationFieldName} instead`
+                        : undefined,
+                    };
+                  },
+                  {
+                    isPgFieldConnection: isConnection,
+                    isPgFieldSimpleCollection: !isConnection,
+                    isPgBackwardRelationField: true,
+                    pgFieldIntrospection: table,
+                  }
+                ),
+              },
+
+              `Backward relation (${
+                isConnection ? "connection" : "simple collection"
+              }) for constraint '${constraint.name}' on table '${
+                table.namespaceName
+              }.${
+                table.name
+              }'. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
+                constraint.name
+              }" ON "${table.namespaceName}"."${table.name}" IS E'@${
+                isConnection ? "foreignFieldName" : "foreignSimpleFieldName"
+              } newNameHere\\n${constraint.description}';`
             );
           }
         }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -375,7 +375,10 @@ export default (function PgBackwardRelationPlugin(
                 constraint.name
               }" ON "${table.namespaceName}"."${table.name}" IS E'@${
                 isConnection ? "foreignFieldName" : "foreignSimpleFieldName"
-              } newNameHere\\n${constraint.description}';`
+              } newNameHere\\n${constraint.description.replace(
+                /['\\]/g,
+                "\\$1"
+              )}';`
             );
           }
         }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -36,6 +36,7 @@ export default (function PgBackwardRelationPlugin(
       pgAddStartEndCursor: addStartEndCursor,
       pgOmit: omit,
       sqlCommentByAddingTags,
+      describePgEntity,
     } = build;
     const {
       scope: { isPgRowType, pgIntrospection: foreignTable },
@@ -220,11 +221,9 @@ export default (function PgBackwardRelationPlugin(
                 }
               ),
             },
-            `Backward relation (single) for constraint '${
-              constraint.name
-            }' on table '${table.namespaceName}.${
-              table.name
-            }'. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
+            `Backward relation (single) for ${describePgEntity(
+              constraint
+            )}. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
               constraint.name
             }" ON "${table.namespaceName}"."${
               table.name
@@ -368,11 +367,9 @@ export default (function PgBackwardRelationPlugin(
 
               `Backward relation (${
                 isConnection ? "connection" : "simple collection"
-              }) for constraint '${constraint.name}' on table '${
-                table.namespaceName
-              }.${
-                table.name
-              }'. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
+              }) for ${describePgEntity(
+                constraint
+              )}. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
                 constraint.name
               }" ON "${table.namespaceName}"."${
                 table.name

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -223,13 +223,12 @@ export default (function PgBackwardRelationPlugin(
             },
             `Backward relation (single) for ${describePgEntity(
               constraint
-            )}. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
-              constraint.name
-            }" ON "${table.namespaceName}"."${
-              table.name
-            }" IS ${sqlCommentByAddingTags(constraint, {
-              foreignSingleFieldName: "newNameHere",
-            })};`
+            )}. To rename this relation with smart comments:\n\n  ${sqlCommentByAddingTags(
+              constraint,
+              {
+                foreignSingleFieldName: "newNameHere",
+              }
+            )}`
           );
         }
         function makeFields(isConnection) {
@@ -369,15 +368,14 @@ export default (function PgBackwardRelationPlugin(
                 isConnection ? "connection" : "simple collection"
               }) for ${describePgEntity(
                 constraint
-              )}. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
-                constraint.name
-              }" ON "${table.namespaceName}"."${
-                table.name
-              }" IS ${sqlCommentByAddingTags(constraint, {
-                [isConnection
-                  ? "foreignFieldName"
-                  : "foreignSimpleFieldName"]: "newNameHere",
-              })};`
+              )}. To rename this relation with smart comments:\n\n  ${sqlCommentByAddingTags(
+                constraint,
+                {
+                  [isConnection
+                    ? "foreignFieldName"
+                    : "foreignSimpleFieldName"]: "newNameHere",
+                }
+              )}`
             );
           }
         }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -35,6 +35,7 @@ export default (function PgBackwardRelationPlugin(
       pgQueryFromResolveData: queryFromResolveData,
       pgAddStartEndCursor: addStartEndCursor,
       pgOmit: omit,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isPgRowType, pgIntrospection: foreignTable },
@@ -227,9 +228,9 @@ export default (function PgBackwardRelationPlugin(
               constraint.name
             }" ON "${table.namespaceName}"."${
               table.name
-            }" IS E'@foreignSingleFieldName newNameHere\\n${
-              constraint.description
-            }';`
+            }" IS ${sqlCommentByAddingTags(constraint, {
+              foreignSingleFieldName: "newNameHere",
+            })};`
           );
         }
         function makeFields(isConnection) {
@@ -373,12 +374,13 @@ export default (function PgBackwardRelationPlugin(
                 table.name
               }'. To rename this relation with smart comments:\n\n  COMMENT ON CONSTRAINT "${
                 constraint.name
-              }" ON "${table.namespaceName}"."${table.name}" IS E'@${
-                isConnection ? "foreignFieldName" : "foreignSimpleFieldName"
-              } newNameHere\\n${constraint.description.replace(
-                /['\\]/g,
-                "\\$1"
-              )}';`
+              }" ON "${table.namespaceName}"."${
+                table.name
+              }" IS ${sqlCommentByAddingTags(constraint, {
+                [isConnection
+                  ? "foreignFieldName"
+                  : "foreignSimpleFieldName"]: "newNameHere",
+              })};`
             );
           }
         }

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -154,7 +154,11 @@ export default (function PgBackwardRelationPlugin(
           legacyRelationMode === DEPRECATED ||
           legacyRelationMode === ONLY;
 
-        if (shouldAddSingleRelation && !omit(table, "read")) {
+        if (
+          shouldAddSingleRelation &&
+          !omit(table, "read") &&
+          singleRelationFieldName
+        ) {
           memo = extend(
             memo,
             {

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -166,6 +166,10 @@ export default (function PgBasicsPlugin(
             return `table ${chalk.bold(
               `"${entity.namespaceName}"."${entity.name}"`
             )}`;
+          } else if (entity.kind === "procedure") {
+            return `function ${chalk.bold(
+              `"${entity.namespaceName}"."${entity.name}"(...args...)`
+            )}`;
           }
         } catch (e) {
           // eslint-disable-next-line no-console

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -384,6 +384,25 @@ export default (function PgBasicsPlugin(
               .join("-and-")}`
           );
         },
+        singleRelationByKeysBackwards(
+          detailedKeys: Keys,
+          table: PgClass,
+          _foreignTable: PgClass,
+          constraint: PgConstraint
+        ) {
+          if (constraint.tags.foreignSingleFieldName) {
+            return constraint.tags.foreignSingleFieldName;
+          }
+          if (constraint.tags.foreignFieldName) {
+            return constraint.tags.foreignFieldName;
+          }
+          return this.singleRelationByKeys(
+            detailedKeys,
+            table,
+            _foreignTable,
+            constraint
+          );
+        },
         manyRelationByKeys(
           detailedKeys: Keys,
           table: PgClass,
@@ -405,6 +424,9 @@ export default (function PgBasicsPlugin(
           _foreignTable: PgClass,
           constraint: PgConstraint
         ) {
+          if (constraint.tags.foreignSimplFieldName) {
+            return constraint.tags.foreignSimpleFieldName;
+          }
           if (constraint.tags.foreignFieldName) {
             return constraint.tags.foreignFieldName;
           }

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -162,6 +162,10 @@ export default (function PgBasicsPlugin(
             )}' on table ${chalk.bold(
               `"${entity.class.namespaceName}"."${entity.class.name}"`
             )}`;
+          } else if (entity.kind === "class") {
+            return `table ${chalk.bold(
+              `"${entity.namespaceName}"."${entity.name}"`
+            )}`;
           }
         } catch (e) {
           // eslint-disable-next-line no-console

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -136,7 +136,7 @@ function omitWithRBACChecks(
 function describePgEntity(entity) {
   try {
     if (entity.kind === "constraint") {
-      return `constraint '${chalk.bold(
+      return `constraint ${chalk.bold(
         `"${entity.name}"`
       )} on ${describePgEntity(entity.class)}`;
     } else if (entity.kind === "class") {

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -81,11 +81,11 @@ export default (function PgColumnsPlugin(builder) {
       inflection,
       pgOmit: omit,
       pgGetSelectValueForFieldAndTypeAndModifier: getSelectValueForFieldAndTypeAndModifier,
+      describePgEntity,
     } = build;
     const {
       scope: { isPgRowType, isPgCompoundType, pgIntrospection: table },
       fieldWithHooks,
-      Self,
     } = context;
     if (
       !(isPgRowType || isPgCompoundType) ||
@@ -164,7 +164,7 @@ export default (function PgColumnsPlugin(builder) {
           );
           return memo;
         }, {}),
-      `Adding columns to '${Self.name}'`
+      `Adding columns to '${describePgEntity(table)}'`
     );
   });
   builder.hook("GraphQLInputObjectType:fields", (fields, build, context) => {
@@ -176,6 +176,7 @@ export default (function PgColumnsPlugin(builder) {
       pgColumnFilter,
       inflection,
       pgOmit: omit,
+      describePgEntity,
     } = build;
     const {
       scope: {
@@ -187,7 +188,6 @@ export default (function PgColumnsPlugin(builder) {
         pgAddSubfield,
       },
       fieldWithHooks,
-      Self,
     } = context;
     if (
       !(isPgRowType || isPgCompoundType) ||
@@ -243,7 +243,7 @@ export default (function PgColumnsPlugin(builder) {
           );
           return memo;
         }, {}),
-      `Adding columns to input object '${Self.name}'`
+      `Adding columns to input object for ${describePgEntity(table)}`
     );
   });
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -169,14 +169,12 @@ export default (function PgColumnsPlugin(builder) {
             },
             `Adding field for ${describePgEntity(
               attr
-            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
-              attr.class.namespaceName
-            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+            )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
               attr,
               {
                 name: "newNameHere",
               }
-            )};`
+            )}`
           );
           return memo;
         }, {}),
@@ -264,14 +262,12 @@ export default (function PgColumnsPlugin(builder) {
             },
             `Adding input object field for ${describePgEntity(
               attr
-            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
-              attr.class.namespaceName
-            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+            )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
               attr,
               {
                 name: "newNameHere",
               }
-            )};`
+            )}`
           );
           return memo;
         }, {}),

--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -82,6 +82,7 @@ export default (function PgColumnsPlugin(builder) {
       pgOmit: omit,
       pgGetSelectValueForFieldAndTypeAndModifier: getSelectValueForFieldAndTypeAndModifier,
       describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isPgRowType, isPgCompoundType, pgIntrospection: table },
@@ -120,47 +121,62 @@ export default (function PgColumnsPlugin(builder) {
               }.${table.name}'; one of them is '${attr.name}'`
             );
           }
-          memo[fieldName] = fieldWithHooks(
-            fieldName,
-            fieldContext => {
-              const { addDataGenerator } = fieldContext;
-              const ReturnType =
-                pgGetGqlTypeByTypeIdAndModifier(
-                  attr.typeId,
-                  attr.typeModifier
-                ) || GraphQLString;
-              addDataGenerator(parsedResolveInfoFragment => {
-                return {
-                  pgQuery: queryBuilder => {
-                    queryBuilder.select(
-                      getSelectValueForFieldAndTypeAndModifier(
-                        ReturnType,
-                        fieldContext,
-                        parsedResolveInfoFragment,
-                        sql.fragment`(${queryBuilder.getTableAlias()}.${sql.identifier(
-                          attr.name
-                        )})`, // The brackets are necessary to stop the parser getting confused, ref: https://www.postgresql.org/docs/9.6/static/rowtypes.html#ROWTYPES-ACCESSING
-                        attr.type,
-                        attr.typeModifier
-                      ),
-                      fieldName
-                    );
-                  },
-                };
-              });
-              return {
-                description: attr.description,
-                type: nullableIf(
-                  GraphQLNonNull,
-                  !attr.isNotNull && !attr.type.domainIsNotNull,
-                  ReturnType
-                ),
-                resolve: (data, _args, _context, _resolveInfo) => {
-                  return pg2gql(data[fieldName], attr.type);
+          memo = extend(
+            memo,
+            {
+              [fieldName]: fieldWithHooks(
+                fieldName,
+                fieldContext => {
+                  const { addDataGenerator } = fieldContext;
+                  const ReturnType =
+                    pgGetGqlTypeByTypeIdAndModifier(
+                      attr.typeId,
+                      attr.typeModifier
+                    ) || GraphQLString;
+                  addDataGenerator(parsedResolveInfoFragment => {
+                    return {
+                      pgQuery: queryBuilder => {
+                        queryBuilder.select(
+                          getSelectValueForFieldAndTypeAndModifier(
+                            ReturnType,
+                            fieldContext,
+                            parsedResolveInfoFragment,
+                            sql.fragment`(${queryBuilder.getTableAlias()}.${sql.identifier(
+                              attr.name
+                            )})`, // The brackets are necessary to stop the parser getting confused, ref: https://www.postgresql.org/docs/9.6/static/rowtypes.html#ROWTYPES-ACCESSING
+                            attr.type,
+                            attr.typeModifier
+                          ),
+                          fieldName
+                        );
+                      },
+                    };
+                  });
+                  return {
+                    description: attr.description,
+                    type: nullableIf(
+                      GraphQLNonNull,
+                      !attr.isNotNull && !attr.type.domainIsNotNull,
+                      ReturnType
+                    ),
+                    resolve: (data, _args, _context, _resolveInfo) => {
+                      return pg2gql(data[fieldName], attr.type);
+                    },
+                  };
                 },
-              };
+                { pgFieldIntrospection: attr }
+              ),
             },
-            { pgFieldIntrospection: attr }
+            `Adding field for ${describePgEntity(
+              attr
+            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
+              attr.class.namespaceName
+            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+              attr,
+              {
+                name: "newNameHere",
+              }
+            )};`
           );
           return memo;
         }, {}),
@@ -177,6 +193,7 @@ export default (function PgColumnsPlugin(builder) {
       inflection,
       pgOmit: omit,
       describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: {
@@ -217,29 +234,44 @@ export default (function PgColumnsPlugin(builder) {
               }.${table.name}'; one of them is '${attr.name}'`
             );
           }
-          memo[fieldName] = fieldWithHooks(
-            fieldName,
-            pgAddSubfield(
-              fieldName,
-              attr.name,
-              attr.type,
-              {
-                description: attr.description,
-                type: nullableIf(
-                  GraphQLNonNull,
-                  isPgBaseInput ||
-                    isPgPatch ||
-                    (!attr.isNotNull && !attr.type.domainIsNotNull) ||
-                    attr.hasDefault,
-                  pgGetGqlInputTypeByTypeIdAndModifier(
-                    attr.typeId,
-                    attr.typeModifier
-                  ) || GraphQLString
+          memo = extend(
+            memo,
+            {
+              [fieldName]: fieldWithHooks(
+                fieldName,
+                pgAddSubfield(
+                  fieldName,
+                  attr.name,
+                  attr.type,
+                  {
+                    description: attr.description,
+                    type: nullableIf(
+                      GraphQLNonNull,
+                      isPgBaseInput ||
+                        isPgPatch ||
+                        (!attr.isNotNull && !attr.type.domainIsNotNull) ||
+                        attr.hasDefault,
+                      pgGetGqlInputTypeByTypeIdAndModifier(
+                        attr.typeId,
+                        attr.typeModifier
+                      ) || GraphQLString
+                    ),
+                  },
+                  attr.typeModifier
                 ),
-              },
-              attr.typeModifier
-            ),
-            { pgFieldIntrospection: attr }
+                { pgFieldIntrospection: attr }
+              ),
+            },
+            `Adding input object field for ${describePgEntity(
+              attr
+            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
+              attr.class.namespaceName
+            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+              attr,
+              {
+                name: "newNameHere",
+              }
+            )};`
           );
           return memo;
         }, {}),

--- a/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
@@ -103,13 +103,12 @@ export default (function PgComputedColumnsPlugin(
                 },
                 `Adding computed column for ${describePgEntity(
                   proc
-                )}. You can rename this field with:\n\n  COMMENT ON FUNCTION "${
-                  proc.namespaceName
-                }"."${
-                  proc.name
-                }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-                  fieldName: "newNameHere",
-                })};`
+                )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
+                  proc,
+                  {
+                    fieldName: "newNameHere",
+                  }
+                )}`
               );
             } catch (e) {
               swallowError(e);

--- a/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
@@ -36,6 +36,7 @@ export default (function PgComputedColumnsPlugin(
       pgMakeProcField: makeProcField,
       swallowError,
       describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const tableType = introspectionResultsByKind.type.filter(
       type =>
@@ -100,7 +101,15 @@ export default (function PgComputedColumnsPlugin(
                     forceList,
                   }),
                 },
-                `Adding computed column for ${describePgEntity(proc)}`
+                `Adding computed column for ${describePgEntity(
+                  proc
+                )}. You can rename this field with:\n\n  COMMENT ON FUNCTION "${
+                  proc.namespaceName
+                }"."${
+                  proc.name
+                }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+                  fieldName: "newNameHere",
+                })};`
               );
             } catch (e) {
               swallowError(e);

--- a/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
@@ -35,6 +35,7 @@ export default (function PgComputedColumnsPlugin(
       pgOmit: omit,
       pgMakeProcField: makeProcField,
       swallowError,
+      describePgEntity,
     } = build;
     const tableType = introspectionResultsByKind.type.filter(
       type =>
@@ -90,11 +91,17 @@ export default (function PgComputedColumnsPlugin(
               ? inflection.computedColumnList(pseudoColumnName, proc, table)
               : inflection.computedColumn(pseudoColumnName, proc, table);
             try {
-              memo[fieldName] = makeProcField(fieldName, proc, build, {
-                fieldWithHooks,
-                computed: true,
-                forceList,
-              });
+              memo = extend(
+                memo,
+                {
+                  [fieldName]: makeProcField(fieldName, proc, build, {
+                    fieldWithHooks,
+                    computed: true,
+                    forceList,
+                  }),
+                },
+                `Adding computed column for ${describePgEntity(proc)}`
+              );
             } catch (e) {
               swallowError(e);
             }

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -60,11 +60,12 @@ export default (function PgConnectionArgCondition(builder) {
           {
             __origin: `Adding condition type for ${describePgEntity(
               table
-            )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-              table.namespaceName
-            }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-              name: "newNameHere",
-            })};`,
+            )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+              table,
+              {
+                name: "newNameHere",
+              }
+            )}`,
             pgIntrospection: table,
             isPgCondition: true,
           }

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -33,19 +33,25 @@ export default (function PgConnectionArgCondition(builder) {
                 .filter(attr => !omit(attr, "filter"))
                 .reduce((memo, attr) => {
                   const fieldName = inflection.column(attr);
-                  memo[fieldName] = fieldWithHooks(
-                    fieldName,
+                  memo = build.extend(
+                    memo,
                     {
-                      description: `Checks for equality with the object’s \`${fieldName}\` field.`,
-                      type:
-                        pgGetGqlInputTypeByTypeIdAndModifier(
-                          attr.typeId,
-                          attr.typeModifier
-                        ) || GraphQLString,
+                      [fieldName]: fieldWithHooks(
+                        fieldName,
+                        {
+                          description: `Checks for equality with the object’s \`${fieldName}\` field.`,
+                          type:
+                            pgGetGqlInputTypeByTypeIdAndModifier(
+                              attr.typeId,
+                              attr.typeModifier
+                            ) || GraphQLString,
+                        },
+                        {
+                          isPgConnectionConditionInputField: true,
+                        }
+                      ),
                     },
-                    {
-                      isPgConnectionConditionInputField: true,
-                    }
+                    `Adding condition argument for ${describePgEntity(attr)}`
                   );
                   return memo;
                 }, {});

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -11,6 +11,8 @@ export default (function PgConnectionArgCondition(builder) {
       pgColumnFilter,
       inflection,
       pgOmit: omit,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     introspectionResultsByKind.class
       .filter(table => table.isSelectable && !omit(table, "filter"))
@@ -50,6 +52,13 @@ export default (function PgConnectionArgCondition(builder) {
             },
           },
           {
+            __origin: `Adding condition type for ${describePgEntity(
+              table
+            )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+              table.namespaceName
+            }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+              name: "newNameHere",
+            })};`,
             pgIntrospection: table,
             isPgCondition: true,
           }

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -36,11 +36,12 @@ export default (function PgConnectionArgOrderBy(builder) {
           {
             __origin: `Adding connection "orderBy" argument for ${describePgEntity(
               table
-            )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-              table.namespaceName
-            }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-              name: "newNameHere",
-            })};`,
+            )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+              table,
+              {
+                name: "newNameHere",
+              }
+            )}`,
             pgIntrospection: table,
             isPgRowSortEnum: true,
           }

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -10,6 +10,8 @@ export default (function PgConnectionArgOrderBy(builder) {
       graphql: { GraphQLEnumType },
       inflection,
       pgOmit: omit,
+      sqlCommentByAddingTags,
+      describePgEntity,
     } = build;
     introspectionResultsByKind.class
       .filter(table => table.isSelectable && !omit(table, "order"))
@@ -32,6 +34,13 @@ export default (function PgConnectionArgOrderBy(builder) {
             },
           },
           {
+            __origin: `Adding connection "orderBy" argument for ${describePgEntity(
+              table
+            )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+              table.namespaceName
+            }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+              name: "newNameHere",
+            })};`,
             pgIntrospection: table,
             isPgRowSortEnum: true,
           }

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -142,7 +142,7 @@ export default (function PgConnectionArgOrderBy(builder) {
             type: new GraphQLList(new GraphQLNonNull(TableOrderByType)),
           },
         },
-        `Adding 'orderBy' to field '${field.name}' of '${Self.name}'`
+        `Adding 'orderBy' argument to field '${field.name}' of '${Self.name}'`
       );
     }
   );

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -2,6 +2,7 @@ export interface PgNamespace {
   kind: "namespace";
   id: string;
   name: string;
+  comment: string | void;
   description: string | void;
   tags: { [tag: string]: string };
 }
@@ -9,6 +10,7 @@ export interface PgNamespace {
 export interface PgProc {
   kind: "procedure";
   name: string;
+  comment: string | void;
   description: string | void;
   namespaceId: string;
   isStrict: boolean;
@@ -27,6 +29,7 @@ export interface PgClass {
   kind: "class";
   id: string;
   name: string;
+  comment: string | void;
   description: string | void;
   classKind: string;
   namespaceId: string;
@@ -51,6 +54,7 @@ export interface PgType {
   kind: "type";
   id: string;
   name: string;
+  comment: string | void;
   description: string | void;
   namespaceId: string;
   namespaceName: string;
@@ -71,6 +75,7 @@ export interface PgAttribute {
   classId: string;
   num: number;
   name: string;
+  comment: string | void;
   description: string | void;
   typeId: string;
   typeModifier: number;
@@ -91,6 +96,7 @@ export interface PgConstraint {
   type: string;
   classId: string;
   foreignClassId: string | void;
+  comment: string | void;
   description: string | void;
   keyAttributeNums: Array<number>;
   foreignKeyAttributeNums: Array<number>;
@@ -106,6 +112,7 @@ export interface PgExtension {
   relocatable: boolean;
   version: string;
   configurationClassIds?: Array<string>;
+  comment: string | void;
   description: string | void;
   tags: { [tag: string]: string | Array<string> };
 }

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -13,6 +13,7 @@ export interface PgProc {
   comment: string | void;
   description: string | void;
   namespaceId: string;
+  namespaceName: string;
   isStrict: boolean;
   returnsSet: boolean;
   isStable: boolean;

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -95,6 +95,7 @@ export interface PgConstraint {
   name: string;
   type: string;
   classId: string;
+  class: PgClass | void;
   foreignClassId: string | void;
   comment: string | void;
   description: string | void;

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -115,6 +115,7 @@ export type PgConstraint = {
   name: string,
   type: string,
   classId: string,
+  class: ?PgClass,
   foreignClassId: ?string,
   comment: ?string,
   description: ?string,
@@ -378,6 +379,14 @@ export default (async function PgIntrospectionPlugin(
       "arrayItemTypeId",
       introspectionResultsByKind.typeById,
       true // Because not all types are arrays
+    );
+
+    relate(
+      introspectionResultsByKind.constraint,
+      "class",
+      "classId",
+      introspectionResultsByKind.classById,
+      true
     );
 
     relate(

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -33,6 +33,7 @@ export type PgProc = {
   comment: ?string,
   description: ?string,
   namespaceId: string,
+  namespaceName: string,
   isStrict: boolean,
   returnsSet: boolean,
   isStable: boolean,

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -22,6 +22,7 @@ export type PgNamespace = {
   kind: "namespace",
   id: string,
   name: string,
+  comment: ?string,
   description: ?string,
   tags: { [string]: string },
 };
@@ -29,6 +30,7 @@ export type PgNamespace = {
 export type PgProc = {
   kind: "procedure",
   name: string,
+  comment: ?string,
   description: ?string,
   namespaceId: string,
   isStrict: boolean,
@@ -47,6 +49,7 @@ export type PgClass = {
   kind: "class",
   id: string,
   name: string,
+  comment: ?string,
   description: ?string,
   classKind: string,
   namespaceId: string,
@@ -71,6 +74,7 @@ export type PgType = {
   kind: "type",
   id: string,
   name: string,
+  comment: ?string,
   description: ?string,
   namespaceId: string,
   namespaceName: string,
@@ -91,6 +95,7 @@ export type PgAttribute = {
   classId: string,
   num: number,
   name: string,
+  comment: ?string,
   description: ?string,
   typeId: string,
   typeModifier: number,
@@ -111,6 +116,7 @@ export type PgConstraint = {
   type: string,
   classId: string,
   foreignClassId: ?string,
+  comment: ?string,
   description: ?string,
   keyAttributeNums: Array<number>,
   foreignKeyAttributeNums: Array<number>,
@@ -126,6 +132,7 @@ export type PgExtension = {
   relocatable: boolean,
   version: string,
   configurationClassIds?: Array<string>,
+  comment: ?string,
   description: ?string,
   tags: { [string]: string },
 };
@@ -199,6 +206,8 @@ export default (async function PgIntrospectionPlugin(
             "extension",
           ].forEach(kind => {
             result[kind].forEach(object => {
+              // Keep a copy of the raw comment
+              object.comment = object.description;
               if (pgEnableTags && object.description) {
                 const parsed = parseTags(object.description);
                 object.tags = parsed.tags;

--- a/packages/graphile-build-pg/src/plugins/PgJWTPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgJWTPlugin.js
@@ -17,6 +17,7 @@ export default (function PgJWTPlugin(
       graphql: { GraphQLScalarType },
       inflection,
       pgParseIdentifier: parseIdentifier,
+      describePgEntity,
     } = build;
     if (!pgJwtTypeIdentifier) {
       return _;
@@ -100,6 +101,9 @@ export default (function PgJWTPlugin(
           },
         },
         {
+          __origin: `Adding JWT type based on ${describePgEntity(
+            compositeType
+          )}`,
           isPgJwtType: true,
         }
       );

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -142,97 +142,111 @@ export default (function PgMutationCreatePlugin(
             }
           );
           const fieldName = inflection.createField(table);
-          memo[fieldName] = fieldWithHooks(
-            fieldName,
-            context => {
-              const { getDataFromParsedResolveInfoFragment } = context;
-              return {
-                description: `Creates a single \`${tableTypeName}\`.`,
-                type: PayloadType,
-                args: {
-                  input: {
-                    type: new GraphQLNonNull(InputType),
-                  },
-                },
-                async resolve(data, { input }, { pgClient }, resolveInfo) {
-                  const parsedResolveInfoFragment = parseResolveInfo(
-                    resolveInfo
-                  );
-                  const resolveData = getDataFromParsedResolveInfoFragment(
-                    parsedResolveInfoFragment,
-                    PayloadType
-                  );
-                  const insertedRowAlias = sql.identifier(Symbol());
-                  const query = queryFromResolveData(
-                    insertedRowAlias,
-                    insertedRowAlias,
-                    resolveData,
-                    {}
-                  );
-                  const sqlColumns = [];
-                  const sqlValues = [];
-                  const inputData = input[inflection.tableFieldName(table)];
-                  pgIntrospectionResultsByKind.attribute
-                    .filter(attr => attr.classId === table.id)
-                    .filter(attr => pgColumnFilter(attr, build, context))
-                    .filter(attr => !omit(attr, "create"))
-                    .forEach(attr => {
-                      const fieldName = inflection.column(attr);
-                      const val = inputData[fieldName];
-                      if (
-                        Object.prototype.hasOwnProperty.call(
-                          inputData,
-                          fieldName
-                        )
-                      ) {
-                        sqlColumns.push(sql.identifier(attr.name));
-                        sqlValues.push(
-                          gql2pg(val, attr.type, attr.typeModifier)
-                        );
-                      }
-                    });
+          memo = build.extend(
+            memo,
+            {
+              [fieldName]: fieldWithHooks(
+                fieldName,
+                context => {
+                  const { getDataFromParsedResolveInfoFragment } = context;
+                  return {
+                    description: `Creates a single \`${tableTypeName}\`.`,
+                    type: PayloadType,
+                    args: {
+                      input: {
+                        type: new GraphQLNonNull(InputType),
+                      },
+                    },
+                    async resolve(data, { input }, { pgClient }, resolveInfo) {
+                      const parsedResolveInfoFragment = parseResolveInfo(
+                        resolveInfo
+                      );
+                      const resolveData = getDataFromParsedResolveInfoFragment(
+                        parsedResolveInfoFragment,
+                        PayloadType
+                      );
+                      const insertedRowAlias = sql.identifier(Symbol());
+                      const query = queryFromResolveData(
+                        insertedRowAlias,
+                        insertedRowAlias,
+                        resolveData,
+                        {}
+                      );
+                      const sqlColumns = [];
+                      const sqlValues = [];
+                      const inputData = input[inflection.tableFieldName(table)];
+                      pgIntrospectionResultsByKind.attribute
+                        .filter(attr => attr.classId === table.id)
+                        .filter(attr => pgColumnFilter(attr, build, context))
+                        .filter(attr => !omit(attr, "create"))
+                        .forEach(attr => {
+                          const fieldName = inflection.column(attr);
+                          const val = inputData[fieldName];
+                          if (
+                            Object.prototype.hasOwnProperty.call(
+                              inputData,
+                              fieldName
+                            )
+                          ) {
+                            sqlColumns.push(sql.identifier(attr.name));
+                            sqlValues.push(
+                              gql2pg(val, attr.type, attr.typeModifier)
+                            );
+                          }
+                        });
 
-                  const mutationQuery = sql.query`
+                      const mutationQuery = sql.query`
                     insert into ${sql.identifier(
                       table.namespace.name,
                       table.name
                     )} ${
-                    sqlColumns.length
-                      ? sql.fragment`(
+                        sqlColumns.length
+                          ? sql.fragment`(
                         ${sql.join(sqlColumns, ", ")}
                       ) values(${sql.join(sqlValues, ", ")})`
-                      : sql.fragment`default values`
-                  } returning *`;
+                          : sql.fragment`default values`
+                      } returning *`;
 
-                  let row;
-                  try {
-                    await pgClient.query("SAVEPOINT graphql_mutation");
-                    const rows = await viaTemporaryTable(
-                      pgClient,
-                      sql.identifier(table.namespace.name, table.name),
-                      mutationQuery,
-                      insertedRowAlias,
-                      query
-                    );
-                    row = rows[0];
-                    await pgClient.query("RELEASE SAVEPOINT graphql_mutation");
-                  } catch (e) {
-                    await pgClient.query(
-                      "ROLLBACK TO SAVEPOINT graphql_mutation"
-                    );
-                    throw e;
-                  }
-                  return {
-                    clientMutationId: input.clientMutationId,
-                    data: row,
+                      let row;
+                      try {
+                        await pgClient.query("SAVEPOINT graphql_mutation");
+                        const rows = await viaTemporaryTable(
+                          pgClient,
+                          sql.identifier(table.namespace.name, table.name),
+                          mutationQuery,
+                          insertedRowAlias,
+                          query
+                        );
+                        row = rows[0];
+                        await pgClient.query(
+                          "RELEASE SAVEPOINT graphql_mutation"
+                        );
+                      } catch (e) {
+                        await pgClient.query(
+                          "ROLLBACK TO SAVEPOINT graphql_mutation"
+                        );
+                        throw e;
+                      }
+                      return {
+                        clientMutationId: input.clientMutationId,
+                        data: row,
+                      };
+                    },
                   };
                 },
-              };
+                {
+                  pgFieldIntrospection: table,
+                  isPgCreateMutationField: true,
+                }
+              ),
             },
-            {
-              pgFieldIntrospection: table,
-              isPgCreateMutationField: true,
-            }
+            `Adding create mutation for ${describePgEntity(
+              table
+            )}. You can omit this default mutation with:\n\n  COMMENT ON TABLE "${
+              table.namespaceName
+            }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+              omit: "create",
+            })};`
           );
           return memo;
         }, {}),

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -95,11 +95,12 @@ export default (function PgMutationCreatePlugin(
             {
               __origin: `Adding table create input type for ${describePgEntity(
                 table
-              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                table.namespaceName
-              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                table,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               isPgCreateInputType: true,
               pgInflection: table,
             }
@@ -131,11 +132,12 @@ export default (function PgMutationCreatePlugin(
             {
               __origin: `Adding table create payload type for ${describePgEntity(
                 table
-              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                table.namespaceName
-              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                table,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               isMutationPayload: true,
               isPgCreatePayloadType: true,
               pgIntrospection: table,
@@ -242,11 +244,12 @@ export default (function PgMutationCreatePlugin(
             },
             `Adding create mutation for ${describePgEntity(
               table
-            )}. You can omit this default mutation with:\n\n  COMMENT ON TABLE "${
-              table.namespaceName
-            }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-              omit: "create",
-            })};`
+            )}. You can omit this default mutation with:\n\n  ${sqlCommentByAddingTags(
+              table,
+              {
+                omit: "create",
+              }
+            )}`
           );
           return memo;
         }, {}),

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -32,6 +32,8 @@ export default (function PgMutationCreatePlugin(
       pgQueryFromResolveData: queryFromResolveData,
       pgOmit: omit,
       pgViaTemporaryTable: viaTemporaryTable,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isRootMutation },
@@ -91,6 +93,13 @@ export default (function PgMutationCreatePlugin(
               },
             },
             {
+              __origin: `Adding table create input type for ${describePgEntity(
+                table
+              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                table.namespaceName
+              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                name: "newNameHere",
+              })};`,
               isPgCreateInputType: true,
               pgInflection: table,
             }
@@ -120,6 +129,13 @@ export default (function PgMutationCreatePlugin(
               },
             },
             {
+              __origin: `Adding table create payload type for ${describePgEntity(
+                table
+              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                table.namespaceName
+              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                name: "newNameHere",
+              })};`,
               isMutationPayload: true,
               isPgCreatePayloadType: true,
               pgIntrospection: table,

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -13,6 +13,7 @@ export default (function PgMutationPayloadEdgePlugin(builder) {
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       inflection,
       pgOmit: omit,
+      describePgEntity,
     } = build;
     const {
       scope: { isMutationPayload, pgIntrospection, pgIntrospectionTable },
@@ -177,7 +178,9 @@ export default (function PgMutationPayloadEdgePlugin(builder) {
           }
         ),
       },
-      `Adding edge field to mutation payload '${Self.name}'`
+      `Adding edge field for table ${describePgEntity(
+        table
+      )} to mutation payload '${Self.name}'`
     );
   });
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/PgMutationProceduresPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationProceduresPlugin.js
@@ -54,13 +54,12 @@ export default (function PgMutationProceduresPlugin(builder) {
               },
               `Adding mutation field for ${describePgEntity(
                 proc
-              )}. You can rename this field with:\n\n  COMMENT ON FUNCTION "${
-                proc.namespaceName
-              }"."${
-                proc.name
-              }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-                name: "newNameHere",
-              })};`
+              )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
+                proc,
+                {
+                  name: "newNameHere",
+                }
+              )}`
             );
           } catch (e) {
             swallowError(e);

--- a/packages/graphile-build-pg/src/plugins/PgMutationProceduresPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationProceduresPlugin.js
@@ -10,6 +10,8 @@ export default (function PgMutationProceduresPlugin(builder) {
       pgMakeProcField: makeProcField,
       pgOmit: omit,
       swallowError,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isRootMutation },
@@ -42,10 +44,24 @@ export default (function PgMutationProceduresPlugin(builder) {
 
           const fieldName = inflection.functionMutationName(proc);
           try {
-            memo[fieldName] = makeProcField(fieldName, proc, build, {
-              fieldWithHooks,
-              isMutation: true,
-            });
+            memo = extend(
+              memo,
+              {
+                [fieldName]: makeProcField(fieldName, proc, build, {
+                  fieldWithHooks,
+                  isMutation: true,
+                }),
+              },
+              `Adding mutation field for ${describePgEntity(
+                proc
+              )}. You can rename this field with:\n\n  COMMENT ON FUNCTION "${
+                proc.namespaceName
+              }"."${
+                proc.name
+              }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+                name: "newNameHere",
+              })};`
+            );
           } catch (e) {
             swallowError(e);
           }

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -270,11 +270,12 @@ export default (async function PgMutationUpdateDeletePlugin(
                   {
                     __origin: `Adding table ${mode} mutation payload type for ${describePgEntity(
                       table
-                    )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                      table.namespaceName
-                    }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                      name: "newNameHere",
-                    })};`,
+                    )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                      table,
+                      {
+                        name: "newNameHere",
+                      }
+                    )}`,
                     isMutationPayload: true,
                     isPgUpdatePayloadType: mode === "update",
                     isPgDeletePayloadType: mode === "delete",
@@ -331,11 +332,12 @@ export default (async function PgMutationUpdateDeletePlugin(
                     {
                       __origin: `Adding table ${mode} (by node ID) mutation input type for ${describePgEntity(
                         table
-                      )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                        table.namespaceName
-                      }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                        name: "newNameHere",
-                      })};`,
+                      )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                        table,
+                        {
+                          name: "newNameHere",
+                        }
+                      )}`,
                       isPgUpdateInputType: mode === "update",
                       isPgUpdateNodeInputType: mode === "update",
                       isPgDeleteInputType: mode === "delete",
@@ -486,11 +488,12 @@ export default (async function PgMutationUpdateDeletePlugin(
                     {
                       __origin: `Adding table ${mode} mutation input type for ${describePgEntity(
                         constraint
-                      )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                        table.namespaceName
-                      }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                        name: "newNameHere",
-                      })};`,
+                      )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                        table,
+                        {
+                          name: "newNameHere",
+                        }
+                      )}`,
                       isPgUpdateInputType: mode === "update",
                       isPgUpdateByKeysInputType: mode === "update",
                       isPgDeleteInputType: mode === "delete",

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -39,6 +39,8 @@ export default (async function PgMutationUpdateDeletePlugin(
       pgQueryFromResolveData: queryFromResolveData,
       pgOmit: omit,
       pgViaTemporaryTable: viaTemporaryTable,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isRootMutation },
@@ -266,6 +268,13 @@ export default (async function PgMutationUpdateDeletePlugin(
                     },
                   },
                   {
+                    __origin: `Adding table ${mode} mutation payload type for ${describePgEntity(
+                      table
+                    )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                      table.namespaceName
+                    }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                      name: "newNameHere",
+                    })};`,
                     isMutationPayload: true,
                     isPgUpdatePayloadType: mode === "update",
                     isPgDeletePayloadType: mode === "delete",
@@ -320,6 +329,13 @@ export default (async function PgMutationUpdateDeletePlugin(
                       ),
                     },
                     {
+                      __origin: `Adding table ${mode} (by node ID) mutation input type for ${describePgEntity(
+                        table
+                      )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                        table.namespaceName
+                      }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                        name: "newNameHere",
+                      })};`,
                       isPgUpdateInputType: mode === "update",
                       isPgUpdateNodeInputType: mode === "update",
                       isPgDeleteInputType: mode === "delete",
@@ -460,6 +476,13 @@ export default (async function PgMutationUpdateDeletePlugin(
                       ),
                     },
                     {
+                      __origin: `Adding table ${mode} mutation input type for ${describePgEntity(
+                        constraint
+                      )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                        table.namespaceName
+                      }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                        name: "newNameHere",
+                      })};`,
                       isPgUpdateInputType: mode === "update",
                       isPgUpdateByKeysInputType: mode === "update",
                       isPgDeleteInputType: mode === "delete",

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -345,75 +345,83 @@ export default (async function PgMutationUpdateDeletePlugin(
                     }
                   );
 
-                  memo[fieldName] = fieldWithHooks(
-                    fieldName,
-                    context => {
-                      const { getDataFromParsedResolveInfoFragment } = context;
-                      return {
-                        description:
-                          mode === "update"
-                            ? `Updates a single \`${tableTypeName}\` using its globally unique id and a patch.`
-                            : `Deletes a single \`${tableTypeName}\` using its globally unique id.`,
-                        type: PayloadType,
-                        args: {
-                          input: {
-                            type: new GraphQLNonNull(InputType),
-                          },
-                        },
-                        async resolve(
-                          parent,
-                          { input },
-                          { pgClient },
-                          resolveInfo
-                        ) {
-                          const nodeId = input[nodeIdFieldName];
-                          try {
-                            const [alias, ...identifiers] = JSON.parse(
-                              base64Decode(nodeId)
-                            );
-                            const NodeTypeByAlias = getNodeType(alias);
-                            if (NodeTypeByAlias !== TableType) {
-                              throw new Error("Mismatched type");
-                            }
-                            if (identifiers.length !== primaryKeys.length) {
-                              throw new Error("Invalid ID");
-                            }
-
-                            return commonCodeRenameMe(
-                              pgClient,
-                              resolveInfo,
-                              getDataFromParsedResolveInfoFragment,
-                              PayloadType,
-                              input,
-                              sql.fragment`(${sql.join(
-                                primaryKeys.map(
-                                  (key, idx) =>
-                                    sql.fragment`${sql.identifier(
-                                      key.name
-                                    )} = ${gql2pg(
-                                      identifiers[idx],
-                                      key.type,
-                                      key.typeModifier
-                                    )}`
-                                ),
-                                ") and ("
-                              )})`,
-                              context
-                            );
-                          } catch (e) {
-                            debug(e);
-                            return null;
-                          }
-                        },
-                      };
-                    },
+                  memo = extend(
+                    memo,
                     {
-                      isPgNodeMutation: true,
-                      pgFieldIntrospection: table,
-                      [mode === "update"
-                        ? "isPgUpdateMutationField"
-                        : "isPgDeleteMutationField"]: true,
-                    }
+                      [fieldName]: fieldWithHooks(
+                        fieldName,
+                        context => {
+                          const {
+                            getDataFromParsedResolveInfoFragment,
+                          } = context;
+                          return {
+                            description:
+                              mode === "update"
+                                ? `Updates a single \`${tableTypeName}\` using its globally unique id and a patch.`
+                                : `Deletes a single \`${tableTypeName}\` using its globally unique id.`,
+                            type: PayloadType,
+                            args: {
+                              input: {
+                                type: new GraphQLNonNull(InputType),
+                              },
+                            },
+                            async resolve(
+                              parent,
+                              { input },
+                              { pgClient },
+                              resolveInfo
+                            ) {
+                              const nodeId = input[nodeIdFieldName];
+                              try {
+                                const [alias, ...identifiers] = JSON.parse(
+                                  base64Decode(nodeId)
+                                );
+                                const NodeTypeByAlias = getNodeType(alias);
+                                if (NodeTypeByAlias !== TableType) {
+                                  throw new Error("Mismatched type");
+                                }
+                                if (identifiers.length !== primaryKeys.length) {
+                                  throw new Error("Invalid ID");
+                                }
+
+                                return commonCodeRenameMe(
+                                  pgClient,
+                                  resolveInfo,
+                                  getDataFromParsedResolveInfoFragment,
+                                  PayloadType,
+                                  input,
+                                  sql.fragment`(${sql.join(
+                                    primaryKeys.map(
+                                      (key, idx) =>
+                                        sql.fragment`${sql.identifier(
+                                          key.name
+                                        )} = ${gql2pg(
+                                          identifiers[idx],
+                                          key.type,
+                                          key.typeModifier
+                                        )}`
+                                    ),
+                                    ") and ("
+                                  )})`,
+                                  context
+                                );
+                              } catch (e) {
+                                debug(e);
+                                return null;
+                              }
+                            },
+                          };
+                        },
+                        {
+                          isPgNodeMutation: true,
+                          pgFieldIntrospection: table,
+                          [mode === "update"
+                            ? "isPgUpdateMutationField"
+                            : "isPgDeleteMutationField"]: true,
+                        }
+                      ),
+                    },
+                    "Adding ${mode} mutation for ${describePgEntity(table)}"
                   );
                 }
 
@@ -493,58 +501,68 @@ export default (async function PgMutationUpdateDeletePlugin(
                     }
                   );
 
-                  memo[fieldName] = fieldWithHooks(
-                    fieldName,
-                    context => {
-                      const { getDataFromParsedResolveInfoFragment } = context;
-                      return {
-                        description:
-                          mode === "update"
-                            ? `Updates a single \`${tableTypeName}\` using a unique key and a patch.`
-                            : `Deletes a single \`${tableTypeName}\` using a unique key.`,
-                        type: PayloadType,
-                        args: {
-                          input: {
-                            type: new GraphQLNonNull(InputType),
-                          },
-                        },
-                        async resolve(
-                          parent,
-                          { input },
-                          { pgClient },
-                          resolveInfo
-                        ) {
-                          return commonCodeRenameMe(
-                            pgClient,
-                            resolveInfo,
-                            getDataFromParsedResolveInfoFragment,
-                            PayloadType,
-                            input,
-                            sql.fragment`(${sql.join(
-                              keys.map(
-                                key =>
-                                  sql.fragment`${sql.identifier(
-                                    key.name
-                                  )} = ${gql2pg(
-                                    input[inflection.column(key)],
-                                    key.type,
-                                    key.typeModifier
-                                  )}`
-                              ),
-                              ") and ("
-                            )})`,
-                            context
-                          );
-                        },
-                      };
-                    },
+                  memo = extend(
+                    memo,
                     {
-                      isPgNodeMutation: false,
-                      pgFieldIntrospection: table,
-                      [mode === "update"
-                        ? "isPgUpdateMutationField"
-                        : "isPgDeleteMutationField"]: true,
-                    }
+                      [fieldName]: fieldWithHooks(
+                        fieldName,
+                        context => {
+                          const {
+                            getDataFromParsedResolveInfoFragment,
+                          } = context;
+                          return {
+                            description:
+                              mode === "update"
+                                ? `Updates a single \`${tableTypeName}\` using a unique key and a patch.`
+                                : `Deletes a single \`${tableTypeName}\` using a unique key.`,
+                            type: PayloadType,
+                            args: {
+                              input: {
+                                type: new GraphQLNonNull(InputType),
+                              },
+                            },
+                            async resolve(
+                              parent,
+                              { input },
+                              { pgClient },
+                              resolveInfo
+                            ) {
+                              return commonCodeRenameMe(
+                                pgClient,
+                                resolveInfo,
+                                getDataFromParsedResolveInfoFragment,
+                                PayloadType,
+                                input,
+                                sql.fragment`(${sql.join(
+                                  keys.map(
+                                    key =>
+                                      sql.fragment`${sql.identifier(
+                                        key.name
+                                      )} = ${gql2pg(
+                                        input[inflection.column(key)],
+                                        key.type,
+                                        key.typeModifier
+                                      )}`
+                                  ),
+                                  ") and ("
+                                )})`,
+                                context
+                              );
+                            },
+                          };
+                        },
+                        {
+                          isPgNodeMutation: false,
+                          pgFieldIntrospection: table,
+                          [mode === "update"
+                            ? "isPgUpdateMutationField"
+                            : "isPgDeleteMutationField"]: true,
+                        }
+                      ),
+                    },
+                    `Adding ${mode} mutation for ${describePgEntity(
+                      constraint
+                    )}`
                   );
                 });
               }

--- a/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
@@ -10,6 +10,7 @@ export default (function PgOrderAllColumnsPlugin(builder) {
       inflection,
       pgOmit: omit,
       describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isPgRowSortEnum, pgIntrospection: table },
@@ -38,7 +39,16 @@ export default (function PgOrderAllColumnsPlugin(builder) {
                 },
               },
             },
-            `Adding ascending orderBy enum value for ${describePgEntity(attr)}`
+            `Adding ascending orderBy enum value for ${describePgEntity(
+              attr
+            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
+              attr.class.namespaceName
+            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+              attr,
+              {
+                name: "newNameHere",
+              }
+            )};`
           );
           memo = extend(
             memo,
@@ -50,7 +60,16 @@ export default (function PgOrderAllColumnsPlugin(builder) {
                 },
               },
             },
-            `Adding descending orderBy enum value for ${describePgEntity(attr)}`
+            `Adding descending orderBy enum value for ${describePgEntity(
+              attr
+            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
+              attr.class.namespaceName
+            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+              attr,
+              {
+                name: "newNameHere",
+              }
+            )};`
           );
           return memo;
         }, {}),

--- a/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
@@ -9,6 +9,7 @@ export default (function PgOrderAllColumnsPlugin(builder) {
       pgColumnFilter,
       inflection,
       pgOmit: omit,
+      describePgEntity,
     } = build;
     const {
       scope: { isPgRowSortEnum, pgIntrospection: table },
@@ -27,18 +28,30 @@ export default (function PgOrderAllColumnsPlugin(builder) {
           }
           const ascFieldName = inflection.orderByColumnEnum(attr, true);
           const descFieldName = inflection.orderByColumnEnum(attr, false);
-          memo[ascFieldName] = {
-            value: {
-              alias: ascFieldName.toLowerCase(),
-              specs: [[attr.name, true]],
+          memo = extend(
+            memo,
+            {
+              [ascFieldName]: {
+                value: {
+                  alias: ascFieldName.toLowerCase(),
+                  specs: [[attr.name, true]],
+                },
+              },
             },
-          };
-          memo[descFieldName] = {
-            value: {
-              alias: descFieldName.toLowerCase(),
-              specs: [[attr.name, false]],
+            `Adding ascending orderBy enum value for ${describePgEntity(attr)}`
+          );
+          memo = extend(
+            memo,
+            {
+              [descFieldName]: {
+                value: {
+                  alias: descFieldName.toLowerCase(),
+                  specs: [[attr.name, false]],
+                },
+              },
             },
-          };
+            `Adding descending orderBy enum value for ${describePgEntity(attr)}`
+          );
           return memo;
         }, {}),
       `Adding order values from table '${table.name}'`

--- a/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgOrderAllColumnsPlugin.js
@@ -41,14 +41,12 @@ export default (function PgOrderAllColumnsPlugin(builder) {
             },
             `Adding ascending orderBy enum value for ${describePgEntity(
               attr
-            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
-              attr.class.namespaceName
-            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+            )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
               attr,
               {
                 name: "newNameHere",
               }
-            )};`
+            )}`
           );
           memo = extend(
             memo,
@@ -62,14 +60,12 @@ export default (function PgOrderAllColumnsPlugin(builder) {
             },
             `Adding descending orderBy enum value for ${describePgEntity(
               attr
-            )}. You can rename this field with:\n\n  COMMENT ON COLUMN "${
-              attr.class.namespaceName
-            }"."${attr.class.name}"."${attr.name}" IS ${sqlCommentByAddingTags(
+            )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
               attr,
               {
                 name: "newNameHere",
               }
-            )};`
+            )}`
           );
           return memo;
         }, {}),

--- a/packages/graphile-build-pg/src/plugins/PgQueryProceduresPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgQueryProceduresPlugin.js
@@ -19,6 +19,8 @@ export default (function PgQueryProceduresPlugin(
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       pgMakeProcField: makeProcField,
       pgOmit: omit,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const {
       scope: { isRootQuery },
@@ -76,10 +78,24 @@ export default (function PgQueryProceduresPlugin(
               ? inflection.functionQueryNameList(proc)
               : inflection.functionQueryName(proc);
             try {
-              memo[fieldName] = makeProcField(fieldName, proc, build, {
-                fieldWithHooks,
-                forceList,
-              });
+              memo = extend(
+                memo,
+                {
+                  [fieldName]: makeProcField(fieldName, proc, build, {
+                    fieldWithHooks,
+                    forceList,
+                  }),
+                },
+                `Adding query field for ${describePgEntity(
+                  proc
+                )}. You can rename this field with:\n\n  COMMENT ON FUNCTION "${
+                  proc.namespaceName
+                }"."${
+                  proc.name
+                }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+                  name: "newNameHere",
+                })};`
+              );
             } catch (e) {
               // eslint-disable-next-line no-console
               console.warn(

--- a/packages/graphile-build-pg/src/plugins/PgQueryProceduresPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgQueryProceduresPlugin.js
@@ -88,13 +88,12 @@ export default (function PgQueryProceduresPlugin(
                 },
                 `Adding query field for ${describePgEntity(
                   proc
-                )}. You can rename this field with:\n\n  COMMENT ON FUNCTION "${
-                  proc.namespaceName
-                }"."${
-                  proc.name
-                }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-                  name: "newNameHere",
-                })};`
+                )}. You can rename this field with:\n\n  ${sqlCommentByAddingTags(
+                  proc,
+                  {
+                    name: "newNameHere",
+                  }
+                )}`
               );
             } catch (e) {
               // eslint-disable-next-line no-console

--- a/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
@@ -84,13 +84,12 @@ export default (function PgScalarFunctionConnectionPlugin(
           {
             __origin: `Adding function result edge type for ${describePgEntity(
               proc
-            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
-              proc.namespaceName
-            }"."${
-              proc.name
-            }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-              name: "newNameHere",
-            })};`,
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  ${sqlCommentByAddingTags(
+              proc,
+              {
+                name: "newNameHere",
+              }
+            )}`,
             isEdgeType: true,
             nodeType: NodeType,
             pgIntrospection: proc,
@@ -136,13 +135,12 @@ export default (function PgScalarFunctionConnectionPlugin(
           {
             __origin: `Adding function connection type for ${describePgEntity(
               proc
-            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
-              proc.namespaceName
-            }"."${
-              proc.name
-            }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-              name: "newNameHere",
-            })};`,
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  ${sqlCommentByAddingTags(
+              proc,
+              {
+                name: "newNameHere",
+              }
+            )}`,
             isConnectionType: true,
             edgeType: EdgeType,
             nodeType: NodeType,

--- a/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
@@ -20,6 +20,8 @@ export default (function PgScalarFunctionConnectionPlugin(
       },
       inflection,
       pgOmit: omit,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const nullableIf = (condition, Type) =>
       condition ? Type : new GraphQLNonNull(Type);
@@ -80,6 +82,15 @@ export default (function PgScalarFunctionConnectionPlugin(
             },
           },
           {
+            __origin: `Adding function result edge type for ${describePgEntity(
+              proc
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
+              proc.namespaceName
+            }"."${
+              proc.name
+            }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+              name: "newNameHere",
+            })};`,
             isEdgeType: true,
             nodeType: NodeType,
             pgIntrospection: proc,

--- a/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
@@ -134,6 +134,15 @@ export default (function PgScalarFunctionConnectionPlugin(
             },
           },
           {
+            __origin: `Adding function connection type for ${describePgEntity(
+              proc
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
+              proc.namespaceName
+            }"."${
+              proc.name
+            }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+              name: "newNameHere",
+            })};`,
             isConnectionType: true,
             edgeType: EdgeType,
             nodeType: NodeType,

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -181,11 +181,12 @@ export default (function PgTablesPlugin(
             {
               __origin: `Adding table type for ${describePgEntity(
                 table
-              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                table.namespaceName
-              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                table,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               pgIntrospection: table,
               isPgRowType: table.isSelectable,
               isPgCompoundType: !table.isSelectable,
@@ -204,11 +205,12 @@ export default (function PgTablesPlugin(
             {
               __origin: `Adding table input type for ${describePgEntity(
                 table
-              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                table.namespaceName
-              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                table,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               pgIntrospection: table,
               isInputType: true,
               isPgRowType: table.isSelectable,
@@ -240,11 +242,12 @@ export default (function PgTablesPlugin(
               {
                 __origin: `Adding table patch type for ${describePgEntity(
                   table
-                )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                  table.namespaceName
-                }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                  name: "newNameHere",
-                })};`,
+                )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                  table,
+                  {
+                    name: "newNameHere",
+                  }
+                )}`,
                 pgIntrospection: table,
                 isPgRowType: table.isSelectable,
                 isPgCompoundType: !table.isSelectable,
@@ -269,11 +272,12 @@ export default (function PgTablesPlugin(
               {
                 __origin: `Adding table base input type for ${describePgEntity(
                   table
-                )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                  table.namespaceName
-                }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                  name: "newNameHere",
-                })};`,
+                )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                  table,
+                  {
+                    name: "newNameHere",
+                  }
+                )}`,
                 pgIntrospection: table,
                 isPgRowType: table.isSelectable,
                 isPgCompoundType: !table.isSelectable,
@@ -374,11 +378,12 @@ export default (function PgTablesPlugin(
             {
               __origin: `Adding table edge type for ${describePgEntity(
                 table
-              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                table.namespaceName
-              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                table,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               isEdgeType: true,
               isPgRowEdgeType: true,
               nodeType: TableType,
@@ -433,11 +438,12 @@ export default (function PgTablesPlugin(
             {
               __origin: `Adding table connection type for ${describePgEntity(
                 table
-              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
-                table.namespaceName
-              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the table's GraphQL type via:\n\n  ${sqlCommentByAddingTags(
+                table,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               isConnectionType: true,
               isPgRowConnectionType: true,
               edgeType: EdgeType,

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -55,6 +55,8 @@ export default (function PgTablesPlugin(
         GraphQLInputObjectType,
       },
       inflection,
+      describePgEntity,
+      sqlCommentByAddingTags,
     } = build;
     const nullableIf = (condition, Type) =>
       condition ? Type : new GraphQLNonNull(Type);
@@ -177,6 +179,13 @@ export default (function PgTablesPlugin(
               },
             },
             {
+              __origin: `Adding table type for ${describePgEntity(
+                table
+              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                table.namespaceName
+              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                name: "newNameHere",
+              })};`,
               pgIntrospection: table,
               isPgRowType: table.isSelectable,
               isPgCompoundType: !table.isSelectable,
@@ -193,6 +202,13 @@ export default (function PgTablesPlugin(
               name: inflection.inputType(TableType),
             },
             {
+              __origin: `Adding table input type for ${describePgEntity(
+                table
+              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                table.namespaceName
+              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                name: "newNameHere",
+              })};`,
               pgIntrospection: table,
               isInputType: true,
               isPgRowType: table.isSelectable,
@@ -222,6 +238,13 @@ export default (function PgTablesPlugin(
                 name: inflection.patchType(TableType),
               },
               {
+                __origin: `Adding table patch type for ${describePgEntity(
+                  table
+                )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                  table.namespaceName
+                }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                  name: "newNameHere",
+                })};`,
                 pgIntrospection: table,
                 isPgRowType: table.isSelectable,
                 isPgCompoundType: !table.isSelectable,
@@ -244,6 +267,13 @@ export default (function PgTablesPlugin(
                 name: inflection.baseInputType(TableType),
               },
               {
+                __origin: `Adding table base input type for ${describePgEntity(
+                  table
+                )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                  table.namespaceName
+                }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                  name: "newNameHere",
+                })};`,
                 pgIntrospection: table,
                 isPgRowType: table.isSelectable,
                 isPgCompoundType: !table.isSelectable,
@@ -342,6 +372,13 @@ export default (function PgTablesPlugin(
               },
             },
             {
+              __origin: `Adding table edge type for ${describePgEntity(
+                table
+              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                table.namespaceName
+              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                name: "newNameHere",
+              })};`,
               isEdgeType: true,
               isPgRowEdgeType: true,
               nodeType: TableType,
@@ -394,6 +431,13 @@ export default (function PgTablesPlugin(
               },
             },
             {
+              __origin: `Adding table connection type for ${describePgEntity(
+                table
+              )}. You can rename the table's GraphQL type via:\n\n  COMMENT ON TABLE "${
+                table.namespaceName
+              }"."${table.name}" IS ${sqlCommentByAddingTags(table, {
+                name: "newNameHere",
+              })};`,
               isConnectionType: true,
               isPgRowConnectionType: true,
               edgeType: EdgeType,

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -217,7 +217,7 @@ export default (function PgTypesPlugin(
         "An interval of time that has passed where the smallest distinct unit is a second.",
       fields: makeIntervalFields(),
     });
-    addType(GQLInterval);
+    addType(GQLInterval, "graphile-build-pg built-in");
 
     const GQLIntervalInput = new GraphQLInputObjectType({
       name: "IntervalInput",
@@ -225,7 +225,7 @@ export default (function PgTypesPlugin(
         "An interval of time that has passed where the smallest distinct unit is a second.",
       fields: makeIntervalFields(),
     });
-    addType(GQLIntervalInput);
+    addType(GQLIntervalInput, "graphile-build-pg built-in");
 
     const stringType = (name, description) =>
       new GraphQLScalarType({
@@ -249,8 +249,8 @@ export default (function PgTypesPlugin(
       "BitString",
       "A string representing a series of binary bits"
     );
-    addType(BigFloat);
-    addType(BitString);
+    addType(BigFloat, "graphile-build-pg built-in");
+    addType(BitString, "graphile-build-pg built-in");
 
     const rawTypes = [
       1186, // interval
@@ -407,11 +407,11 @@ export default (function PgTypesPlugin(
     });
 
     // Other plugins might want to use JSON
-    addType(JSONType);
-    addType(UUIDType);
-    addType(DateType);
-    addType(DateTimeType);
-    addType(TimeType);
+    addType(JSONType, "graphile-build-pg built-in");
+    addType(UUIDType, "graphile-build-pg built-in");
+    addType(DateType, "graphile-build-pg built-in");
+    addType(DateTimeType, "graphile-build-pg built-in");
+    addType(TimeType, "graphile-build-pg built-in");
 
     const oidLookup = {
       "20": stringType(
@@ -652,8 +652,8 @@ export default (function PgTypesPlugin(
               },
             },
           });
-          addType(Range);
-          addType(RangeInput);
+          addType(Range, "graphile-build-pg built-in");
+          addType(RangeInput, "graphile-build-pg built-in");
         } else {
           RangeInput = getTypeByName(inflection.inputType(Range.name));
         }

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -78,11 +78,11 @@ export default (function PgTypesPlugin(
     const {
       pgIntrospectionResultsByKind: introspectionResultsByKind,
       getTypeByName,
-      addType,
       pgSql: sql,
       inflection,
       graphql,
     } = build;
+    const addType = build.addType.bind(build);
     const {
       GraphQLNonNull,
       GraphQLString,

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -419,6 +419,7 @@ export default function makeProcField(
             },
           },
           Object.assign(
+            {},
             {
               __origin: `Adding mutation function payload type for ${describePgEntity(
                 proc

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -422,13 +422,12 @@ export default function makeProcField(
             {
               __origin: `Adding mutation function payload type for ${describePgEntity(
                 proc
-              )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
-                proc.namespaceName
-              }"."${
-                proc.name
-              }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-                name: "newNameHere",
-              })};`,
+              )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  ${sqlCommentByAddingTags(
+                proc,
+                {
+                  name: "newNameHere",
+                }
+              )}`,
               isMutationPayload: true,
             },
             payloadTypeScope
@@ -454,13 +453,12 @@ export default function makeProcField(
           {
             __origin: `Adding mutation function input type for ${describePgEntity(
               proc
-            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
-              proc.namespaceName
-            }"."${
-              proc.name
-            }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
-              name: "newNameHere",
-            })};`,
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  ${sqlCommentByAddingTags(
+              proc,
+              {
+                name: "newNameHere",
+              }
+            )}`,
             isMutationInput: true,
           }
         );

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -49,6 +49,8 @@ export default function makeProcField(
     pgQueryFromResolveData: queryFromResolveData,
     pgAddStartEndCursor: addStartEndCursor,
     pgViaTemporaryTable: viaTemporaryTable,
+    describePgEntity,
+    sqlCommentByAddingTags,
   }: {| ...Build |},
   {
     fieldWithHooks,
@@ -417,8 +419,16 @@ export default function makeProcField(
             },
           },
           Object.assign(
-            {},
             {
+              __origin: `Adding mutation function payload type for ${describePgEntity(
+                proc
+              )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
+                proc.namespaceName
+              }"."${
+                proc.name
+              }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+                name: "newNameHere",
+              })};`,
               isMutationPayload: true,
             },
             payloadTypeScope
@@ -442,6 +452,15 @@ export default function makeProcField(
             ),
           },
           {
+            __origin: `Adding mutation function input type for ${describePgEntity(
+              proc
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  COMMENT ON FUNCTION "${
+              proc.namespaceName
+            }"."${
+              proc.name
+            }"(...arg types go here...) IS ${sqlCommentByAddingTags(proc, {
+              name: "newNameHere",
+            })};`,
             isMutationInput: true,
           }
         );

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -251,10 +251,13 @@ class SchemaBuilder extends EventEmitter {
             )}[${hookName}${debugStr}]:   Executing '${hookDisplayName}'`
           );
 
-          const previousHook = build.status.currentHookName;
+          const previousHookName = build.status.currentHookName;
+          const previousHookEvent = build.status.currentHookEvent;
           build.status.currentHookName = hookDisplayName;
+          build.status.currentHookEvent = hookName;
           newObj = hook(newObj, build, context);
-          build.status.currentHookName = previousHook;
+          build.status.currentHookName = previousHookName;
+          build.status.currentHookEvent = previousHookEvent;
 
           if (!newObj) {
             throw new Error(

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -245,13 +245,17 @@ class SchemaBuilder extends EventEmitter {
         this.depth++;
         try {
           const hookDisplayName = hook.displayName || hook.name || "anonymous";
-          build.status.currentHookName = hookDisplayName;
           debug(
             `${INDENT.repeat(
               this.depth
             )}[${hookName}${debugStr}]:   Executing '${hookDisplayName}'`
           );
+
+          const previousHook = build.status.currentHookName;
+          build.status.currentHookName = hookDisplayName;
           newObj = hook(newObj, build, context);
+          build.status.currentHookName = previousHook;
+
           if (!newObj) {
             throw new Error(
               `Hook '${hook.displayName ||

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -322,7 +322,10 @@ class SchemaBuilder extends EventEmitter {
       this._generatedSchema = build.newWithHooks(
         GraphQLSchema,
         {},
-        { isSchema: true }
+        {
+          __origin: `GraphQL built-in`,
+          isSchema: true,
+        }
       );
     }
     if (!this._generatedSchema) {

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -54,14 +54,14 @@ export type Build = {|
     _context: mixed,
     resolveInfo: GraphQLResolveInfo
   ): string,
-  addType(type: GraphQLNamedType): void,
+  addType(type: GraphQLNamedType, origin?: ?string): void,
   getTypeByName(typeName: string): ?GraphQLType,
   extend<Obj1: *, Obj2: *>(base: Obj1, extra: Obj2, hint?: string): Obj1 & Obj2,
-  newWithHooks<T: GraphQLNamedType | GraphQLSchema>(
+  newWithHooks<T: GraphQLNamedType | GraphQLSchema, ConfigType: *>(
     Class<T>,
-    spec: {},
-    scope: {},
-    returnNullOnInvalid?: boolean
+    spec: ConfigType,
+    scope: Scope,
+    performNonEmptyFieldsCheck?: boolean
   ): ?T,
   fieldDataGeneratorsByType: Map<*, *>, // @deprecated - use fieldDataGeneratorsByFieldNameByType instead
   fieldDataGeneratorsByFieldNameByType: Map<*, *>,
@@ -71,6 +71,10 @@ export type Build = {|
     [string]: (...args: Array<any>) => string,
   },
   swallowError: (e: Error) => void,
+  status: {
+    currentHookName: ?string,
+    currentHookEvent: ?string,
+  },
 |};
 
 export type BuildExtensionQuery = {|
@@ -78,6 +82,7 @@ export type BuildExtensionQuery = {|
 |};
 
 export type Scope = {
+  __origin: ?string,
   [string]: mixed,
 };
 

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -245,6 +245,7 @@ class SchemaBuilder extends EventEmitter {
         this.depth++;
         try {
           const hookDisplayName = hook.displayName || hook.name || "anonymous";
+          build.status.currentHookName = hookDisplayName;
           debug(
             `${INDENT.repeat(
               this.depth

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -4,7 +4,7 @@ import chalk from "chalk";
 const aExtendedB = new WeakMap();
 const INDENT = "  ";
 
-export function indent(text) {
+export function indent(text: string) {
   return (
     INDENT + text.replace(/\n/g, "\n" + INDENT).replace(/\n +(?=\n|$)/g, "\n")
   );
@@ -31,7 +31,8 @@ export default function extend<Obj1: *, Obj2: *>(
     const hintKey = `_source__${key}`;
     const hintB = extra[hintKey] || hint;
     if (aExtendedB.get(newValue) !== oldValue && keysA.indexOf(key) >= 0) {
-      const hintA = base[hintKey];
+      // $FlowFixMe
+      const hintA: ?string = base[hintKey];
       const firstEntityDetails = !hintA
         ? "We don't have any information about the first entity."
         : `The first entity was:\n\n${indent(chalk.magenta(hintA))}`;

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -16,6 +16,13 @@ export default function extend<Obj1: *, Obj2: *>(
   const keysA = Object.keys(base);
   const keysB = Object.keys(extra);
   const hints = Object.create(null);
+  for (const key of keysA) {
+    const hintKey = `_source__${key}`;
+    if (base[hintKey]) {
+      hints[hintKey] = base[hintKey];
+    }
+  }
+
   for (const key of keysB) {
     const newValue = extra[key];
     const oldValue = base[key];
@@ -35,17 +42,19 @@ export default function extend<Obj1: *, Obj2: *>(
         )}'.\n\n${indent(firstEntityDetails)}\n\n${indent(secondEntityDetails)}`
       );
     }
-    hints[hintKey] = hintB || base[hintKey];
+    hints[hintKey] = hints[hintKey] || hintB || base[hintKey];
   }
   const obj = Object.assign({}, base, extra);
   aExtendedB.set(obj, base);
   for (const hintKey in hints) {
-    Object.defineProperty(obj, hintKey, {
-      configurable: false,
-      enumerable: false,
-      value: hints[hintKey],
-      writable: false,
-    });
+    if (hints[hintKey]) {
+      Object.defineProperty(obj, hintKey, {
+        configurable: false,
+        enumerable: false,
+        value: hints[hintKey],
+        writable: false,
+      });
+    }
   }
   return obj;
 }

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -9,14 +9,25 @@ export default function extend<Obj1: *, Obj2: *>(
 ): Obj1 & Obj2 {
   const keysA = Object.keys(base);
   const keysB = Object.keys(extra);
+  const hints = Object.create(null);
   for (const key of keysB) {
     const newValue = extra[key];
     const oldValue = base[key];
     if (aExtendedB.get(newValue) !== oldValue && keysA.indexOf(key) >= 0) {
       throw new Error(`Overwriting key '${key}' is not allowed! ${hint || ""}`);
     }
+    const hintKey = `_source__${key}`;
+    hints[hintKey] = extra[hintKey] || base[hintKey] || hint;
   }
   const obj = Object.assign({}, base, extra);
   aExtendedB.set(obj, base);
+  for (const hintKey in hints) {
+    Object.defineProperty(obj, hintKey, {
+      configurable: false,
+      enumerable: false,
+      value: hints[hintKey],
+      writable: false,
+    });
+  }
   return obj;
 }

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -5,7 +5,9 @@ const aExtendedB = new WeakMap();
 const INDENT = "  ";
 
 export function indent(text) {
-  return INDENT + text.replace(/\n/g, "\n" + INDENT);
+  return (
+    INDENT + text.replace(/\n/g, "\n" + INDENT).replace(/\n +(?=\n|$)/g, "\n")
+  );
 }
 
 export default function extend<Obj1: *, Obj2: *>(

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -4,7 +4,7 @@ import chalk from "chalk";
 const aExtendedB = new WeakMap();
 const INDENT = "  ";
 
-function indent(text) {
+export function indent(text) {
   return INDENT + text.replace(/\n/g, "\n" + INDENT);
 }
 

--- a/packages/graphile-build/src/index.js
+++ b/packages/graphile-build/src/index.js
@@ -3,6 +3,7 @@
 import util from "util";
 import SchemaBuilder from "./SchemaBuilder";
 import {
+  SwallowErrorsPlugin,
   StandardTypesPlugin,
   NodePlugin,
   QueryPlugin,
@@ -71,6 +72,7 @@ export const buildSchema = async (
 };
 
 export const defaultPlugins: Array<Plugin> = [
+  SwallowErrorsPlugin,
   StandardTypesPlugin,
   NodePlugin,
   QueryPlugin,
@@ -81,6 +83,7 @@ export const defaultPlugins: Array<Plugin> = [
 ];
 
 export {
+  SwallowErrorsPlugin,
   StandardTypesPlugin,
   NodePlugin,
   QueryPlugin,

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -269,24 +269,27 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
         (this
           ? `'addType' call during hook '${this.status.currentHookName}'`
           : null);
-      if (allTypes[type.name] && allTypes[type.name] !== type) {
-        const oldTypeSource = allTypesSources[type.name];
-        const firstEntityDetails = !oldTypeSource
-          ? "The first type was registered from an unknown origin."
-          : `The first entity was:\n\n${indent(oldTypeSource)}`;
-        const secondEntityDetails = !newTypeSource
-          ? "The second type was registered from an unknown origin."
-          : `The second entity was:\n\n${indent(newTypeSource)}`;
-        throw new Error(
-          `A type naming conflict has occurred - two entities have tried to define the same type '${chalk.bold(
-            type.name
-          )}'.\n\n${indent(firstEntityDetails)}\n\n${indent(
-            secondEntityDetails
-          )}`
-        );
+      if (allTypes[type.name]) {
+        if (allTypes[type.name] !== type) {
+          const oldTypeSource = allTypesSources[type.name];
+          const firstEntityDetails = !oldTypeSource
+            ? "The first type was registered from an unknown origin."
+            : `The first entity was:\n\n${indent(oldTypeSource)}`;
+          const secondEntityDetails = !newTypeSource
+            ? "The second type was registered from an unknown origin."
+            : `The second entity was:\n\n${indent(newTypeSource)}`;
+          throw new Error(
+            `A type naming conflict has occurred - two entities have tried to define the same type '${chalk.bold(
+              type.name
+            )}'.\n\n${indent(firstEntityDetails)}\n\n${indent(
+              secondEntityDetails
+            )}`
+          );
+        }
+      } else {
+        allTypes[type.name] = type;
+        allTypesSources[type.name] = newTypeSource;
       }
-      allTypes[type.name] = type;
-      allTypesSources[type.name] = newTypeSource;
     },
     getTypeByName(typeName) {
       return allTypes[typeName];

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -768,7 +768,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
       }
 
       if (finalSpec.name) {
-        this.addType(Self, scope.origin);
+        this.addType(Self, scope.__origin);
       }
       fieldDataGeneratorsByFieldNameByType.set(
         Self,

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -768,7 +768,15 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
       }
 
       if (finalSpec.name) {
-        this.addType(Self, scope.__origin);
+        this.addType(
+          Self,
+          scope.__origin ||
+            (this
+              ? `'newWithHooks' call during hook '${
+                  this.status.currentHookName
+                }'`
+              : null)
+        );
       }
       fieldDataGeneratorsByFieldNameByType.set(
         Self,

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -585,7 +585,13 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
             const fieldsSpec = builder.applyHooks(
               this,
               "GraphQLObjectType:fields",
-              rawFields,
+              this.extend(
+                {},
+                rawFields,
+                `Default field included in newWithHooks call for '${
+                  rawSpec.name
+                }'. ${inScope.__origin || ""}`
+              ),
               fieldsContext,
               `|${rawSpec.name}`
             );
@@ -674,7 +680,13 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
             const fieldsSpec = builder.applyHooks(
               this,
               "GraphQLInputObjectType:fields",
-              rawFields,
+              this.extend(
+                {},
+                rawFields,
+                `Default field included in newWithHooks call for '${
+                  rawSpec.name
+                }'. ${inScope.__origin || ""}`
+              ),
               fieldsContext,
               `|${getNameFromType(Self)}`
             );

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -274,10 +274,14 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
           const oldTypeSource = allTypesSources[type.name];
           const firstEntityDetails = !oldTypeSource
             ? "The first type was registered from an unknown origin."
-            : `The first entity was:\n\n${indent(oldTypeSource)}`;
+            : `The first entity was:\n\n${indent(
+                chalk.magenta(oldTypeSource)
+              )}`;
           const secondEntityDetails = !newTypeSource
             ? "The second type was registered from an unknown origin."
-            : `The second entity was:\n\n${indent(newTypeSource)}`;
+            : `The second entity was:\n\n${indent(
+                chalk.yellow(newTypeSource)
+              )}`;
           throw new Error(
             `A type naming conflict has occurred - two entities have tried to define the same type '${chalk.bold(
               type.name

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -795,6 +795,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
     resolveNode,
     status: {
       currentHookName: null,
+      currentHookEvent: null,
     },
   };
 }

--- a/packages/graphile-build/src/plugins/MutationPlugin.js
+++ b/packages/graphile-build/src/plugins/MutationPlugin.js
@@ -29,7 +29,10 @@ export default (async function MutationPlugin(builder) {
         description:
           "The root mutation type which contains root level fields which mutate data.",
       },
-      { isRootMutation: true },
+      {
+        __origin: `graphile-build built-in (root mutation type)`,
+        isRootMutation: true,
+      },
       true
     );
     if (isValidMutation(Mutation)) {

--- a/packages/graphile-build/src/plugins/MutationPlugin.js
+++ b/packages/graphile-build/src/plugins/MutationPlugin.js
@@ -36,9 +36,13 @@ export default (async function MutationPlugin(builder) {
       true
     );
     if (isValidMutation(Mutation)) {
-      return extend(schema, {
-        mutation: Mutation,
-      });
+      return extend(
+        schema,
+        {
+          mutation: Mutation,
+        },
+        "Adding mutation type to schema"
+      );
     } else {
       return schema;
     }

--- a/packages/graphile-build/src/plugins/NodePlugin.js
+++ b/packages/graphile-build/src/plugins/NodePlugin.js
@@ -220,7 +220,7 @@ export default (function NodePlugin(
             }
           ),
         },
-        `Adding node helpers to the root Query`
+        `Adding Relay Global Object Identification support to the root Query via 'node' and '${nodeIdFieldName}' fields`
       );
     }
   );

--- a/packages/graphile-build/src/plugins/NodePlugin.js
+++ b/packages/graphile-build/src/plugins/NodePlugin.js
@@ -135,7 +135,9 @@ export default (function NodePlugin(
           },
         },
       },
-      {}
+      {
+        __origin: `graphile-build built-in (NodePlugin); you can omit this plugin if you like, but you'll lose compatibility with Relay`,
+      }
     );
     return _;
   });

--- a/packages/graphile-build/src/plugins/QueryPlugin.js
+++ b/packages/graphile-build/src/plugins/QueryPlugin.js
@@ -43,7 +43,10 @@ export default (async function QueryPlugin(builder) {
           },
         }),
       },
-      { isRootQuery: true },
+      {
+        __origin: `graphile-build built-in (root query type)`,
+        isRootQuery: true,
+      },
       true
     );
     if (queryType) {

--- a/packages/graphile-build/src/plugins/StandardTypesPlugin.js
+++ b/packages/graphile-build/src/plugins/StandardTypesPlugin.js
@@ -25,7 +25,7 @@ export default (function StandardTypesPlugin(builder) {
         "Cursor",
         "A location in a connection that can be used for resuming pagination."
       );
-      build.addType(Cursor);
+      build.addType(Cursor, "graphile-build built-in");
       return build;
     }
   );

--- a/packages/graphile-build/src/plugins/StandardTypesPlugin.js
+++ b/packages/graphile-build/src/plugins/StandardTypesPlugin.js
@@ -75,6 +75,7 @@ export default (function StandardTypesPlugin(builder) {
         }),
       },
       {
+        __origin: `graphile-build built-in`,
         isPageInfo: true,
       }
     );

--- a/packages/graphile-build/src/plugins/SubscriptionPlugin.js
+++ b/packages/graphile-build/src/plugins/SubscriptionPlugin.js
@@ -36,9 +36,13 @@ export default (async function SubscriptionPlugin(builder) {
       true
     );
     if (isValidSubscription(Subscription)) {
-      return extend(schema, {
-        subscription: Subscription,
-      });
+      return extend(
+        schema,
+        {
+          subscription: Subscription,
+        },
+        "Adding subscription type to schema"
+      );
     } else {
       return schema;
     }

--- a/packages/graphile-build/src/plugins/SubscriptionPlugin.js
+++ b/packages/graphile-build/src/plugins/SubscriptionPlugin.js
@@ -29,7 +29,10 @@ export default (async function SubscriptionPlugin(builder) {
         description:
           "The root subscription type which contains root level fields which mutate data.",
       },
-      { isRootSubscription: true },
+      {
+        __origin: `graphile-build built-in (root subscription type)`,
+        isRootSubscription: true,
+      },
       true
     );
     if (isValidSubscription(Subscription)) {

--- a/packages/graphile-build/src/plugins/SwallowErrorsPlugin.js
+++ b/packages/graphile-build/src/plugins/SwallowErrorsPlugin.js
@@ -12,8 +12,10 @@ export default (function SwallowErrorsPlugin(
         // This plugin is a bit of a misnomer - to better maintain backwards
         // compatibility, `swallowError` still exists on `makeNewBuild`; and
         // thus this plugin is really `dontSwallowErrors`.
+        // $FlowFixMe
         return Object.assign({}, build, {
           swallowError(e) {
+            // $FlowFixMe
             e.recoverable = true;
             throw e;
           },

--- a/packages/graphile-build/src/plugins/SwallowErrorsPlugin.js
+++ b/packages/graphile-build/src/plugins/SwallowErrorsPlugin.js
@@ -1,0 +1,26 @@
+// @flow
+import type { Plugin, Build } from "../SchemaBuilder";
+
+export default (function SwallowErrorsPlugin(
+  builder,
+  { dontSwallowErrors = false }
+) {
+  builder.hook(
+    "build",
+    (build: Build): Build => {
+      if (dontSwallowErrors) {
+        // This plugin is a bit of a misnomer - to better maintain backwards
+        // compatibility, `swallowError` still exists on `makeNewBuild`; and
+        // thus this plugin is really `dontSwallowErrors`.
+        return Object.assign({}, build, {
+          swallowError(e) {
+            e.recoverable = true;
+            throw e;
+          },
+        });
+      } else {
+        return build;
+      }
+    }
+  );
+}: Plugin);

--- a/packages/graphile-build/src/plugins/index.js
+++ b/packages/graphile-build/src/plugins/index.js
@@ -7,6 +7,7 @@ import SubscriptionPlugin from "./SubscriptionPlugin";
 import NodePlugin from "./NodePlugin";
 import QueryPlugin from "./QueryPlugin";
 import StandardTypesPlugin from "./StandardTypesPlugin";
+import SwallowErrorsPlugin from "./SwallowErrorsPlugin";
 
 export {
   ClientMutationIdDescriptionPlugin,
@@ -16,4 +17,5 @@ export {
   NodePlugin,
   QueryPlugin,
   StandardTypesPlugin,
+  SwallowErrorsPlugin,
 };

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -79,6 +79,7 @@ type Query {
 
 exports[`supports @scope directive with simple values 1`] = `
 Object {
+  "__origin": "graphile-build built-in (root query type)",
   "fieldDirectives": Object {
     "scope": Object {
       "floatTest": 3.141592,
@@ -115,6 +116,7 @@ type Query {
 
 exports[`supports @scope directive with variable value 1`] = `
 Object {
+  "__origin": "graphile-build built-in (root query type)",
   "embedTest": Object {
     "sub": Array [
       Array [

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -210,6 +210,7 @@ export default function makeExtendSchemaPlugin(
           const interfaces = getInterfaces(definition.interfaces, build);
           const directives = getDirectives(definition.directives);
           const scope = {
+            __origin: `makeExtendSchemaPlugin`,
             directives,
             ...(directives.scope || {}),
           };
@@ -244,6 +245,7 @@ export default function makeExtendSchemaPlugin(
           const description = getDescription(definition.description);
           const directives = getDirectives(definition.directives);
           const scope = {
+            __origin: `makeExtendSchemaPlugin`,
             directives,
             ...(directives.scope || {}),
           };

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -5,15 +5,15 @@ exports[`simple collections naming clash 1`] = `
 
   The first entity was:
   
-    [35mBackward relation (connection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:[39m
+    [35mBackward relation (connection) for constraint '[1mpost_author_id_fkey[22m' on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
     [35m[39m
-    [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignFieldName newNameHere\\nRest of existing \\'comment\\' \\nhere.';[39m
+    [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignFieldName newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
   
-    [33mBackward relation (simple collection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:[39m
+    [33mBackward relation (simple collection) for constraint '[1mpost_author_id_fkey[22m' on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
     [33m[39m
-    [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
+    [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignSimpleFieldName newNameHere[22m\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
 exports[`table naming clash 1`] = `[Error: Type 'PeopleOrderBy' has already been registered!]`;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -69,7 +69,7 @@ exports[`function naming clash - nodeId 1`] = `
 
   The first entity was:
 
-    [35mAdding node helpers to the root Query[39m
+    [35mAdding Relay Global Object Identification support to the root Query via 'node' and 'nodeId' fields[39m
 
   The second entity was:
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`function naming clash - nodeId 1`] = `
+[Error: A naming conflict has occurred - two entities have tried to define the same key '[1mnodeId[22m'.
+
+  The first entity was:
+
+    [35mAdding node helpers to the root Query[39m
+
+  The second entity was:
+
+    [33mAdding query field for function [1m"c"."int_set_query"(...args...)[22m. You can rename this field with:[39m
+    [33m[39m
+    [33m  COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
+`;
+
 exports[`function naming clash - payload 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mQEdge[22m'.
 
@@ -21,13 +35,13 @@ exports[`simple collections naming clash 1`] = `
 
   The first entity was:
 
-    [35mBackward relation (connection) for constraint '[1mpost_author_id_fkey[22m' on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
+    [35mBackward relation (connection) for constraint [1m"post_author_id_fkey"[22m on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
     [35m[39m
     [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignFieldName newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    [33mBackward relation (simple collection) for constraint '[1mpost_author_id_fkey[22m' on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
+    [33mBackward relation (simple collection) for constraint [1m"post_author_id_fkey"[22m on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
     [33m[39m
     [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignSimpleFieldName newNameHere[22m\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -21,9 +21,9 @@ exports[`table naming clash 1`] = `
 
   The first entity was:
   
-    'addType' call during hook 'PgOrderByPrimaryKeyPlugin/GraphQLEnumType:values/anonymous'
+    'addType' call during hook 'PgConnectionArgOrderBy/init/anonymous'
 
   The second entity was:
   
-    'addType' call during hook 'PgOrderByPrimaryKeyPlugin/GraphQLEnumType:values/anonymous']
+    'addType' call during hook 'PgConnectionArgOrderBy/init/anonymous']
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -7,11 +7,11 @@ exports[`simple collections naming clash 1`] = `
   
     [35mBackward relation (connection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:[39m
     [35m[39m
-    [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignFieldName newNameHere\\n';[39m
+    [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignFieldName newNameHere\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
   
     [33mBackward relation (simple collection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:[39m
     [33m[39m
-    [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n';[39m]
+    [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simple collections naming clash 1`] = `
+[Error: Overwriting key 'clash' is not allowed! Backward relation (simple collection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:
+
+  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n';]
+`;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`column naming clash - rename 1`] = `
+[Error: A naming conflict has occurred - two entities have tried to define the same key '[1mWONT_CAST_EASY_ASC[22m'.
+
+  The first entity was:
+
+    [35mAdding ascending orderBy enum value for column [1m"wont_cast_easy"[22m on table [1m"c"."edge_case"[22m. You can rename this field with:[39m
+    [35m[39m
+    [35m  COMMENT ON COLUMN "c"."edge_case"."wont_cast_easy" IS E'[1m@name newNameHere[22m';[39m
+
+  The second entity was:
+
+    [33mAdding ascending orderBy enum value for column [1m"row_id"[22m on table [1m"c"."edge_case"[22m (with smart comments: [1m@name wontCastEasy[22m). You can rename this field with:[39m
+    [33m[39m
+    [33m  COMMENT ON COLUMN "c"."edge_case"."row_id" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
+`;
+
 exports[`function naming clash - computed 1`] = `
 [Error: A naming conflict has occurred - two entities have tried to define the same key '[1mrowId[22m'.
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -197,7 +197,9 @@ exports[`table naming clash - query 1`] = `
 
   The second entity was:
 
-    [33mAdding "row by node ID" fields to root Query type[39m]
+    [33mAdding row by globally unique identifier field for table [1m"a"."post"[22m (with smart comments: [1m@name query[22m). You can rename this table via:[39m
+    [33m[39m
+    [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
 exports[`table naming clash - subscription 1`] = `

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -4,15 +4,15 @@ exports[`function naming clash - payload 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mQEdge[22m'.
 
   The first entity was:
-  
+
     Adding function result edge type for function [1m"c"."int_set_query"(...args...)[22m. You can rename the function's GraphQL field (and its dependent types) via:
-    
+
       COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
 
   The second entity was:
-  
+
     Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
 `;
 
@@ -20,13 +20,13 @@ exports[`simple collections naming clash 1`] = `
 [Error: A naming conflict has occurred - two entities have tried to define the same key '[1mclash[22m'.
 
   The first entity was:
-  
+
     [35mBackward relation (connection) for constraint '[1mpost_author_id_fkey[22m' on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
     [35m[39m
     [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignFieldName newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
-  
+
     [33mBackward relation (simple collection) for constraint '[1mpost_author_id_fkey[22m' on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
     [33m[39m
     [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignSimpleFieldName newNameHere[22m\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
@@ -36,15 +36,15 @@ exports[`table naming clash - condition 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPersonCondition[22m'.
 
   The first entity was:
-  
+
     Adding condition type for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
 
   The second entity was:
-  
+
     Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
 `;
 
@@ -52,15 +52,15 @@ exports[`table naming clash - direct 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPeopleOrderBy[22m'.
 
   The first entity was:
-  
+
     Adding connection "orderBy" argument for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
 
   The second entity was:
-  
+
     Adding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';]
 `;
 
@@ -68,13 +68,13 @@ exports[`table naming clash - mutation 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mMutation[22m'.
 
   The first entity was:
-  
+
     Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
 
   The second entity was:
-  
+
     graphile-build built-in (root mutation type)]
 `;
 
@@ -82,15 +82,15 @@ exports[`table naming clash - order 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPeopleOrderBy[22m'.
 
   The first entity was:
-  
+
     Adding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
 
   The second entity was:
-  
+
     Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
 `;
 
@@ -98,11 +98,11 @@ exports[`table naming clash - query 1`] = `
 [Error: A naming conflict has occurred - two entities have tried to define the same key '[1mquery[22m'.
 
   The first entity was:
-  
+
     [35mDefault field included in newWithHooks call for 'Query'. graphile-build built-in (root query type)[39m
 
   The second entity was:
-  
+
     [33mAdding "row by node ID" fields to root Query type[39m]
 `;
 
@@ -110,12 +110,12 @@ exports[`table naming clash - subscription 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mSubscription[22m'.
 
   The first entity was:
-  
+
     Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-    
+
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
 
   The second entity was:
-  
+
     graphile-build built-in (root subscription type)]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`function naming clash - payload 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mQEdge[22m'.
+
+  The first entity was:
+  
+    Adding function result edge type for function [1m"c"."int_set_query"(...args...)[22m. You can rename the function's GraphQL field (and its dependent types) via:
+    
+      COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+
+  The second entity was:
+  
+    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+`;
+
 exports[`simple collections naming clash 1`] = `
 [Error: A naming conflict has occurred - two entities have tried to define the same key '[1mclash[22m'.
 
@@ -48,6 +64,20 @@ exports[`table naming clash - direct 1`] = `
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';]
 `;
 
+exports[`table naming clash - mutation 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mMutation[22m'.
+
+  The first entity was:
+  
+    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+
+  The second entity was:
+  
+    graphile-build built-in (root mutation type)]
+`;
+
 exports[`table naming clash - order 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPeopleOrderBy[22m'.
 
@@ -62,4 +92,30 @@ exports[`table naming clash - order 1`] = `
     Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
     
       COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+`;
+
+exports[`table naming clash - query 1`] = `
+[Error: A naming conflict has occurred - two entities have tried to define the same key '[1mquery[22m'.
+
+  The first entity was:
+  
+    [35mDefault field included in newWithHooks call for 'Query'. graphile-build built-in (root query type)[39m
+
+  The second entity was:
+  
+    [33mAdding "row by node ID" fields to root Query type[39m]
+`;
+
+exports[`table naming clash - subscription 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mSubscription[22m'.
+
+  The first entity was:
+  
+    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+
+  The second entity was:
+  
+    graphile-build built-in (root subscription type)]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,7 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`simple collections naming clash 1`] = `
-[Error: Overwriting key 'clash' is not allowed! Backward relation (simple collection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:
+[Error: A naming conflict has occurred - two entities have tried to define the same key '[1mclash[22m'.
 
-  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n';]
+  The first entity was:
+  
+    [35mBackward relation (connection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:[39m
+    [35m[39m
+    [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignFieldName newNameHere\\n';[39m
+
+  The second entity was:
+  
+    [33mBackward relation (simple collection) for constraint 'post_author_id_fkey' on table 'a.post'. To rename this relation with smart comments:[39m
+    [33m[39m
+    [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n';[39m]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`function naming clash - createPost 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mCreatePostPayload[22m'.
+
+  The first entity was:
+
+    [35mAdding table create payload type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m';[39m
+
+  The second entity was:
+
+    [33mAdding mutation function payload type for function [1m"a"."mutation_text_array"(...args...)[22m (with smart comments: [1m@name createPost[22m). You can rename the function's GraphQL field (and its dependent types) via:[39m
+    [33m[39m
+    [33m  COMMENT ON FUNCTION "a"."mutation_text_array"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
+`;
+
 exports[`function naming clash - nodeId 1`] = `
 [Error: A naming conflict has occurred - two entities have tried to define the same key '[1mnodeId[22m'.
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -9,7 +9,7 @@ exports[`function naming clash - nodeId 1`] = `
 
   The second entity was:
 
-    [33mAdding query field for function [1m"c"."int_set_query"(...args...)[22m. You can rename this field with:[39m
+    [33mAdding query field for function [1m"c"."int_set_query"(...args...)[22m (with smart comments: [1m@name nodeId[22m). You can rename this field with:[39m
     [33m[39m
     [33m  COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
@@ -19,13 +19,13 @@ exports[`function naming clash - payload 1`] = `
 
   The first entity was:
 
-    [35mAdding function result edge type for function [1m"c"."int_set_query"(...args...)[22m. You can rename the function's GraphQL field (and its dependent types) via:[39m
+    [35mAdding function result edge type for function [1m"c"."int_set_query"(...args...)[22m (with smart comments: [1m@name q[22m). You can rename the function's GraphQL field (and its dependent types) via:[39m
     [35m[39m
     [35m  COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    [33mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [33mAdding table type for table [1m"a"."post"[22m (with smart comments: [1m@name q_edge[22m). You can rename the table's GraphQL type via:[39m
     [33m[39m
     [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
@@ -35,13 +35,13 @@ exports[`simple collections naming clash 1`] = `
 
   The first entity was:
 
-    [35mBackward relation (connection) for constraint [1m"post_author_id_fkey"[22m on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
+    [35mBackward relation (connection) for constraint [1m"post_author_id_fkey"[22m on table [1m"a"."post"[22m (with smart comments: [1m@foreignFieldName clash[22m). To rename this relation with smart comments:[39m
     [35m[39m
     [35m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignFieldName newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    [33mBackward relation (simple collection) for constraint [1m"post_author_id_fkey"[22m on table [1m"a"."post"[22m. To rename this relation with smart comments:[39m
+    [33mBackward relation (simple collection) for constraint [1m"post_author_id_fkey"[22m on table [1m"a"."post"[22m (with smart comments: [1m@foreignFieldName clash[22m). To rename this relation with smart comments:[39m
     [33m[39m
     [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignSimpleFieldName newNameHere[22m\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
@@ -57,7 +57,7 @@ exports[`table naming clash - condition 1`] = `
 
   The second entity was:
 
-    [33mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [33mAdding table type for table [1m"a"."post"[22m (with smart comments: [1m@name person_condition[22m). You can rename the table's GraphQL type via:[39m
     [33m[39m
     [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
@@ -67,7 +67,7 @@ exports[`table naming clash - direct 1`] = `
 
   The first entity was:
 
-    [35mAdding connection "orderBy" argument for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35mAdding connection "orderBy" argument for table [1m"a"."post"[22m (with smart comments: [1m@name person[22m). You can rename the table's GraphQL type via:[39m
     [35m[39m
     [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
@@ -83,7 +83,7 @@ exports[`table naming clash - mutation 1`] = `
 
   The first entity was:
 
-    [35mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35mAdding table type for table [1m"a"."post"[22m (with smart comments: [1m@name mutation[22m). You can rename the table's GraphQL type via:[39m
     [35m[39m
     [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
@@ -103,7 +103,7 @@ exports[`table naming clash - order 1`] = `
 
   The second entity was:
 
-    [33mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [33mAdding table type for table [1m"a"."post"[22m (with smart comments: [1m@name people_order_by[22m). You can rename the table's GraphQL type via:[39m
     [33m[39m
     [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
@@ -125,7 +125,7 @@ exports[`table naming clash - subscription 1`] = `
 
   The first entity was:
 
-    [35mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35mAdding table type for table [1m"a"."post"[22m (with smart comments: [1m@name subscription[22m). You can rename the table's GraphQL type via:[39m
     [35m[39m
     [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -15,3 +15,5 @@ exports[`simple collections naming clash 1`] = `
     [33m[39m
     [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'@foreignSimpleFieldName newNameHere\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
+
+exports[`table naming clash 1`] = `[Error: Type 'PeopleOrderBy' has already been registered!]`;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -16,7 +16,23 @@ exports[`simple collections naming clash 1`] = `
     [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignSimpleFieldName newNameHere[22m\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
-exports[`table naming clash 1`] = `
+exports[`table naming clash - condition 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPersonCondition[22m'.
+
+  The first entity was:
+  
+    Adding condition type for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
+
+  The second entity was:
+  
+    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+`;
+
+exports[`table naming clash - direct 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPeopleOrderBy[22m'.
 
   The first entity was:
@@ -32,12 +48,12 @@ exports[`table naming clash 1`] = `
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';]
 `;
 
-exports[`table naming clash 2`] = `
-[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPersonCondition[22m'.
+exports[`table naming clash - order 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPeopleOrderBy[22m'.
 
   The first entity was:
   
-    Adding condition type for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
+    Adding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
     
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -21,9 +21,13 @@ exports[`table naming clash 1`] = `
 
   The first entity was:
   
-    'addType' call during hook 'PgConnectionArgOrderBy/init/anonymous'
+    Adding connection "orderBy" argument for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
 
   The second entity was:
   
-    'addType' call during hook 'PgConnectionArgOrderBy/init/anonymous']
+    Adding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -16,6 +16,22 @@ exports[`function naming clash - createPost 1`] = `
     [33m  COMMENT ON FUNCTION "a"."mutation_text_array"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
+exports[`function naming clash - deletePost 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mDeletePostPayload[22m'.
+
+  The first entity was:
+
+    [35mAdding table delete mutation payload type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m';[39m
+
+  The second entity was:
+
+    [33mAdding mutation function payload type for function [1m"a"."mutation_text_array"(...args...)[22m (with smart comments: [1m@name deletePost[22m). You can rename the function's GraphQL field (and its dependent types) via:[39m
+    [33m[39m
+    [33m  COMMENT ON FUNCTION "a"."mutation_text_array"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
+`;
+
 exports[`function naming clash - nodeId 1`] = `
 [Error: A naming conflict has occurred - two entities have tried to define the same key '[1mnodeId[22m'.
 
@@ -44,6 +60,22 @@ exports[`function naming clash - payload 1`] = `
     [33mAdding table type for table [1m"a"."post"[22m (with smart comments: [1m@name q_edge[22m). You can rename the table's GraphQL type via:[39m
     [33m[39m
     [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
+`;
+
+exports[`function naming clash - updatePost 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mUpdatePostPayload[22m'.
+
+  The first entity was:
+
+    [35mAdding table update mutation payload type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m';[39m
+
+  The second entity was:
+
+    [33mAdding mutation function payload type for function [1m"a"."mutation_text_array"(...args...)[22m (with smart comments: [1m@name updatePost[22m). You can rename the function's GraphQL field (and its dependent types) via:[39m
+    [33m[39m
+    [33m  COMMENT ON FUNCTION "a"."mutation_text_array"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
 exports[`simple collections naming clash 1`] = `

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -5,15 +5,15 @@ exports[`function naming clash - payload 1`] = `
 
   The first entity was:
 
-    Adding function result edge type for function [1m"c"."int_set_query"(...args...)[22m. You can rename the function's GraphQL field (and its dependent types) via:
-
-      COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+    [35mAdding function result edge type for function [1m"c"."int_set_query"(...args...)[22m. You can rename the function's GraphQL field (and its dependent types) via:[39m
+    [35m[39m
+    [35m  COMMENT ON FUNCTION "c"."int_set_query"(...arg types go here...) IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+    [33mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [33m[39m
+    [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
 exports[`simple collections naming clash 1`] = `
@@ -37,15 +37,15 @@ exports[`table naming clash - condition 1`] = `
 
   The first entity was:
 
-    Adding condition type for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
+    [35mAdding condition type for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';[39m
 
   The second entity was:
 
-    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+    [33mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [33m[39m
+    [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
 exports[`table naming clash - direct 1`] = `
@@ -53,15 +53,15 @@ exports[`table naming clash - direct 1`] = `
 
   The first entity was:
 
-    Adding connection "orderBy" argument for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+    [35mAdding connection "orderBy" argument for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    Adding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';]
+    [33mAdding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:[39m
+    [33m[39m
+    [33m  COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';[39m]
 `;
 
 exports[`table naming clash - mutation 1`] = `
@@ -69,13 +69,13 @@ exports[`table naming clash - mutation 1`] = `
 
   The first entity was:
 
-    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+    [35mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    graphile-build built-in (root mutation type)]
+    [33mgraphile-build built-in (root mutation type)[39m]
 `;
 
 exports[`table naming clash - order 1`] = `
@@ -83,15 +83,15 @@ exports[`table naming clash - order 1`] = `
 
   The first entity was:
 
-    Adding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
+    [35mAdding connection "orderBy" argument for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';[39m
 
   The second entity was:
 
-    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+    [33mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [33m[39m
+    [33m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
 exports[`table naming clash - query 1`] = `
@@ -111,11 +111,11 @@ exports[`table naming clash - subscription 1`] = `
 
   The first entity was:
 
-    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
-
-      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';
+    [35mAdding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:[39m
+    [35m[39m
+    [35m  COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m
 
   The second entity was:
 
-    graphile-build built-in (root subscription type)]
+    [33mgraphile-build built-in (root subscription type)[39m]
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -16,4 +16,14 @@ exports[`simple collections naming clash 1`] = `
     [33m  COMMENT ON CONSTRAINT "post_author_id_fkey" ON "a"."post" IS E'[1m@foreignSimpleFieldName newNameHere[22m\\n@foreignFieldName clash\\nRest of existing \\'comment\\' \\nhere.';[39m]
 `;
 
-exports[`table naming clash 1`] = `[Error: Type 'PeopleOrderBy' has already been registered!]`;
+exports[`table naming clash 1`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPeopleOrderBy[22m'.
+
+  The first entity was:
+  
+    'addType' call during hook 'PgOrderByPrimaryKeyPlugin/GraphQLEnumType:values/anonymous'
+
+  The second entity was:
+  
+    'addType' call during hook 'PgOrderByPrimaryKeyPlugin/GraphQLEnumType:values/anonymous']
+`;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`function naming clash - computed 1`] = `
+[Error: A naming conflict has occurred - two entities have tried to define the same key '[1mrowId[22m'.
+
+  The first entity was:
+
+    [35mAdding columns to 'table [1m"c"."edge_case"[22m'[39m
+
+  The second entity was:
+
+    [33mAdding computed column for function [1m"c"."edge_case_computed"(...args...)[22m (with smart comments: [1m@fieldName rowId[22m). You can rename this field with:[39m
+    [33m[39m
+    [33m  COMMENT ON FUNCTION "c"."edge_case_computed"(...arg types go here...) IS E'[1m@fieldName newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';[39m]
+`;
+
 exports[`function naming clash - createPost 1`] = `
 [Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mCreatePostPayload[22m'.
 

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -31,3 +31,19 @@ exports[`table naming clash 1`] = `
     
       COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';]
 `;
+
+exports[`table naming clash 2`] = `
+[Error: A type naming conflict has occurred - two entities have tried to define the same type '[1mPersonCondition[22m'.
+
+  The first entity was:
+  
+    Adding condition type for table [1m"c"."person"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "c"."person" IS E'[1m@name newNameHere[22m\\nPerson test comment';
+
+  The second entity was:
+  
+    Adding table type for table [1m"a"."post"[22m. You can rename the table's GraphQL type via:
+    
+      COMMENT ON TABLE "a"."post" IS E'[1m@name newNameHere[22m\\nRest of existing \\'comment\\' \\nhere.';]
+`;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/extend-errors.test.js.snap
@@ -21,7 +21,9 @@ exports[`function naming clash - computed 1`] = `
 
   The first entity was:
 
-    [35mAdding columns to 'table [1m"c"."edge_case"[22m'[39m
+    [35mAdding field for column [1m"row_id"[22m on table [1m"c"."edge_case"[22m. You can rename this field with:[39m
+    [35m[39m
+    [35m  COMMENT ON COLUMN "c"."edge_case"."row_id" IS E'[1m@name newNameHere[22m';[39m
 
   The second entity was:
 

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -1,13 +1,18 @@
 const { withPgClient } = require("../helpers");
 const { createPostGraphileSchema } = require("../..");
+const { printSchema } = require("graphql");
 
 function check(description, sql) {
   test(description, async () => {
     let error;
+    let schema;
     await withPgClient(async pgClient => {
       await pgClient.query(sql);
       try {
-        await createPostGraphileSchema(pgClient, ["a", "b", "c"], {
+        schema = await createPostGraphileSchema(pgClient, ["a", "b", "c"], {
+          graphileBuildOptions: {
+            dontSwallowErrors: true,
+          },
           simpleCollections: "both",
           appendPlugins: [
             function DummySubPlugin(builder) {
@@ -96,5 +101,11 @@ check(
   "function naming clash - nodeId",
   `
     comment on function c.int_set_query(int, int, int) is E'@name nodeId\nRest of existing ''comment'' \nhere.';
+  `
+);
+check(
+  "function naming clash - createPost",
+  `
+    comment on function a.mutation_text_array() is E'@name createPost\nRest of existing ''comment'' \nhere.';
   `
 );

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -133,3 +133,9 @@ check(
     comment on function c.edge_case_computed(c.edge_case) is E'@fieldName rowId\nRest of existing ''comment'' \nhere.';
   `
 );
+check(
+  "column naming clash - rename",
+  `
+    comment on column c.edge_case.row_id is E'@name wontCastEasy\nRest of existing ''comment'' \nhere.';
+  `
+);

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -36,6 +36,11 @@ function check(description, sql) {
         error = e;
       }
     });
+    // Debugging
+    if (!error) {
+      // eslint-disable-next-line no-console
+      //console.error(printSchema(schema));
+    }
     expect(error).toBeTruthy();
     expect(error).toMatchSnapshot();
   });

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -25,9 +25,17 @@ check(
     comment on constraint post_author_id_fkey on a.post is E'@foreignFieldName clash\nRest of existing ''comment'' \nhere.';
   `
 );
+
 check(
   "table naming clash",
   `
     comment on table a.post is E'@name person\nRest of existing ''comment'' \nhere.';
+  `
+);
+
+check(
+  "table naming clash",
+  `
+    comment on table a.post is E'@name person_condition\nRest of existing ''comment'' \nhere.';
   `
 );

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -92,3 +92,9 @@ check(
     comment on function c.int_set_query(int, int, int) is E'@name q\nRest of existing ''comment'' \nhere.';
   `
 );
+check(
+  "function naming clash - nodeId",
+  `
+    comment on function c.int_set_query(int, int, int) is E'@name nodeId\nRest of existing ''comment'' \nhere.';
+  `
+);

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -127,3 +127,9 @@ check(
     comment on function a.mutation_text_array() is E'@name deletePost\nRest of existing ''comment'' \nhere.';
   `
 );
+check(
+  "function naming clash - computed",
+  `
+    comment on function c.edge_case_computed(c.edge_case) is E'@fieldName rowId\nRest of existing ''comment'' \nhere.';
+  `
+);

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -25,3 +25,9 @@ check(
     comment on constraint post_author_id_fkey on a.post is E'@foreignFieldName clash\nRest of existing ''comment'' \nhere.';
   `
 );
+check(
+  "table naming clash",
+  `
+    comment on table a.post is E'@name person\nRest of existing ''comment'' \nhere.';
+  `
+);

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -22,6 +22,6 @@ function check(description, sql) {
 check(
   "simple collections naming clash",
   `
-    comment on constraint post_author_id_fkey on a.post is E'@foreignFieldName clash';
+    comment on constraint post_author_id_fkey on a.post is E'@foreignFieldName clash\nRest of existing ''comment'' \nhere.';
   `
 );

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -115,3 +115,15 @@ check(
     comment on function a.mutation_text_array() is E'@name createPost\nRest of existing ''comment'' \nhere.';
   `
 );
+check(
+  "function naming clash - updatePost",
+  `
+    comment on function a.mutation_text_array() is E'@name updatePost\nRest of existing ''comment'' \nhere.';
+  `
+);
+check(
+  "function naming clash - deletePost",
+  `
+    comment on function a.mutation_text_array() is E'@name deletePost\nRest of existing ''comment'' \nhere.';
+  `
+);

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -27,15 +27,22 @@ check(
 );
 
 check(
-  "table naming clash",
+  "table naming clash - direct",
   `
     comment on table a.post is E'@name person\nRest of existing ''comment'' \nhere.';
   `
 );
 
 check(
-  "table naming clash",
+  "table naming clash - condition",
   `
     comment on table a.post is E'@name person_condition\nRest of existing ''comment'' \nhere.';
+  `
+);
+
+check(
+  "table naming clash - order",
+  `
+    comment on table a.post is E'@name people_order_by\nRest of existing ''comment'' \nhere.';
   `
 );

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -1,5 +1,6 @@
 const { withPgClient } = require("../helpers");
 const { createPostGraphileSchema } = require("../..");
+// eslint-disable-next-line no-unused-vars
 const { printSchema } = require("graphql");
 
 function check(description, sql) {

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -5,6 +5,7 @@ const { printSchema } = require("graphql");
 function check(description, sql) {
   test(description, async () => {
     let error;
+    // eslint-disable-next-line no-unused-vars
     let schema;
     await withPgClient(async pgClient => {
       await pgClient.query(sql);
@@ -39,7 +40,7 @@ function check(description, sql) {
     // Debugging
     if (!error) {
       // eslint-disable-next-line no-console
-      //console.error(printSchema(schema));
+      // console.error(printSchema(schema));
     }
     expect(error).toBeTruthy();
     expect(error).toMatchSnapshot();

--- a/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
+++ b/packages/postgraphile-core/__tests__/integration/extend-errors.test.js
@@ -1,0 +1,27 @@
+const { withPgClient } = require("../helpers");
+const { createPostGraphileSchema } = require("../..");
+
+function check(description, sql) {
+  test(description, async () => {
+    let error;
+    await withPgClient(async pgClient => {
+      await pgClient.query(sql);
+      try {
+        await createPostGraphileSchema(pgClient, ["a", "b", "c"], {
+          simpleCollections: "both",
+        });
+      } catch (e) {
+        error = e;
+      }
+    });
+    expect(error).toBeTruthy();
+    expect(error).toMatchSnapshot();
+  });
+}
+
+check(
+  "simple collections naming clash",
+  `
+    comment on constraint post_author_id_fkey on a.post is E'@foreignFieldName clash';
+  `
+);

--- a/packages/postgraphile-core/scripts/test
+++ b/packages/postgraphile-core/scripts/test
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export FORCE_COLOR=1
+
 if [ -x ".env" ]; then
   set -a
   . ./.env


### PR DESCRIPTION
Reveals where the origin of two conflictingly named fields or types has come from, and if possible gives a hint as to how to solve the conflict.

Looks something like this:

![screenshot 2018-08-31 12 12 11](https://user-images.githubusercontent.com/129910/44909405-18feb980-ad17-11e8-9183-25fd6f27248e.png)

PRs improving this are very welcome, this is just a first stab to make conflicts less painful.

When reviewing the code, be sure to ignore whitespace changes (by adding `?w=1` to the end of the URL) as many of the changes are just wrapping existing code with an extra function call. Really need to refactor this...

- Fixes a bug in the inflector where a smart comment override for a single relation is applied both forwards and backwards
- Adds loads more information to `newWithHooks` and `extend` calls
- Fixes some bugs where fields can be accidentally overwritten if they have the same name - now causes a conflict instead like it should have all along
- Added a useful utility function for turning a Pg introspection type (PgClass, PgProc, PgAttribute, ...) into human readable text
- Added a useful utility function for outputting tweaked smart-comment SQL, for use in hints
- Added `comment` to relevant introspection types to store the original comment (in addition to the existing parsed description/tags)
- Gives constraint introspection types a direct reference to their associated class
- Added a `status` object to `Build` that can be used to track what the currently running hook is (useful in error messages).
- Added internal `dontSwallowErrors` setting; this is not an official interface so don't rely on it yet but it's a handy way (especially in tests) to prevent PostGraphile deliberately swallowing errors. We might wrap this and a few other settings up into a `--strict` flag in future.